### PR TITLE
Phase 3: Complete AFL match view with e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ bin/
 # Vue.js
 .DS_Store
 node_modules
-/frontend/dist
-/frontend/dist-ssr
 *.local
 .env.local
 .env.*.local

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ just run-all       # AFL service + gateway + frontend
 ```
 Or individually: `just run-afl`, `just run-gateway`, `just run-frontend`
 
+### Testing
+
+```sh
+just test-e2e      # Playwright e2e tests (requires run-all + dev-seed)
+```
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [ai/architecture/control-plane.md](ai/architecture/control-plane.md) for the
 
 ## Getting Started
 
-Prerequisites: Docker, Go 1.25+, [just](https://github.com/casey/just)
+Prerequisites: Docker, Go 1.25+, Node.js 20+, [just](https://github.com/casey/just)
 
 ```sh
 cp .env.example .env
@@ -63,6 +63,13 @@ just dev-seed      # load test data (optional)
 For psql: `docker exec -it xffl-postgres psql -U postgres -d xffl`
 
 To stop: `just dev-down` | To nuke and start fresh: `just dev-reset`
+
+### Running
+
+```sh
+just run-all       # AFL service + gateway + frontend
+```
+Or individually: `just run-afl`, `just run-gateway`, `just run-frontend`
 
 
 ## Development Workflow

--- a/ai/architecture/principles.md
+++ b/ai/architecture/principles.md
@@ -57,7 +57,7 @@ Dependencies point inward; never outward. Business logic has zero framework depe
 
 ### Agent Behaviour
 - When requirements are unclear: Ask a question, propose possible options, wait for confirmation before implementing.
-- Do not modify `ai/` files unless explicitly instructed.
+- Do not modify `ai/` files unless explicitly instructed, except: mark sprint tasks as done in `ai/plans/current-sprint.md` when completing them.
 
 ## Service Layout
 

--- a/ai/architecture/repo-map.md
+++ b/ai/architecture/repo-map.md
@@ -4,6 +4,7 @@
 ai/           → Human-agent interface (do not modify)
 ai-runtime/   → Agent working memory and runtime state (gitignored)
 services/     → Individual services
+frontend/     → Web frontend (Vue 3 SPA)
 contracts/    → Shared API contracts between services
 shared/       → Shared libraries
 tests/        → e2e tests

--- a/ai/decisions/adr-008-gateway-routing.md
+++ b/ai/decisions/adr-008-gateway-routing.md
@@ -1,6 +1,6 @@
 ---
-status: deferred
-date: 2026-03-14
+status: accepted
+date: 2026-03-22
 scope: interface
 enforceable: false
 ---
@@ -11,12 +11,17 @@ enforceable: false
 
 Gateway proxies frontend requests to the correct backend service. First-cut used simple string-based routing (presence of "afl"/"ffl" in query text). Works but fragile.
 
+Phase 3 brings the gateway forward to provide a single entry point for the Vue frontend.
+
 ## Options
 
-1. **String-based routing** — zero config, predictable, breaks if query names don't contain service identifiers
-2. **GraphQL query parsing** — route by field/type, more robust
-3. **GraphQL Federation** — most capable, most complex
+1. **Simple reverse proxy** — stdlib `httputil.ReverseProxy`, forward `/query` to AFL service. No routing logic needed while there is only one service.
+2. **String-based routing** — zero config, predictable, breaks if query names don't contain service identifiers
+3. **GraphQL query parsing** — route by field/type, more robust
+4. **GraphQL Federation** — most capable, most complex
 
 ## Decision
 
-Deferred to Phase 8. Frontend connects directly to services during earlier phases. Decision informed by real query patterns.
+Option 1: simple reverse proxy. Only AFL exists today — no routing decision required. When FFL arrives (Phase 5), upgrade to option 2 or 3 based on real query patterns.
+
+Gateway runs on `:8090`, proxies `/query` to AFL (`:8080`), handles CORS, and exposes `/health`.

--- a/ai/decisions/adr-011-frontend-stack.md
+++ b/ai/decisions/adr-011-frontend-stack.md
@@ -3,6 +3,11 @@ status: accepted
 date: 2026-03-23
 scope: frontend
 enforceable: true
+rules:
+  - "typescript strict mode, no any types"
+  - "all visual styling via Tailwind, no themed component libraries"
+  - "server state lives in Apollo cache, not duplicated in Pinia"
+  - "SPA only, no SSR framework without a new ADR"
 ---
 
 # ADR-011: Frontend Stack
@@ -36,6 +41,7 @@ Need a web frontend for managing fantasy teams, viewing AFL stats, searching, an
 
 ## Rationale
 
+- **TypeScript:** Strict mode throughout. Type safety across GraphQL queries, components, and router.
 - **Vue 3 + Vite:** Lightweight, fast HMR, standard pairing.
 - **Apollo Client:** Purpose-built for GraphQL; handles caching, queries, mutations against the gateway.
 - **Tailwind CSS:** Full control over appearance without fighting a theme system.
@@ -46,5 +52,6 @@ Need a web frontend for managing fantasy teams, viewing AFL stats, searching, an
 ## Alternatives considered
 
 - **PrimeVue themed:** Faster to start but locks into a visual identity. Rejected — want a custom look.
-- **Headless UI (Radix Vue):** Good primitives but smaller ecosystem than PrimeVue. Could supplement later for very custom components.
+- **shadcn-vue (Radix Vue):** Headless primitives with copy-paste component templates. Appealing philosophy but Vue port is less mature than React original, and you own all copied code. PrimeVue unstyled gives similar headless behaviour as a maintained dependency — less to own.
+- **Nuxt:** SSR, file-based routing, auto-imports. Overkill for an SPA that doesn't need SEO or server-side rendering. Vue + Vite + Vue Router is sufficient; can migrate later if needs change.
 - **No component library:** Maximum control but re-implementing accessibility (focus traps, ARIA, keyboard nav) is not worth it for a hobby project.

--- a/ai/decisions/adr-011-frontend-stack.md
+++ b/ai/decisions/adr-011-frontend-stack.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: revisiting
 date: 2026-03-14
 scope: frontend
 enforceable: false

--- a/ai/decisions/adr-011-frontend-stack.md
+++ b/ai/decisions/adr-011-frontend-stack.md
@@ -1,21 +1,50 @@
 ---
-status: revisiting
-date: 2026-03-14
+status: accepted
+date: 2026-03-23
 scope: frontend
-enforceable: false
+enforceable: true
 ---
 
 # ADR-011: Frontend Stack
 
 ## Context
 
-Need a web frontend for managing fantasy teams, viewing AFL stats, searching, and displaying the ladder.
+Need a web frontend for managing fantasy teams, viewing AFL stats, searching, and displaying the ladder. Want a custom visual identity — not boxed into a component library theme — while still getting accessible, battle-tested UI behaviour out of the box.
 
 ## Decision
 
-Vue 3 + TypeScript + Vite. Apollo Client for GraphQL. PrimeVue for UI components.
+### Pass 1 — Core (scaffold + first view)
+
+| Layer | Choice |
+|-------|--------|
+| Framework / Build | Vue 3 + TypeScript + Vite |
+| Server State / GraphQL | Apollo Client |
+| Styling | Tailwind CSS |
+
+### Pass 2 — When the first view needs them
+
+| Layer | Choice |
+|-------|--------|
+| UI Components | PrimeVue unstyled |
+| State Management | Pinia |
+| Hooks / Utilities | VueUse |
+
+### Styling approach
+
+- PrimeVue unstyled provides behaviour (tables, modals, dropdowns); Tailwind provides all visual styling.
+- Small variant wrappers (class maps in `ui/variants.ts`) for consistent button/input/badge patterns — no component abstraction layer until pain is felt.
 
 ## Rationale
 
-- **Why for Hobby:** Vue is lightweight and reactive, Vite gives instant HMR, Apollo is purpose-built for GraphQL, PrimeVue provides DataTable/Dialog/forms out of the box
-- **Scale Path:** Add Pinia for state management, SSR with Nuxt, component library extraction
+- **Vue 3 + Vite:** Lightweight, fast HMR, standard pairing.
+- **Apollo Client:** Purpose-built for GraphQL; handles caching, queries, mutations against the gateway.
+- **Tailwind CSS:** Full control over appearance without fighting a theme system.
+- **PrimeVue unstyled:** Accessible component behaviour without imposed styles. Added in pass 2 so each dependency earns its place.
+- **Pinia:** Clean separation — Pinia for local UI state, Apollo cache for server state. Added when UI state management is actually needed.
+- **VueUse:** Zero-cost reactive utilities. Added when hand-rolling becomes tedious.
+
+## Alternatives considered
+
+- **PrimeVue themed:** Faster to start but locks into a visual identity. Rejected — want a custom look.
+- **Headless UI (Radix Vue):** Good primitives but smaller ecosystem than PrimeVue. Could supplement later for very custom components.
+- **No component library:** Maximum control but re-implementing accessibility (focus traps, ARIA, keyboard nav) is not worth it for a hobby project.

--- a/ai/decisions/decisions.md
+++ b/ai/decisions/decisions.md
@@ -14,5 +14,5 @@ Quick reference for agents. Read full ADRs only when you need detail on a specif
 | 008 | Accepted | — | Simple reverse proxy gateway on :8090; revisit routing when second service arrives |
 | 009 | Accepted | ✅ | sqlc + pgx; app-layer tx via `DB.WithTx`; `MapPgError` for domain error translation |
 | 010 | Accepted | — | Denormalised read models in DB; consistency maintained through domain logic on writes |
-| 011 | Accepted | — | Vue 3 + TypeScript + Vite; Apollo Client; PrimeVue |
+| 011 | Accepted | ✅ | Vue 3 + TypeScript (strict) + Vite + Tailwind; Apollo for server state; PrimeVue unstyled for behaviour; SPA only |
 | 012 | Accepted | ✅ | Domain entities are pure and side-effect-free; repositories return fully-loaded aggregates; use cases orchestrate data loading |

--- a/ai/decisions/decisions.md
+++ b/ai/decisions/decisions.md
@@ -11,7 +11,7 @@ Quick reference for agents. Read full ADRs only when you need detail on a specif
 | 005 | Accepted | ✅ | Four layers per service: Domain → Application → Infrastructure → Interface; dependencies point inward |
 | 006 | Accepted | — | Zinc as search engine via dedicated Search service with event-driven indexing |
 | 007 | Accepted | ✅ | `go.work` at repo root referencing all modules |
-| 008 | Deferred | — | Gateway routing — deferred to Phase 8; frontend connects directly to services until then |
+| 008 | Accepted | — | Simple reverse proxy gateway on :8090; revisit routing when second service arrives |
 | 009 | Accepted | ✅ | sqlc + pgx; app-layer tx via `DB.WithTx`; `MapPgError` for domain error translation |
 | 010 | Accepted | — | Denormalised read models in DB; consistency maintained through domain logic on writes |
 | 011 | Accepted | — | Vue 3 + TypeScript + Vite; Apollo Client; PrimeVue |

--- a/ai/plans/current-sprint.md
+++ b/ai/plans/current-sprint.md
@@ -1,37 +1,40 @@
 # Current Sprint
 
-**Sprint goal:** ADR-012 — Refactor AFL domain entities into proper aggregates with domain purity
+**Sprint goal:** Phase 3 — UX Scaffold (Gateway + Vue 3 app + first AFL view with editing)
+
+## Research
+
+### Gateway approach (ADR-008)
+- [ ] Research gateway options (string routing, query parsing, federation, reverse proxy)
+- [ ] Evaluate against current needs (single service now, multi-service later)
+- [ ] Update ADR-008 with decision
+
+### Frontend component library (ADR-011)
+- [ ] Research current component library options (PrimeVue, alternatives)
+- [ ] Update ADR-011 with decision
 
 ## Tasks
 
-### ADR
-- [x] Write ADR-012: Domain Purity and Aggregate Completeness
-- [x] Add to decisions index
+### Gateway
+- [ ] Implement gateway service based on ADR-008 decision
+- [ ] GraphQL proxy routing to AFL service
+- [ ] CORS configuration
+- [ ] Health check endpoint
+- [ ] Add to `docker-compose.yml` / `justfile`
 
-### Domain layer — aggregate modelling
-- [x] Reshape `Match` as aggregate root: embed `Home`/`Away` as `ClubMatch` values (not IDs)
-- [x] Reshape `ClubMatch`: embed `[]PlayerMatch` as child entities
-- [x] Move `CalculateClubMatchScore` to method on `ClubMatch`
-- [x] Add `Match.Winner()` domain method
-- [x] Add domain unit tests for `ClubMatch.Score()`, `Match.Winner()`, edge cases (draw, no players)
+### Vue 3 project setup
+- [ ] Scaffold Vue 3 + TypeScript + Vite project
+- [ ] Configure Apollo Client pointing at gateway (:8090)
+- [ ] Set up Vue Router
+- [ ] Install and configure PrimeVue
+- [ ] Add to `justfile`
 
-### Domain layer — repository interfaces
-- [x] Add aggregate-aware repository methods (e.g. `MatchRepository.FindByIDWithDetails`)
-- [x] Keep existing per-entity methods for lightweight queries
-
-### Infrastructure layer — aggregate repositories
-- [x] Implement aggregate-loading repository methods (multi-query assembly)
-- [x] Reuse existing sqlc queries (no new SQL needed)
-
-### Application layer — use cases
-- [x] Add `GetMatchWithDetails` query
-- [x] Refactor `UpdatePlayerMatch` command to use aggregate for score recalculation
-
-### Interface layer — resolvers
-- [x] Update GraphQL resolvers to use `Home.ID`/`Away.ID` instead of removed `HomeClubMatchID`/`AwayClubMatchID`
-- [x] Use `StoredScore` in convert layer
+### AFL Match view
+- [ ] Match result display with player stats
+- [ ] Inline editing of player stats
+- [ ] Wire up mutations through Apollo Client
 
 ### Tests
-- [x] Domain unit tests (pure logic, no mocks) — 16/16 pass
-- [ ] Integration tests for aggregate repository methods (requires DB)
-- [x] Verify existing GraphQL integration tests still compile and pass structurally
+- [ ] Playwright setup
+- [ ] Match view read tests
+- [ ] Match view edit tests

--- a/ai/plans/current-sprint.md
+++ b/ai/plans/current-sprint.md
@@ -33,11 +33,11 @@
 - [ ] Install VueUse (pass 2 — when reactive utilities needed)
 
 ### AFL Match view
-- [ ] Match result display with player stats
-- [ ] Inline editing of player stats
-- [ ] Wire up mutations through Apollo Client
+- [x] Match result display with player stats
+- [x] Inline editing of player stats
+- [x] Wire up mutations through Apollo Client
 
 ### Tests
-- [ ] Playwright setup
-- [ ] Match view read tests
-- [ ] Match view edit tests
+- [x] Playwright setup
+- [x] Match view read tests
+- [x] Match view edit tests

--- a/ai/plans/current-sprint.md
+++ b/ai/plans/current-sprint.md
@@ -5,9 +5,9 @@
 ## Research
 
 ### Gateway approach (ADR-008)
-- [ ] Research gateway options (string routing, query parsing, federation, reverse proxy)
-- [ ] Evaluate against current needs (single service now, multi-service later)
-- [ ] Update ADR-008 with decision
+- [x] Research gateway options (string routing, query parsing, federation, reverse proxy)
+- [x] Evaluate against current needs (single service now, multi-service later)
+- [x] Update ADR-008 with decision
 
 ### Frontend component library (ADR-011)
 - [ ] Research current component library options (PrimeVue, alternatives)
@@ -16,11 +16,11 @@
 ## Tasks
 
 ### Gateway
-- [ ] Implement gateway service based on ADR-008 decision
-- [ ] GraphQL proxy routing to AFL service
-- [ ] CORS configuration
-- [ ] Health check endpoint
-- [ ] Add to `docker-compose.yml` / `justfile`
+- [x] Implement gateway service based on ADR-008 decision
+- [x] GraphQL proxy routing to AFL service
+- [x] CORS configuration
+- [x] Health check endpoint
+- [x] Add to `docker-compose.yml` / `justfile`
 
 ### Vue 3 project setup
 - [ ] Scaffold Vue 3 + TypeScript + Vite project

--- a/ai/plans/current-sprint.md
+++ b/ai/plans/current-sprint.md
@@ -10,8 +10,8 @@
 - [x] Update ADR-008 with decision
 
 ### Frontend component library (ADR-011)
-- [ ] Research current component library options (PrimeVue, alternatives)
-- [ ] Update ADR-011 with decision
+- [x] Research current component library options (PrimeVue, alternatives)
+- [x] Update ADR-011 with decision
 
 ## Tasks
 
@@ -22,12 +22,15 @@
 - [x] Health check endpoint
 - [x] Add to `docker-compose.yml` / `justfile`
 
-### Vue 3 project setup
-- [ ] Scaffold Vue 3 + TypeScript + Vite project
-- [ ] Configure Apollo Client pointing at gateway (:8090)
-- [ ] Set up Vue Router
-- [ ] Install and configure PrimeVue
-- [ ] Add to `justfile`
+### Vue 3 project setup (pass 1)
+- [x] Scaffold Vue 3 + TypeScript + Vite project
+- [x] Configure Apollo Client pointing at gateway (:8090)
+- [x] Set up Vue Router
+- [x] Configure Tailwind CSS
+- [x] `justfile` already configured
+- [ ] Install PrimeVue unstyled (pass 2 — when first view needs it)
+- [ ] Install Pinia (pass 2 — when UI state management needed)
+- [ ] Install VueUse (pass 2 — when reactive utilities needed)
 
 ### AFL Match view
 - [ ] Match result display with player stats

--- a/ai/plans/roadmap.md
+++ b/ai/plans/roadmap.md
@@ -26,15 +26,16 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 - [x] Interface layer — GraphQL schema + resolvers + HTTP server
 - [x] Tests — unit (domain) + integration (GraphQL with real DB)
 
-## Phase 3: UX Scaffold
+## Phase 3: UX Scaffold ✅
 
 **Goal:** Gateway + Vue 3 app scaffold + first AFL view with edit capability
 
-- [ ] ADR — choose design system / component library
-- [ ] Gateway — GraphQL proxy routing to AFL, CORS, health checks
-- [ ] Vue 3 project setup — TypeScript, Vite, Apollo Client (pointing at gateway :8090), router
-- [ ] AFL Match view — match result with player stats, inline editing of player stats
-- [ ] Playwright tests for match view (read + edit)
+- [x] ADR-008 — gateway as simple reverse proxy
+- [x] ADR-011 — frontend stack (Vue 3, Apollo, Tailwind, PrimeVue unstyled)
+- [x] Gateway — GraphQL proxy routing to AFL, CORS, health checks
+- [x] Vue 3 project setup — TypeScript, Vite, Apollo Client (pointing at gateway :8090), router, Tailwind
+- [x] AFL Match view — match result with player stats, inline editing, mutations via Apollo
+- [x] Playwright e2e tests for match view (read + edit, 6 tests)
 
 ## Phase 4: AFL Frontend
 

--- a/ai/prompts/system-prompt.md
+++ b/ai/prompts/system-prompt.md
@@ -5,21 +5,15 @@ You are working in a SOA monorepo. All architectural rules are defined in `ai/ar
 ## Before You Code
 
 1. Read `ai/plans/current-sprint.md`
-2. Read `ai/architecture/` — `repo-map.md`, `service-map.md`, `bounded-contexts.md`
+2. Read `ai/repo-map.md`, then `ai/architecture/` — `service-map.md`, `bounded-contexts.md`
 3. Check `ai/decisions/decisions.md` for relevant decisions; read full ADRs only when you need detail
 
 ## Development Process
 
-All non-trivial tasks MUST begin by creating or resetting `ai-runtime/current-task.md`. Do not proceed to implementation until the Understand and Test Plan sections are filled.
+For tasks that touch multiple services or involve significant new functionality, create or reset `ai-runtime/current-task.md` before implementing. Skip this for single-file fixes, doc updates, seed data changes, and other small tasks.
 
 1. **Understand** — identify affected services, relevant ADRs, bounded contexts
-   → Record in current-task.md: Summary, affected services, relevant ADRs
 2. **Test plan** — define what tests are needed before writing code
-   → Record in current-task.md: test cases under Steps
 3. **Implement** — write failing tests, then minimal implementation
-   → Record in current-task.md: files changed, decisions made
 4. **Validate** — run tests, run /checkarch and /checkdoc
-   → Record in current-task.md: test results, validation results
-5. **Reflect** — note assumptions, risks, and anything learned
-   → Record in current-task.md: Reflection section
-   → If a systemic issue emerged, propose an update to principles, ADRs, or prompts
+5. **Reflect** — if a systemic issue emerged, propose an update to principles, ADRs, or prompts

--- a/ai/repo-map.md
+++ b/ai/repo-map.md
@@ -4,10 +4,9 @@
 ai/           → Human-agent interface (do not modify)
 ai-runtime/   → Agent working memory and runtime state (gitignored)
 services/     → Individual services
-frontend/     → Web frontend (Vue 3 SPA)
+frontend/     → Web frontend (Vue 3 SPA, e2e tests in frontend/web/e2e/)
 contracts/    → Shared API contracts between services
 shared/       → Shared libraries
-tests/        → e2e tests
 dev/          → Local dev tooling
 first-cut/    → Legacy prototype (ignore unless migrating)
 ```

--- a/dev/postgres/seed/01_afl_seed.sql
+++ b/dev/postgres/seed/01_afl_seed.sql
@@ -1,23 +1,27 @@
--- Insert AFL test data
+-- AFL test data (idempotent — safe to re-run)
+BEGIN;
 
--- Insert AFL League
+-- Clear existing data (nullify match FKs first to break circular ref)
+UPDATE afl.match SET home_club_match_id = NULL, away_club_match_id = NULL;
+DELETE FROM afl.player_match;
+DELETE FROM afl.club_match;
+DELETE FROM afl.match;
+DELETE FROM afl.round;
+DELETE FROM afl.player_season;
+DELETE FROM afl.club_season;
+DELETE FROM afl.season;
+DELETE FROM afl.player;
+
+-- League (unique on name)
 INSERT INTO afl.league (name) VALUES ('AFL') ON CONFLICT (name) DO NOTHING;
 
--- Insert 2025 Season
+-- Season
 INSERT INTO afl.season (league_id, name)
 SELECT l.id, 'AFL 2025'
 FROM afl.league l WHERE l.name = 'AFL'
 ON CONFLICT DO NOTHING;
 
--- Insert Round 13
-INSERT INTO afl.round (season_id, name)
-SELECT s.id, 'Round 13'
-FROM afl.season s
-JOIN afl.league l ON s.league_id = l.id
-WHERE l.name = 'AFL' AND s.name = 'AFL 2025'
-ON CONFLICT DO NOTHING;
-
--- Insert all 18 AFL clubs
+-- All 18 AFL clubs (unique on name)
 INSERT INTO afl.club (name) VALUES
 ('Adelaide Crows'),
 ('Brisbane Lions'),
@@ -39,61 +43,39 @@ INSERT INTO afl.club (name) VALUES
 ('Western Bulldogs')
 ON CONFLICT (name) DO NOTHING;
 
--- Insert club_season records for both teams
+-- Club seasons for Adelaide and Brisbane
 INSERT INTO afl.club_season (club_id, season_id, drv_played, drv_won, drv_lost, drv_drawn, drv_for, drv_against, drv_premiership_points)
-SELECT
-    c.id,
-    s.id,
-    12, -- played 12 games so far
-    8,  -- won 8 (Adelaide example)
-    4,  -- lost 4
-    0,  -- drawn 0
-    1245, -- for score
-    1156, -- against score
-    32  -- premiership points (8 wins * 4 points)
-FROM afl.club c
-JOIN afl.season s ON s.name = 'AFL 2025'
+SELECT c.id, s.id, 12, 8, 4, 0, 1245, 1156, 32
+FROM afl.club c, afl.season s
 JOIN afl.league l ON s.league_id = l.id
-WHERE c.name = 'Adelaide Crows' AND l.name = 'AFL'
+WHERE c.name = 'Adelaide Crows' AND l.name = 'AFL' AND s.name = 'AFL 2025'
 ON CONFLICT (club_id, season_id) DO NOTHING;
 
 INSERT INTO afl.club_season (club_id, season_id, drv_played, drv_won, drv_lost, drv_drawn, drv_for, drv_against, drv_premiership_points)
-SELECT
-    c.id,
-    s.id,
-    12, -- played 12 games so far
-    7,  -- won 7 (Brisbane example)
-    5,  -- lost 5
-    0,  -- drawn 0
-    1198, -- for score
-    1167, -- against score
-    28  -- premiership points (7 wins * 4 points)
-FROM afl.club c
-JOIN afl.season s ON s.name = 'AFL 2025'
+SELECT c.id, s.id, 12, 7, 5, 0, 1198, 1167, 28
+FROM afl.club c, afl.season s
 JOIN afl.league l ON s.league_id = l.id
-WHERE c.name = 'Brisbane Lions' AND l.name = 'AFL'
+WHERE c.name = 'Brisbane Lions' AND l.name = 'AFL' AND s.name = 'AFL 2025'
 ON CONFLICT (club_id, season_id) DO NOTHING;
 
--- First create the match record (without club references for now)
+-- Round 13
+INSERT INTO afl.round (season_id, name)
+SELECT s.id, 'Round 13'
+FROM afl.season s
+JOIN afl.league l ON s.league_id = l.id
+WHERE l.name = 'AFL' AND s.name = 'AFL 2025';
+
+-- Match: Adelaide v Brisbane at Adelaide Oval
 INSERT INTO afl.match (round_id, venue, start_dt, drv_result)
-SELECT
-    r.id as round_id,
-    'Adelaide Oval',
-    '2025-06-15 14:10:00'::timestamp,
-    'no_result'
+SELECT r.id, 'Adelaide Oval', '2025-06-15 14:10:00+09:30', 'no_result'
 FROM afl.round r
 JOIN afl.season s ON r.season_id = s.id
 JOIN afl.league l ON s.league_id = l.id
-WHERE l.name = 'AFL' AND s.name = 'AFL 2025' AND r.name = 'Round 13'
-ON CONFLICT DO NOTHING;
+WHERE l.name = 'AFL' AND s.name = 'AFL 2025' AND r.name = 'Round 13';
 
--- Insert club_match records for both teams
--- Adelaide Crows (home team)
+-- Home club match (Adelaide Crows)
 INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
-SELECT
-    m.id,
-    cs.id,
-    0, 0, 0
+SELECT m.id, cs.id, 0, 0, 0
 FROM afl.match m
 JOIN afl.round r ON m.round_id = r.id
 JOIN afl.season s ON r.season_id = s.id
@@ -101,15 +83,12 @@ JOIN afl.league l ON s.league_id = l.id
 JOIN afl.club_season cs ON cs.season_id = s.id
 JOIN afl.club c ON cs.club_id = c.id
 WHERE l.name = 'AFL' AND s.name = 'AFL 2025' AND r.name = 'Round 13'
-  AND c.name = 'Adelaide Crows' AND m.venue = 'Adelaide Oval'
-ON CONFLICT DO NOTHING;
+  AND c.name = 'Adelaide Crows'
+ON CONFLICT (club_season_id, match_id) DO NOTHING;
 
--- Brisbane Lions (away team)
+-- Away club match (Brisbane Lions)
 INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
-SELECT
-    m.id,
-    cs.id,
-    0, 0, 0
+SELECT m.id, cs.id, 0, 0, 0
 FROM afl.match m
 JOIN afl.round r ON m.round_id = r.id
 JOIN afl.season s ON r.season_id = s.id
@@ -117,46 +96,117 @@ JOIN afl.league l ON s.league_id = l.id
 JOIN afl.club_season cs ON cs.season_id = s.id
 JOIN afl.club c ON cs.club_id = c.id
 WHERE l.name = 'AFL' AND s.name = 'AFL 2025' AND r.name = 'Round 13'
-  AND c.name = 'Brisbane Lions' AND m.venue = 'Adelaide Oval'
+  AND c.name = 'Brisbane Lions'
+ON CONFLICT (club_season_id, match_id) DO NOTHING;
+
+-- Link home/away club matches to the match
+UPDATE afl.match SET
+  home_club_match_id = (
+    SELECT cm.id FROM afl.club_match cm
+    JOIN afl.club_season cs ON cm.club_season_id = cs.id
+    JOIN afl.club c ON cs.club_id = c.id
+    WHERE cm.match_id = afl.match.id AND c.name = 'Adelaide Crows'
+  ),
+  away_club_match_id = (
+    SELECT cm.id FROM afl.club_match cm
+    JOIN afl.club_season cs ON cm.club_season_id = cs.id
+    JOIN afl.club c ON cs.club_id = c.id
+    WHERE cm.match_id = afl.match.id AND c.name = 'Brisbane Lions'
+  )
+WHERE afl.match.venue = 'Adelaide Oval';
+
+-- Players
+INSERT INTO afl.player (name) VALUES
+('Jordan Dawson'),
+('Rory Laird'),
+('Ben Keays'),
+('Lachie Neale'),
+('Hugh McCluggage'),
+('Dayne Zorko')
 ON CONFLICT DO NOTHING;
 
--- Insert Jordan Dawson player
-INSERT INTO afl.player (name) VALUES ('Jordan Dawson') ON CONFLICT DO NOTHING;
-
--- Insert Jordan Dawson player_season (with Adelaide Crows for 2025)
+-- Player seasons — Adelaide
 INSERT INTO afl.player_season (player_id, club_season_id)
-SELECT
-    p.id,
-    cs.id
-FROM afl.player p
-JOIN afl.club_season cs ON cs.season_id = (
-    SELECT s.id FROM afl.season s
-    JOIN afl.league l ON s.league_id = l.id
-    WHERE l.name = 'AFL' AND s.name = 'AFL 2025'
-)
+SELECT p.id, cs.id
+FROM afl.player p, afl.club_season cs
 JOIN afl.club c ON cs.club_id = c.id
-WHERE p.name = 'Jordan Dawson' AND c.name = 'Adelaide Crows'
+JOIN afl.season s ON cs.season_id = s.id
+JOIN afl.league l ON s.league_id = l.id
+WHERE p.name IN ('Jordan Dawson', 'Rory Laird', 'Ben Keays')
+  AND c.name = 'Adelaide Crows' AND l.name = 'AFL' AND s.name = 'AFL 2025'
 ON CONFLICT (player_id, club_season_id) DO NOTHING;
 
--- Insert Jordan Dawson player_match record for the Crows v Brisbane match
+-- Player seasons — Brisbane
+INSERT INTO afl.player_season (player_id, club_season_id)
+SELECT p.id, cs.id
+FROM afl.player p, afl.club_season cs
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.season s ON cs.season_id = s.id
+JOIN afl.league l ON s.league_id = l.id
+WHERE p.name IN ('Lachie Neale', 'Hugh McCluggage', 'Dayne Zorko')
+  AND c.name = 'Brisbane Lions' AND l.name = 'AFL' AND s.name = 'AFL 2025'
+ON CONFLICT (player_id, club_season_id) DO NOTHING;
+
+-- Player match records — Adelaide players
 INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
-SELECT
-    ps.id,
-    cm.id,
-    0, 0, 0, 0, 0, 0, 0
+SELECT ps.id, cm.id, 18, 12, 6, 0, 4, 2, 1
 FROM afl.player_season ps
 JOIN afl.player p ON ps.player_id = p.id
 JOIN afl.club_season cs ON ps.club_season_id = cs.id
 JOIN afl.club c ON cs.club_id = c.id
 JOIN afl.club_match cm ON cm.club_season_id = cs.id
-JOIN afl.match m ON cm.match_id = m.id
-JOIN afl.round r ON m.round_id = r.id
-JOIN afl.season s ON r.season_id = s.id
-JOIN afl.league l ON s.league_id = l.id
-WHERE p.name = 'Jordan Dawson'
-  AND c.name = 'Adelaide Crows'
-  AND l.name = 'AFL'
-  AND s.name = 'AFL 2025'
-  AND r.name = 'Round 13'
-  AND m.venue = 'Adelaide Oval'
+WHERE p.name = 'Jordan Dawson' AND c.name = 'Adelaide Crows'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 22, 15, 4, 0, 6, 0, 2
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+WHERE p.name = 'Rory Laird' AND c.name = 'Adelaide Crows'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 14, 18, 3, 0, 7, 1, 0
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+WHERE p.name = 'Ben Keays' AND c.name = 'Adelaide Crows'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+-- Player match records — Brisbane players
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 20, 16, 5, 0, 8, 3, 2
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+WHERE p.name = 'Lachie Neale' AND c.name = 'Brisbane Lions'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 16, 10, 7, 0, 5, 1, 3
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+WHERE p.name = 'Hugh McCluggage' AND c.name = 'Brisbane Lions'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 10, 14, 2, 0, 9, 0, 1
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+WHERE p.name = 'Dayne Zorko' AND c.name = 'Brisbane Lions'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+COMMIT;

--- a/frontend/web/.gitignore
+++ b/frontend/web/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/web/.gitignore
+++ b/frontend/web/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+test-results/

--- a/frontend/web/e2e/match-view.spec.ts
+++ b/frontend/web/e2e/match-view.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Match view', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate: Seasons → first season → first match
+    await page.goto('/')
+    await page.getByRole('link', { name: 'AFL 2025' }).first().click()
+    await page.getByRole('link', { name: /Adelaide Crows.+v.+Brisbane Lions/ }).first().click()
+  })
+
+  test('displays match header with teams and venue', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Adelaide Crows')
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Brisbane Lions')
+    await expect(page.getByText('Adelaide Oval')).toBeVisible()
+  })
+
+  test('displays home team player stats', async ({ page }) => {
+    const homeSection = page.getByRole('heading', { name: 'Adelaide Crows' }).locator('..')
+
+    // Check players appear in the table
+    await expect(page.getByText('Jordan Dawson')).toBeVisible()
+    await expect(page.getByText('Rory Laird')).toBeVisible()
+    await expect(page.getByText('Ben Keays')).toBeVisible()
+  })
+
+  test('displays away team player stats', async ({ page }) => {
+    await expect(page.getByText('Lachie Neale')).toBeVisible()
+    await expect(page.getByText('Hugh McCluggage')).toBeVisible()
+    await expect(page.getByText('Dayne Zorko')).toBeVisible()
+  })
+
+  test('displays stat column headers', async ({ page }) => {
+    for (const label of ['K', 'HB', 'M', 'HO', 'T', 'G', 'B', 'D', 'SC']) {
+      await expect(page.getByRole('columnheader', { name: label }).first()).toBeVisible()
+    }
+  })
+
+  test('displays totals row', async ({ page }) => {
+    await expect(page.getByText('Totals').first()).toBeVisible()
+  })
+
+  test('edits a player stat and sees updated value', async ({ page }) => {
+    // Find Jordan Dawson's kicks input (first editable input in his row)
+    const dawsonRow = page.getByRole('row').filter({ hasText: 'Jordan Dawson' })
+    const kicksInput = dawsonRow.getByRole('spinbutton').first()
+
+    // Read current value, change it, and verify
+    const currentValue = await kicksInput.inputValue()
+    const newValue = String(Number(currentValue) + 1)
+
+    await kicksInput.fill(newValue)
+    await kicksInput.press('Tab') // trigger change event
+
+    // Wait for mutation response — the disposals column should update
+    // (disposals = kicks + handballs, so increasing kicks by 1 increases disposals by 1)
+    await expect(kicksInput).toHaveValue(newValue)
+  })
+})

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>xFFL</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -1,0 +1,2519 @@
+{
+  "name": "xffl-frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xffl-frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@apollo/client": "^3.13.4",
+        "@vue/apollo-composable": "^4.2.2",
+        "graphql": "^16.10.0",
+        "graphql-tag": "^2.12.6",
+        "vue": "^3.5.13",
+        "vue-router": "^4.5.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.8",
+        "@vitejs/plugin-vue": "^5.2.3",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.4",
+        "tailwindcss": "^4.1.8",
+        "typescript": "~5.7.2",
+        "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.1.tgz",
+      "integrity": "sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/apollo-composable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/apollo-composable/-/apollo-composable-4.2.2.tgz",
+      "integrity": "sha512-5j+Jl07Gemz5vmuS8u/FfWtYgr04Rh0rjQ5HBv6DZDP7d+pvQfsCIRgX5adJoZJcznJLsQ0JupO/mZmRCBWGaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "throttle-debounce": "^5.0.0",
+        "ts-essentials": "^9.4.0",
+        "vue-demi": "^0.14.6"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^3.4.13",
+        "@vue/composition-api": "^1.0.0",
+        "graphql": ">=15",
+        "vue": "^2.6.0 || ^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/apollo-composable/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
+      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.321",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
+      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
+      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.2.tgz",
+      "integrity": "sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "zen-observable": "0.8.15"
+      }
+    }
+  }
+}

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -16,6 +16,7 @@
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.1.8",
         "@vitejs/plugin-vue": "^5.2.3",
         "autoprefixer": "^10.4.21",
@@ -624,6 +625,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2130,6 +2147,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "xffl-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.8",
+    "@vitejs/plugin-vue": "^5.2.3",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^4.1.8",
+    "typescript": "~5.7.2",
+    "vite": "^6.2.0"
+  },
+  "dependencies": {
+    "@apollo/client": "^3.13.4",
+    "@vue/apollo-composable": "^4.2.2",
+    "graphql": "^16.10.0",
+    "graphql-tag": "^2.12.6",
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.0"
+  }
+}

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.8",
     "@vitejs/plugin-vue": "^5.2.3",
     "autoprefixer": "^10.4.21",

--- a/frontend/web/playwright.config.ts
+++ b/frontend/web/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 15_000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+})

--- a/frontend/web/postcss.config.js
+++ b/frontend/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="min-h-screen bg-gray-950 text-gray-100">
+    <nav class="border-b border-gray-800 px-6 py-4">
+      <div class="max-w-5xl mx-auto flex items-center gap-6">
+        <router-link to="/" class="text-lg font-semibold tracking-tight hover:text-white transition-colors">
+          xFFL
+        </router-link>
+      </div>
+    </nav>
+    <main class="max-w-5xl mx-auto px-6 py-8">
+      <router-view />
+    </main>
+  </div>
+</template>

--- a/frontend/web/src/app/apollo.ts
+++ b/frontend/web/src/app/apollo.ts
@@ -1,0 +1,10 @@
+import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client/core'
+
+const httpLink = createHttpLink({
+  uri: 'http://localhost:8090/query',
+})
+
+export const apolloClient = new ApolloClient({
+  link: httpLink,
+  cache: new InMemoryCache(),
+})

--- a/frontend/web/src/app/main.css
+++ b/frontend/web/src/app/main.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -1,0 +1,26 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: () => import('@/features/afl/views/SeasonsView.vue'),
+    },
+    {
+      path: '/afl/seasons/:seasonId',
+      name: 'season',
+      component: () => import('@/features/afl/views/SeasonView.vue'),
+      props: true,
+    },
+    {
+      path: '/afl/seasons/:seasonId/matches/:matchId',
+      name: 'match',
+      component: () => import('@/features/afl/views/MatchView.vue'),
+      props: true,
+    },
+  ],
+})
+
+export default router

--- a/frontend/web/src/env.d.ts
+++ b/frontend/web/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<object, object, unknown>
+  export default component
+}

--- a/frontend/web/src/features/afl/api/mutations.ts
+++ b/frontend/web/src/features/afl/api/mutations.ts
@@ -1,0 +1,19 @@
+import gql from 'graphql-tag'
+
+export const UPDATE_PLAYER_MATCH = gql`
+  mutation UpdatePlayerMatch($input: UpdateAFLPlayerMatchInput!) {
+    updateAFLPlayerMatch(input: $input) {
+      id
+      player { id name }
+      kicks
+      handballs
+      marks
+      hitouts
+      tackles
+      goals
+      behinds
+      disposals
+      score
+    }
+  }
+`

--- a/frontend/web/src/features/afl/api/queries.ts
+++ b/frontend/web/src/features/afl/api/queries.ts
@@ -1,0 +1,97 @@
+import gql from 'graphql-tag'
+
+export const GET_SEASONS = gql`
+  query GetSeasons {
+    aflSeasons {
+      id
+      name
+    }
+  }
+`
+
+export const GET_SEASON = gql`
+  query GetSeason($id: ID!) {
+    aflSeason(id: $id) {
+      id
+      name
+      rounds {
+        id
+        name
+        matches {
+          id
+          venue
+          startTime
+          result
+          homeClubMatch {
+            id
+            club { id name }
+            score
+          }
+          awayClubMatch {
+            id
+            club { id name }
+            score
+          }
+        }
+      }
+    }
+  }
+`
+
+export const GET_MATCH = gql`
+  query GetMatch($seasonId: ID!) {
+    aflSeason(id: $seasonId) {
+      id
+      rounds {
+        id
+        name
+        matches {
+          id
+          venue
+          startTime
+          result
+          homeClubMatch {
+            id
+            club { id name }
+            rushedBehinds
+            score
+            playerMatches {
+              id
+              playerSeasonId
+              player { id name }
+              kicks
+              handballs
+              marks
+              hitouts
+              tackles
+              goals
+              behinds
+              disposals
+              score
+            }
+          }
+          awayClubMatch {
+            id
+            club { id name }
+            rushedBehinds
+            score
+            playerMatches {
+              id
+              playerSeasonId
+              player { id name }
+              kicks
+              handballs
+              marks
+              hitouts
+              tackles
+              goals
+              behinds
+              disposals
+              score
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/frontend/web/src/features/afl/components/PlayerStatsTable.vue
+++ b/frontend/web/src/features/afl/components/PlayerStatsTable.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-gray-800 text-left text-gray-400">
+          <th class="py-2 pr-4 font-medium">Player</th>
+          <th v-for="col in statColumns" :key="col.key" class="py-2 px-2 font-medium text-right w-16">
+            {{ col.label }}
+          </th>
+          <th class="py-2 px-2 font-medium text-right w-16">D</th>
+          <th class="py-2 px-2 font-medium text-right w-16">SC</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="pm in clubMatch.playerMatches"
+          :key="pm.id"
+          class="border-b border-gray-800/50 hover:bg-gray-900/50"
+        >
+          <td class="py-2 pr-4 font-medium">{{ pm.player.name }}</td>
+          <td v-for="col in statColumns" :key="col.key" class="py-1 px-1 text-right">
+            <input
+              type="number"
+              :value="pm[col.key]"
+              min="0"
+              class="w-14 rounded bg-transparent px-1 py-1 text-right text-gray-100 tabular-nums hover:bg-gray-800 focus:bg-gray-800 focus:outline-none focus:ring-1 focus:ring-gray-600"
+              @change="onStatChange(pm, col.key, $event)"
+            />
+          </td>
+          <td class="py-2 px-2 text-right tabular-nums text-gray-400">{{ pm.disposals }}</td>
+          <td class="py-2 px-2 text-right tabular-nums text-gray-400">{{ pm.score }}</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr class="border-t border-gray-700 font-semibold text-gray-300">
+          <td class="py-2 pr-4">Totals</td>
+          <td v-for="col in statColumns" :key="col.key" class="py-2 px-2 text-right tabular-nums">
+            {{ totals[col.key] }}
+          </td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ totals.disposals }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ totals.score }}</td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface PlayerMatch {
+  id: string
+  playerSeasonId: string
+  player: { id: string; name: string }
+  kicks: number
+  handballs: number
+  marks: number
+  hitouts: number
+  tackles: number
+  goals: number
+  behinds: number
+  disposals: number
+  score: number
+}
+
+interface ClubMatch {
+  id: string
+  club: { id: string; name: string }
+  playerMatches: PlayerMatch[]
+}
+
+const props = defineProps<{ clubMatch: ClubMatch }>()
+const emit = defineEmits<{
+  update: [input: { playerSeasonId: string; clubMatchId: string; [key: string]: unknown }]
+}>()
+
+const statColumns = [
+  { key: 'kicks' as const, label: 'K' },
+  { key: 'handballs' as const, label: 'HB' },
+  { key: 'marks' as const, label: 'M' },
+  { key: 'hitouts' as const, label: 'HO' },
+  { key: 'tackles' as const, label: 'T' },
+  { key: 'goals' as const, label: 'G' },
+  { key: 'behinds' as const, label: 'B' },
+]
+
+type StatKey = typeof statColumns[number]['key']
+
+const totals = computed(() => {
+  const keys = [...statColumns.map(c => c.key), 'disposals' as const, 'score' as const]
+  const sums: Record<string, number> = {}
+  for (const key of keys) {
+    sums[key] = props.clubMatch.playerMatches.reduce((sum, pm) => sum + pm[key], 0)
+  }
+  return sums
+})
+
+function onStatChange(pm: PlayerMatch, key: StatKey, event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = parseInt(target.value, 10)
+  if (isNaN(value) || value < 0) return
+  if (value === pm[key]) return
+
+  emit('update', {
+    playerSeasonId: pm.playerSeasonId,
+    clubMatchId: props.clubMatch.id,
+    [key]: value,
+  })
+}
+</script>

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <router-link
+      :to="{ name: 'season', params: { seasonId: props.seasonId } }"
+      class="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+    >
+      ← Back to season
+    </router-link>
+
+    <div v-if="loading" class="mt-6 text-gray-400">Loading match…</div>
+    <div v-else-if="error" class="mt-6 text-red-400">{{ error.message }}</div>
+    <template v-else-if="match">
+      <div class="mt-4 mb-8">
+        <h1 class="text-2xl font-bold">
+          {{ match.homeClubMatch?.club.name ?? '—' }}
+          <span class="text-gray-500 mx-2">v</span>
+          {{ match.awayClubMatch?.club.name ?? '—' }}
+        </h1>
+        <p v-if="match.venue" class="text-sm text-gray-400 mt-1">{{ match.venue }}</p>
+        <p v-if="match.result" class="text-lg font-semibold mt-2">
+          {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
+        </p>
+      </div>
+
+      <div v-for="side in sides" :key="side.label" class="mb-10">
+        <h2 class="text-lg font-semibold mb-3">{{ side.label }}</h2>
+        <PlayerStatsTable
+          v-if="side.clubMatch"
+          :club-match="side.clubMatch"
+          @update="handleUpdate"
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useQuery, useMutation } from '@vue/apollo-composable'
+import { GET_MATCH } from '../api/queries'
+import { UPDATE_PLAYER_MATCH } from '../api/mutations'
+import PlayerStatsTable from '../components/PlayerStatsTable.vue'
+
+const props = defineProps<{ seasonId: string; matchId: string }>()
+
+const { result, loading, error } = useQuery(GET_MATCH, () => ({ seasonId: props.seasonId }))
+
+const match = computed(() => {
+  const season = result.value?.aflSeason
+  if (!season) return null
+  for (const round of season.rounds) {
+    const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
+    if (found) return found
+  }
+  return null
+})
+
+const sides = computed(() => {
+  if (!match.value) return []
+  return [
+    { label: match.value.homeClubMatch?.club.name ?? 'Home', clubMatch: match.value.homeClubMatch },
+    { label: match.value.awayClubMatch?.club.name ?? 'Away', clubMatch: match.value.awayClubMatch },
+  ]
+})
+
+const { mutate } = useMutation(UPDATE_PLAYER_MATCH)
+
+function handleUpdate(input: { playerSeasonId: string; clubMatchId: string; [key: string]: unknown }) {
+  mutate({ input })
+}
+</script>

--- a/frontend/web/src/features/afl/views/SeasonView.vue
+++ b/frontend/web/src/features/afl/views/SeasonView.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <router-link to="/" class="text-sm text-gray-500 hover:text-gray-300 transition-colors">
+      ← Seasons
+    </router-link>
+
+    <div v-if="loading" class="mt-6 text-gray-400">Loading season…</div>
+    <div v-else-if="error" class="mt-6 text-red-400">{{ error.message }}</div>
+    <template v-else-if="result?.aflSeason">
+      <h1 class="text-2xl font-bold mt-4 mb-6">{{ result.aflSeason.name }}</h1>
+
+      <div v-for="round in result.aflSeason.rounds" :key="round.id" class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-300 mb-3">{{ round.name }}</h2>
+        <div class="space-y-2">
+          <router-link
+            v-for="match in round.matches"
+            :key="match.id"
+            :to="{ name: 'match', params: { seasonId: props.seasonId, matchId: match.id } }"
+            class="flex items-center justify-between rounded-lg border border-gray-800 px-4 py-3 hover:border-gray-600 transition-colors"
+          >
+            <span class="font-medium">
+              {{ match.homeClubMatch?.club.name ?? '—' }}
+              <span class="text-gray-500 mx-2">v</span>
+              {{ match.awayClubMatch?.club.name ?? '—' }}
+            </span>
+            <span v-if="match.result" class="text-sm text-gray-400">
+              {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
+            </span>
+          </router-link>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useQuery } from '@vue/apollo-composable'
+import { GET_SEASON } from '../api/queries'
+
+const props = defineProps<{ seasonId: string }>()
+const { result, loading, error } = useQuery(GET_SEASON, () => ({ id: props.seasonId }))
+</script>

--- a/frontend/web/src/features/afl/views/SeasonsView.vue
+++ b/frontend/web/src/features/afl/views/SeasonsView.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-6">AFL Seasons</h1>
+
+    <div v-if="loading" class="text-gray-400">Loading seasons…</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <div v-else class="space-y-2">
+      <router-link
+        v-for="season in result?.aflSeasons"
+        :key="season.id"
+        :to="{ name: 'season', params: { seasonId: season.id } }"
+        class="block rounded-lg border border-gray-800 px-4 py-3 hover:border-gray-600 transition-colors"
+      >
+        {{ season.name }}
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useQuery } from '@vue/apollo-composable'
+import { GET_SEASONS } from '../api/queries'
+
+const { result, loading, error } = useQuery(GET_SEASONS)
+</script>

--- a/frontend/web/src/main.ts
+++ b/frontend/web/src/main.ts
@@ -1,0 +1,11 @@
+import './app/main.css'
+import { createApp } from 'vue'
+import { DefaultApolloClient } from '@vue/apollo-composable'
+import { apolloClient } from './app/apollo'
+import router from './app/router'
+import App from './App.vue'
+
+const app = createApp(App)
+app.use(router)
+app.provide(DefaultApolloClient, apolloClient)
+app.mount('#app')

--- a/frontend/web/tsconfig.json
+++ b/frontend/web/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    /* Paths */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/frontend/web/vite.config.ts
+++ b/frontend/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 3000,
+  },
+})

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.25
 use (
 	./contracts/events
 	./services/afl
+	./services/gateway
 	./shared/database
 	./shared/events
 )

--- a/justfile
+++ b/justfile
@@ -54,6 +54,10 @@ run-gateway:
 run-frontend:
     cd frontend/web && npm run dev
 
+# Run frontend e2e tests (requires run-all to be running)
+test-e2e:
+    cd frontend/web && npx playwright test
+
 # Run AFL service, gateway, and frontend together
 run-all:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -53,3 +53,12 @@ run-gateway:
 # Run Frontend (port 3000)
 run-frontend:
     cd frontend/web && npm run dev
+
+# Run AFL service, gateway, and frontend together
+run-all:
+    #!/usr/bin/env bash
+    trap 'kill 0' EXIT
+    just run-afl &
+    just run-gateway &
+    just run-frontend &
+    wait

--- a/services/afl/api/graphql/query.graphqls
+++ b/services/afl/api/graphql/query.graphqls
@@ -60,6 +60,7 @@ type AFLClubSeason {
 
 type AFLPlayerMatch {
   id: ID!
+  playerSeasonId: ID!
   player: AFLPlayer!
   kicks: Int!
   handballs: Int!

--- a/services/afl/internal/interface/graphql/convert.go
+++ b/services/afl/internal/interface/graphql/convert.go
@@ -115,8 +115,9 @@ func convertClubMatch(cm domain.ClubMatch, club domain.Club) *AFLClubMatch {
 
 func convertPlayerMatch(pm domain.PlayerMatch, player domain.Player) *AFLPlayerMatch {
 	return &AFLPlayerMatch{
-		ID:        toID(pm.ID),
-		Player:    convertPlayer(player),
+		ID:             toID(pm.ID),
+		PlayerSeasonID: toID(pm.PlayerSeasonID),
+		Player:         convertPlayer(player),
 		Kicks:     pm.Kicks,
 		Handballs: pm.Handballs,
 		Marks:     pm.Marks,

--- a/services/afl/internal/interface/graphql/generated.go
+++ b/services/afl/internal/interface/graphql/generated.go
@@ -80,17 +80,18 @@ type ComplexityRoot struct {
 	}
 
 	AFLPlayerMatch struct {
-		Behinds   func(childComplexity int) int
-		Disposals func(childComplexity int) int
-		Goals     func(childComplexity int) int
-		Handballs func(childComplexity int) int
-		Hitouts   func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Kicks     func(childComplexity int) int
-		Marks     func(childComplexity int) int
-		Player    func(childComplexity int) int
-		Score     func(childComplexity int) int
-		Tackles   func(childComplexity int) int
+		Behinds        func(childComplexity int) int
+		Disposals      func(childComplexity int) int
+		Goals          func(childComplexity int) int
+		Handballs      func(childComplexity int) int
+		Hitouts        func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Kicks          func(childComplexity int) int
+		Marks          func(childComplexity int) int
+		Player         func(childComplexity int) int
+		PlayerSeasonID func(childComplexity int) int
+		Score          func(childComplexity int) int
+		Tackles        func(childComplexity int) int
 	}
 
 	AFLRound struct {
@@ -368,6 +369,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.AFLPlayerMatch.Player(childComplexity), true
+	case "AFLPlayerMatch.playerSeasonId":
+		if e.ComplexityRoot.AFLPlayerMatch.PlayerSeasonID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerMatch.PlayerSeasonID(childComplexity), true
 	case "AFLPlayerMatch.score":
 		if e.ComplexityRoot.AFLPlayerMatch.Score == nil {
 			break
@@ -634,6 +641,7 @@ type AFLClubSeason {
 
 type AFLPlayerMatch {
   id: ID!
+  playerSeasonId: ID!
   player: AFLPlayer!
   kicks: Int!
   handballs: Int!
@@ -992,6 +1000,8 @@ func (ec *executionContext) fieldContext_AFLClubMatch_playerMatches(_ context.Co
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_AFLPlayerMatch_id(ctx, field)
+			case "playerSeasonId":
+				return ec.fieldContext_AFLPlayerMatch_playerSeasonId(ctx, field)
 			case "player":
 				return ec.fieldContext_AFLPlayerMatch_player(ctx, field)
 			case "kicks":
@@ -1573,6 +1583,35 @@ func (ec *executionContext) fieldContext_AFLPlayerMatch_id(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _AFLPlayerMatch_playerSeasonId(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerMatch) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerMatch_playerSeasonId,
+		func(ctx context.Context) (any, error) {
+			return obj.PlayerSeasonID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerMatch_playerSeasonId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerMatch",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AFLPlayerMatch_player(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerMatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2141,6 +2180,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAFLPlayerMatch(ctx conte
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_AFLPlayerMatch_id(ctx, field)
+			case "playerSeasonId":
+				return ec.fieldContext_AFLPlayerMatch_playerSeasonId(ctx, field)
 			case "player":
 				return ec.fieldContext_AFLPlayerMatch_player(ctx, field)
 			case "kicks":
@@ -4420,6 +4461,11 @@ func (ec *executionContext) _AFLPlayerMatch(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("AFLPlayerMatch")
 		case "id":
 			out.Values[i] = ec._AFLPlayerMatch_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "playerSeasonId":
+			out.Values[i] = ec._AFLPlayerMatch_playerSeasonId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/services/afl/internal/interface/graphql/models_gen.go
+++ b/services/afl/internal/interface/graphql/models_gen.go
@@ -43,17 +43,18 @@ type AFLPlayer struct {
 }
 
 type AFLPlayerMatch struct {
-	ID        string     `json:"id"`
-	Player    *AFLPlayer `json:"player"`
-	Kicks     int        `json:"kicks"`
-	Handballs int        `json:"handballs"`
-	Marks     int        `json:"marks"`
-	Hitouts   int        `json:"hitouts"`
-	Tackles   int        `json:"tackles"`
-	Goals     int        `json:"goals"`
-	Behinds   int        `json:"behinds"`
-	Disposals int        `json:"disposals"`
-	Score     int        `json:"score"`
+	ID             string     `json:"id"`
+	PlayerSeasonID string     `json:"playerSeasonId"`
+	Player         *AFLPlayer `json:"player"`
+	Kicks          int        `json:"kicks"`
+	Handballs      int        `json:"handballs"`
+	Marks          int        `json:"marks"`
+	Hitouts        int        `json:"hitouts"`
+	Tackles        int        `json:"tackles"`
+	Goals          int        `json:"goals"`
+	Behinds        int        `json:"behinds"`
+	Disposals      int        `json:"disposals"`
+	Score          int        `json:"score"`
 }
 
 type AFLRound struct {

--- a/services/afl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/afl/internal/interface/graphql/mutation.resolvers.go
@@ -7,7 +7,6 @@ package graphql
 
 import (
 	"context"
-
 	"xffl/services/afl/internal/domain"
 )
 

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8090"
+	}
+
+	aflURL := os.Getenv("AFL_SERVICE_URL")
+	if aflURL == "" {
+		aflURL = "http://localhost:8080"
+	}
+
+	corsOrigin := os.Getenv("CORS_ORIGIN")
+	if corsOrigin == "" {
+		corsOrigin = "http://localhost:3000"
+	}
+
+	target, err := url.Parse(aflURL)
+	if err != nil {
+		log.Fatalf("invalid AFL_SERVICE_URL: %v", err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+
+	mux.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", corsOrigin)
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		proxy.ServeHTTP(w, r)
+	})
+
+	log.Printf("Gateway starting on :%s (proxying to %s)", port, aflURL)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/services/gateway/go.mod
+++ b/services/gateway/go.mod
@@ -1,0 +1,3 @@
+module xffl/services/gateway
+
+go 1.25


### PR DESCRIPTION
## Summary
- Complete AFL match view with player stats display and inline editing
- Fix seed data to be idempotent with proper home/away club match links
- Add Playwright e2e test suite (6 tests covering read + edit flows)
- Streamline agent workflow: conditional current-task.md, allow sprint task updates
- Move repo-map.md to ai/, tidy gitignore ownership

## Test plan
- [ ] `just dev-up && just dev-seed` — seed data loads cleanly
- [ ] `just run-all` — AFL service, gateway, frontend all start
- [ ] Navigate http://localhost:3000 → season → match — player stats render for both teams
- [ ] Edit a stat inline — mutation fires, value persists
- [ ] `just test-e2e` — all 6 Playwright tests pass