### PR TITLE
Add observable AI workflow and operationalise ADRs

### DIFF
--- a/.claude/skills/checkarch/SKILL.md
+++ b/.claude/skills/checkarch/SKILL.md
@@ -9,7 +9,7 @@ Validate code against the architecture principles defined in `ai/architecture/pr
 ## Steps
 
 1. Read `ai/architecture/principles.md` to load the current rules.
-2. Read all `ai/decisions/adr-*.md` files. Extract only rules that are **mechanically verifiable from code** (imports, directory structure, package boundaries, naming). Skip rules that are purely about technology choice or process.
+2. Read all `ai/decisions/adr-*.md` files. Focus on ADRs with `enforceable: true` in frontmatter. Use the `rules:` field as your primary checklist for that ADR. Still apply judgment — rules are plain language, not exact patterns. Skip ADRs with `enforceable: false`.
 3. Ask the user what scope to check:
    - **Uncommitted changes** — `git diff HEAD`
    - **Current branch** — `git diff main...HEAD` (all commits since branching from main)
@@ -24,14 +24,7 @@ Validate code against the architecture principles defined in `ai/architecture/pr
    - **No shared DB** — services do not import another service's internal packages.
    - **GraphQL roots** — query root types correspond to aggregates, not join entities.
    - **Testing rules** — domain tests have no mocks or infrastructure imports. Interface tests are integration tests (not unit tests with mocked dependencies).
-6. Additionally check against any verifiable rules extracted from ADRs in step 2. Common examples:
-   - **ADR-001 (repo layout)** — services live under `services/`, shared code under `shared/`
-   - **ADR-002 (GraphQL per service)** — each service has its own GraphQL schema, no shared schema files
-   - **ADR-003 (shared DB schema isolation)** — no cross-service database imports or shared DB connection packages
-   - **ADR-005 (clean architecture layers)** — covered by principles checks above, verify no additional constraints from the ADR
-   - **ADR-007 (Go workspace)** — `go.work` exists and references all service modules
-   - **ADR-009 (DB persistence layer)** — persistence implementations live in infrastructure, not application or domain
-   - Other ADRs — extract and check any rule that can be verified from code structure or imports; skip the rest
+6. Additionally check against the `rules:` listed in each enforceable ADR's frontmatter. Use the rules as a checklist and apply judgment to verify each one from code structure, imports, and file locations.
 7. Present a summary of violations grouped by source (principles vs ADR number), with file paths and line numbers.
 8. If violations are found, ask the user: "Want me to fix these violations?"
 9. If yes, fix them and show the changes for approval before applying.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ node_modules
 
 # Zinc
 data
+
+# AI runtime (working memory, logs)
+ai-runtime/*
+!ai-runtime/.gitkeep

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See `ai/decisions`.
 
 ## AI Control Plane
 
-The `ai/` directory is the interface between human architects and AI agents. It separates architectural intent from implementation code.
+The `ai/` directory is the interface between human architects and AI agents. It separates architectural intent from implementation code. It is a declarative control plane that any AI tool can read and is not tied to a specific agent or framework.
 
 | Doc                                  | Purpose                                             |
 |--------------------------------------|-----------------------------------------------------|
@@ -48,7 +48,7 @@ The `ai/` directory is the interface between human architects and AI agents. It 
 | [ai/prompts/](ai/prompts/)           | Agent operating instructions                        |
 | ai-runtime/                            | Working memory and runtime state (gitignored)       |
 
-Agents read this directory before making changes, ensuring implementation follows the system’s architecture and decisions.
+See [ai/architecture/control-plane.md](ai/architecture/control-plane.md) for the full design.
 
 ## Getting Started
 
@@ -88,14 +88,13 @@ The `ai/` directory is the interface between you (the human architect) and AI ag
 3. Work with the agent: requirements → TDD → implement → review
 4. Commit working code, update sprint tasks
 
-### Future: Agentic Stack
+### Evolution
 
-The target setup for maximum solo-developer productivity:
+The agentic workflow evolves incrementally based on real needs:
 
-| Tool | Role |
-|------|------|
-| **GSD** | Project manager — planning, task breakdown, prioritisation |
-| **Superpowers** | Coding workflow — structured development flow |
-| **Claude Code** | Implementation — coding, testing, repo modification |
+1. **Working memory** (done) — `ai-runtime/current-task.md` externalises agent reasoning
+2. **Skills** (done) — `.claude/skills/` for repeatable validation (checkarch, checkdoc)
+3. **Instrumentation** (future) — hooks for automatic observability
+4. **More autonomy** (if needed) — only when human-in-the-loop becomes the bottleneck
 
-GSD and Superpowers are not yet integrated. For now, use Claude Code directly with the `ai/` docs as your steering mechanism.
+No frameworks are adopted speculatively. Each layer is added when the previous one proves useful.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The `ai/` directory is the interface between human architects and AI agents. It 
 | [ai/plans/](ai/plans/)               | Roadmap and current sprint                          |
 | [ai/decisions/](ai/decisions/)       | Architecture Decision Records                       |
 | [ai/prompts/](ai/prompts/)           | Agent operating instructions                        |
+| ai-runtime/                            | Working memory and runtime state (gitignored)       |
 
 Agents read this directory before making changes, ensuring implementation follows the system’s architecture and decisions.
 

--- a/ai/architecture/control-plane.md
+++ b/ai/architecture/control-plane.md
@@ -1,0 +1,32 @@
+# AI Control Plane
+
+The ai/ directory is a declarative control plane for AI agents. Human architects define what to build and why; agents handle how.
+
+## Philosophy
+
+- **Human-in-the-loop** — human is architect (what/why), agent is implementer (how)
+- **Structured environment, not autonomous agent** — no agent loops, no step automation
+- **Agent-agnostic** — any LLM tool (Claude Code, Cursor, Aider) reads ai/ and ai-runtime/
+- **Observable** — working memory in ai-runtime/ makes agent reasoning visible
+- **Incremental** — evolve based on real usage, not hypothetical needs
+
+## Layers
+
+| Layer | Directory | Purpose | Who writes |
+|-------|-----------|---------|------------|
+| Control Plane | `ai/` | Architecture, decisions, plans, prompts | Human (agents read-only) |
+| Runtime | `ai-runtime/` | Working memory, execution state | Agent (ephemeral, gitignored) |
+| Agent Config | `.claude/` | Skills, hooks, settings | Human (Claude Code only) |
+
+## Constraints
+
+- `ai/` is read-only for agents — human maintains architectural intent
+- `ai-runtime/` is gitignored — ephemeral, per-session state
+- `.claude/` is vendor-specific — enhances but is not required
+- Architecture and ADRs override code (see principles.md)
+
+## What this is not
+
+- Not an agent framework — no autonomous planning or task loops
+- Not vendor-locked — the core system works without .claude/
+- Not speculative — features are added when needed, not before

--- a/ai/architecture/principles.md
+++ b/ai/architecture/principles.md
@@ -51,6 +51,7 @@ Dependencies point inward; never outward. Business logic has zero framework depe
 - Prefer duplication over incorrect abstractions in `shared/`.
 
 ### Development Workflow
+- Prefer the simplest solution that satisfies current requirements.
 - Prefer TDD.
 - Prefer small, incremental commits.
 

--- a/ai/architecture/repo-map.md
+++ b/ai/architecture/repo-map.md
@@ -2,6 +2,7 @@
 
 ```
 ai/           → Human-agent interface (do not modify)
+ai-runtime/   → Agent working memory and runtime state (gitignored)
 services/     → Individual services
 contracts/    → Shared API contracts between services
 shared/       → Shared libraries

--- a/ai/decisions/adr-001-repo-layout.md
+++ b/ai/decisions/adr-001-repo-layout.md
@@ -1,7 +1,15 @@
-# ADR-001: AI-Optimized Repository Layout
+---
+status: accepted
+date: 2026-03-14
+scope: repo
+enforceable: true
+rules:
+  - "services live under services/"
+  - "shared code lives under shared/"
+  - "contracts live under contracts/"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-001: AI-Optimized Repository Layout
 
 ## Context
 

--- a/ai/decisions/adr-002-graphql-per-service.md
+++ b/ai/decisions/adr-002-graphql-per-service.md
@@ -1,7 +1,14 @@
-# ADR-002: GraphQL APIs Per Service
+---
+status: accepted
+date: 2026-03-14
+scope: interface
+enforceable: true
+rules:
+  - "each service owns its own GraphQL schema"
+  - "no shared schema files across services"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-002: GraphQL APIs Per Service
 
 ## Context
 

--- a/ai/decisions/adr-003-shared-db-schema-isolation.md
+++ b/ai/decisions/adr-003-shared-db-schema-isolation.md
@@ -1,7 +1,15 @@
-# ADR-003: Shared Database with Schema Isolation
+---
+status: accepted
+date: 2026-03-14
+scope: infra
+enforceable: true
+rules:
+  - "no cross-schema joins"
+  - "each service accesses only its own schema"
+  - "no cross-service database imports"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-003: Shared Database with Schema Isolation
 
 ## Context
 

--- a/ai/decisions/adr-004-event-driven-communication.md
+++ b/ai/decisions/adr-004-event-driven-communication.md
@@ -1,7 +1,15 @@
-# ADR-004: Event-Driven Cross-Service Communication
+---
+status: accepted
+date: 2026-03-15
+scope: domain
+enforceable: true
+rules:
+  - "cross-service communication uses EventDispatcher interface"
+  - "events carry full JSON payloads"
+  - "subscribers must not call back to the producer"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-15
+# ADR-004: Event-Driven Cross-Service Communication
 
 ## Context
 

--- a/ai/decisions/adr-005-clean-architecture-layers.md
+++ b/ai/decisions/adr-005-clean-architecture-layers.md
@@ -1,7 +1,16 @@
-# ADR-005: Clean Architecture with Go Idioms
+---
+status: accepted
+date: 2026-03-14
+scope: domain
+enforceable: true
+rules:
+  - "four layers per service: domain, application, infrastructure, interface"
+  - "dependencies point inward only"
+  - "domain layer has no external dependencies"
+  - "interfaces defined where consumed"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-005: Clean Architecture with Go Idioms
 
 ## Context
 

--- a/ai/decisions/adr-006-zinc-search-engine.md
+++ b/ai/decisions/adr-006-zinc-search-engine.md
@@ -1,7 +1,11 @@
-# ADR-006: Zinc Search Engine
+---
+status: accepted
+date: 2026-03-14
+scope: infra
+enforceable: false
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-006: Zinc Search Engine
 
 ## Context
 

--- a/ai/decisions/adr-007-go-workspace.md
+++ b/ai/decisions/adr-007-go-workspace.md
@@ -1,7 +1,14 @@
-# ADR-007: Go Workspace
+---
+status: accepted
+date: 2026-03-14
+scope: repo
+enforceable: true
+rules:
+  - "go.work exists at repo root"
+  - "go.work references all modules under services/, shared/, contracts/"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-007: Go Workspace
 
 ## Context
 

--- a/ai/decisions/adr-008-gateway-routing.md
+++ b/ai/decisions/adr-008-gateway-routing.md
@@ -1,7 +1,11 @@
-# ADR-008: Gateway Routing Strategy
+---
+status: deferred
+date: 2026-03-14
+scope: interface
+enforceable: false
+---
 
-**Status:** Deferred (Phase 8)
-**Date:** 2026-03-14
+# ADR-008: Gateway Routing Strategy
 
 ## Context
 

--- a/ai/decisions/adr-009-db-persistence-layer.md
+++ b/ai/decisions/adr-009-db-persistence-layer.md
@@ -1,7 +1,16 @@
-# ADR-009: Database Persistence Layer
+---
+status: accepted
+date: 2026-03-15
+scope: infra
+enforceable: true
+rules:
+  - "sqlc-generated code lives in infrastructure layer"
+  - "transaction boundaries (DB.WithTx) owned by application layer"
+  - "MapPgError lives in infrastructure layer"
+  - "domain entities have no sqlc/pgx dependencies"
+---
 
-**Status:** Accepted
-**Date:** 2026-03-15
+# ADR-009: Database Persistence Layer
 
 ## Context
 

--- a/ai/decisions/adr-010-denormalized-read-models.md
+++ b/ai/decisions/adr-010-denormalized-read-models.md
@@ -1,7 +1,11 @@
-# ADR-010: Denormalized Read Models
+---
+status: accepted
+date: 2026-03-14
+scope: infra
+enforceable: false
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-010: Denormalized Read Models
 
 ## Context
 

--- a/ai/decisions/adr-011-frontend-stack.md
+++ b/ai/decisions/adr-011-frontend-stack.md
@@ -1,7 +1,11 @@
-# ADR-011: Frontend Stack
+---
+status: accepted
+date: 2026-03-14
+scope: frontend
+enforceable: false
+---
 
-**Status:** Accepted
-**Date:** 2026-03-14
+# ADR-011: Frontend Stack
 
 ## Context
 

--- a/ai/decisions/decisions.md
+++ b/ai/decisions/decisions.md
@@ -2,16 +2,16 @@
 
 Quick reference for agents. Read full ADRs only when you need detail on a specific decision.
 
-| ADR | Status | Decision |
-|-----|--------|----------|
-| 001 | Accepted | AI-optimised monorepo with `ai/` as human-agent interface |
-| 002 | Accepted | AFL and FFL expose GraphQL (gqlgen); Search exposes REST |
-| 003 | Accepted | Single PG database (`xffl`), schema isolation (`afl.*`, `ffl.*`); no cross-schema joins |
-| 004 | Accepted | PG LISTEN/NOTIFY for events; full JSON payloads; `EventDispatcher` interface in `shared/events/` |
-| 005 | Accepted | Four layers per service: Domain → Application → Infrastructure → Interface; dependencies point inward |
-| 006 | Accepted | Zinc as search engine via dedicated Search service with event-driven indexing |
-| 007 | Accepted | `go.work` at repo root referencing all modules |
-| 008 | Deferred | Gateway routing — deferred to Phase 8; frontend connects directly to services until then |
-| 009 | Accepted | sqlc + pgx; app-layer tx via `DB.WithTx`; `MapPgError` for domain error translation |
-| 010 | Accepted | Denormalised read models in DB; consistency maintained through domain logic on writes |
-| 011 | Accepted | Vue 3 + TypeScript + Vite; Apollo Client; PrimeVue |
+| ADR | Status | Enforceable | Decision |
+|-----|--------|-------------|----------|
+| 001 | Accepted | ✅ | AI-optimised monorepo with `ai/` as human-agent interface |
+| 002 | Accepted | ✅ | AFL and FFL expose GraphQL (gqlgen); Search exposes REST |
+| 003 | Accepted | ✅ | Single PG database (`xffl`), schema isolation (`afl.*`, `ffl.*`); no cross-schema joins |
+| 004 | Accepted | ✅ | PG LISTEN/NOTIFY for events; full JSON payloads; `EventDispatcher` interface in `shared/events/` |
+| 005 | Accepted | ✅ | Four layers per service: Domain → Application → Infrastructure → Interface; dependencies point inward |
+| 006 | Accepted | — | Zinc as search engine via dedicated Search service with event-driven indexing |
+| 007 | Accepted | ✅ | `go.work` at repo root referencing all modules |
+| 008 | Deferred | — | Gateway routing — deferred to Phase 8; frontend connects directly to services until then |
+| 009 | Accepted | ✅ | sqlc + pgx; app-layer tx via `DB.WithTx`; `MapPgError` for domain error translation |
+| 010 | Accepted | — | Denormalised read models in DB; consistency maintained through domain logic on writes |
+| 011 | Accepted | — | Vue 3 + TypeScript + Vite; Apollo Client; PrimeVue |

--- a/ai/prompts/system-prompt.md
+++ b/ai/prompts/system-prompt.md
@@ -22,3 +22,4 @@ For non-trivial work, update `ai-runtime/current-task.md` at each step.
    → Record in current-task.md: test results, validation results
 5. **Reflect** — note assumptions, risks, and anything learned
    → Record in current-task.md: Reflection section
+   → If a systemic issue emerged, propose an update to principles, ADRs, or prompts

--- a/ai/prompts/system-prompt.md
+++ b/ai/prompts/system-prompt.md
@@ -17,3 +17,13 @@ You are working in a SOA monorepo. All architectural rules are defined in `ai/ar
 5. Run tests
 6. Refactor
 7. Remind user about /checkdoc and /checkarch skills
+
+## Task Tracking
+
+For non-trivial work:
+- Use `ai-runtime/current-task.md` for working memory
+- Create or reset it at the start of each task
+- Update it after each step: planning, implementation, testing, validation
+- Record checkarch/checkdoc results in the Validation section
+- Add reflection before marking complete
+- Keep it concise — externalized reasoning, not documentation

--- a/ai/prompts/system-prompt.md
+++ b/ai/prompts/system-prompt.md
@@ -10,20 +10,15 @@ You are working in a SOA monorepo. All architectural rules are defined in `ai/ar
 
 ## Development Process
 
-1. Understand task
-2. Identify affected services
-3. Write failing tests
-4. Implement minimal solution
-5. Run tests
-6. Refactor
-7. Remind user about /checkdoc and /checkarch skills
+For non-trivial work, update `ai-runtime/current-task.md` at each step.
 
-## Task Tracking
-
-For non-trivial work:
-- Use `ai-runtime/current-task.md` for working memory
-- Create or reset it at the start of each task
-- Update it after each step: planning, implementation, testing, validation
-- Record checkarch/checkdoc results in the Validation section
-- Add reflection before marking complete
-- Keep it concise — externalized reasoning, not documentation
+1. **Understand** — identify affected services, relevant ADRs, bounded contexts
+   → Record in current-task.md: Summary, affected services, relevant ADRs
+2. **Test plan** — define what tests are needed before writing code
+   → Record in current-task.md: test cases under Steps
+3. **Implement** — write failing tests, then minimal implementation
+   → Record in current-task.md: files changed, decisions made
+4. **Validate** — run tests, run /checkarch and /checkdoc
+   → Record in current-task.md: test results, validation results
+5. **Reflect** — note assumptions, risks, and anything learned
+   → Record in current-task.md: Reflection section


### PR DESCRIPTION
## Summary

Evolves the AI Control Plane from a passive documentation system into an observable, structured workflow:

- **Working memory** — new `ai-runtime/` directory with `current-task.md` for agent working memory (gitignored, agent-agnostic)
- **Control plane docs** — new `ai/architecture/control-plane.md` documenting the three-layer model, philosophy, and constraints
- **Enforceable ADRs** — all 11 ADRs now have YAML frontmatter with `status`, `scope`, `enforceable`, and `rules` fields. checkarch reads the frontmatter instead of maintaining a hardcoded rule list
- **Visible checkpoints** — development process now specifies what artifact each step produces in `current-task.md`
- **Feedback loop** — reflect step proposes system updates when systemic issues emerge
- **Simplicity principle** — explicit pressure against unnecessary complexity
- **README updated** — replaces speculative GSD/Superpowers roadmap with incremental evolution strategy

## Key design decisions

- `ai/` remains the declarative control plane (human-maintained, agent read-only)
- `ai-runtime/` is agent-agnostic — any LLM tool can read/write it, not tied to Claude Code
- `.claude/` stays vendor-specific (skills, hooks, settings)
- checkarch keeps prompt-based judgment — ADR metadata improves its inputs, not replaces its reasoning
