### PR TITLE
Phase 6: FFL Frontend — all pages, backend wiring, e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ data
 
 # AI control plane
 ai-snapshot.out
+plans/current-task.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ first-cut/       → Legacy prototype (reference only)
 4. **TDD** — write failing tests first, then minimal implementation.
 5. **No new dependencies/services/infra without an ADR.**
 6. **When unclear, ask** — propose options, wait for confirmation.
+7. **Never commit or push without permission** — do not run `git commit` or `git push` unless the user explicitly asks. Each commit requires separate, explicit approval. "Move on" or "next task" does not mean "commit".
+8. **Update sprint doc immediately** — check off items in `plans/current-sprint.md` as soon as each task or sub-task is completed. Do not batch updates.
 
 ## Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ just test-e2e        # Playwright e2e tests (requires run-all)
 **Always before coding:**
 - `plans/current-sprint.md` — what to work on now
 - `ai/architecture/principles.md` — architecture rules and service layout
+- `ai/architecture/cookbook.md` — implementation recipes, file paths, code generation commands
 
 **Before architecture changes:**
 - `ai/decisions/decisions.md` — ADR index with summary table

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XFFL — Fantasy Football League
+# xFFL — Fantasy Football League
 
 Multi-service fantasy football application bridging real AFL statistics with fantasy league scoring and search.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See `ai/architecture/` for bounded contexts, service map, and principles.
 
 Vue 3 + TypeScript SPA served by Vite (port 3000). Apollo Client manages server state via the GraphQL gateway — no separate state store. Tailwind CSS for styling (see ADR-011).
 
-Structure mirrors backend bounded contexts:
+Frontend features follow user workflows, not backend services. The initial structure mirrors bounded contexts, but features may span services as the UI evolves.
 
     frontend/web/src/
     ├── features/afl/    → AFL views, components, GraphQL queries
@@ -36,11 +36,11 @@ Structure mirrors backend bounded contexts:
 
 ### Architecture Decisions
 
-This project demonstrates a modular microservices architecture that balances learning, experimentation, and future scalability. The choices made are deliberate for a hobby project that might grow.
+This project uses a **service-oriented modular monolith** architecture. Services are logically separated and independently evolvable, but currently run in a single environment with a shared database. This is a deliberate choice — the boundaries are real, but the infrastructure complexity of true microservices is deferred until needed.
 
 The architecture supports multiple evolution paths:
 
-- **Monolith Consolidation:** Merge services into single binary if complexity isn't needed
+- **Stay Here:** The modular monolith may be all this project ever needs
 - **True Microservices:** Separate databases, independent deployment, service mesh
 - **Event-Driven Scale:** Migrate from PostgreSQL events to cloud messaging (AWS/GCP/Azure)
 - **Event Sourcing:** Add event store, replay capabilities, full audit trails

--- a/ai/architecture/control-plane.md
+++ b/ai/architecture/control-plane.md
@@ -16,6 +16,7 @@ The ai/ directory is a declarative control plane for AI agents. Human architects
 |-------|-----------|---------|------------|
 | Control Plane | `ai/` | Architecture, decisions, prompts | Human (agents read-only) |
 | Plans | `plans/` | Roadmap, sprint, working memory | Collaborative (agents check off items; scope changes need discussion) |
+| Working Memory | `plans/current-task.md` | Ephemeral scratchpad for multi-step reasoning (gitignored) | Agent (optional, not required) |
 | Agent Config | `.claude/` | Skills, hooks, settings | Human (Claude Code only) |
 
 ## Source of Truth Hierarchy
@@ -28,11 +29,23 @@ When instructions conflict, architectural authority wins:
 
 CLAUDE.md is the entry point agents read first, but if it drifts from principles or ADRs, the architecture docs win.
 
+## Decision Protocol (when unclear)
+
+If instructions conflict or are ambiguous:
+
+1. Prefer the simplest interpretation that satisfies the current sprint goal
+2. Do not expand scope beyond `plans/current-sprint.md`
+3. If still unclear: propose 2–3 options, ask user before proceeding
+
 ## Constraints
 
 - `ai/` is read-only for agents — human maintains architectural intent
 - `.claude/` is vendor-specific — enhances but is not required
 - Architecture and ADRs override code (see principles.md)
+
+## Guardrail
+
+The control plane must remain smaller and simpler than the code it governs. If maintaining `ai/` becomes a burden, offer suggestions to simplify it.
 
 ## What this is not
 

--- a/ai/architecture/cookbook.md
+++ b/ai/architecture/cookbook.md
@@ -1,0 +1,108 @@
+# Developer Cookbook
+
+Recipes and patterns for implementing changes across the stack. Read this before exploring the codebase.
+
+## Service structure (identical for AFL and FFL)
+
+```
+services/{afl,ffl}/
+  cmd/main.go                              → Wiring: pool → sqlcgen.Queries → repos → app.Queries/Commands → Resolver → server
+  api/graphql/{query,mutation}.graphqls     → GraphQL schema (source of truth for API)
+  gqlgen.yml                               → gqlgen config (models, resolver layout)
+  sqlc.yaml                                → SQLC config (points at schema SQL + query SQL)
+  internal/
+    domain/                                → Structs, enums, repository interfaces. Zero dependencies.
+    application/
+      queries.go                           → Read-only operations. Holds all repo interfaces.
+      commands.go                          → Write operations. Uses TxManager for transactions.
+    infrastructure/postgres/
+      sqlc/*.sql                           → Hand-written SQL queries (SQLC input)
+      sqlcgen/                             → Generated Go from SQLC (DO NOT EDIT)
+      repository.go                        → Implements domain repo interfaces, maps sqlcgen types ↔ domain types
+      db.go                                → TxManager, transaction helpers
+    interface/graphql/
+      resolver.go                          → Resolver struct { Queries, Commands }
+      query.resolvers.go                   → Query resolver implementations
+      mutation.resolvers.go                → Mutation resolver implementations
+      convert.go                           → Domain ↔ GraphQL type converters (toID, fromID, convertPlayer, etc.)
+      generated.go                         → gqlgen generated (DO NOT EDIT)
+      models_gen.go                        → gqlgen generated models (DO NOT EDIT)
+```
+
+## Recipe: Add a column to an existing table
+
+Files to touch, in order:
+
+1. **Schema** — `dev/postgres/init/{01_afl,02_ffl}_schema.sql` — add the column
+2. **Domain** — `internal/domain/<entity>.go` — add field to struct (use `*int` for nullable)
+3. **SQLC queries** — `internal/infrastructure/postgres/sqlc/<entity>.sql` — add column to SELECT lists and RETURNING clauses
+4. **Generate SQLC** — run `cd services/{svc} && sqlc generate`
+5. **Repository** — `internal/infrastructure/postgres/repository.go` — map the new sqlcgen field to domain field. Use helpers: `int32PtrToIntPtr`, `derefOr`, `positionPtr`, etc.
+6. **GraphQL schema** — `api/graphql/query.graphqls` — add field to the relevant type
+7. **Generate gqlgen** — run `cd services/{svc} && go run github.com/99designs/gqlgen generate`
+8. **Resolver** — `internal/interface/graphql/query.resolvers.go` — populate the new field (may need converter update in `convert.go`)
+9. **Seed data** — `dev/postgres/seed/*.sql` — add values for the new column
+10. **Reset DB** — `just dev-reset && just dev-up && just dev-seed`
+
+## Recipe: Add a new GraphQL query
+
+1. **Schema** — add query to `api/graphql/query.graphqls` (and any new types)
+2. **Generate gqlgen** — creates a panic stub in `query.resolvers.go`
+3. If it needs new data access:
+   - Add SQLC query → `sqlc generate` → add repo method → add domain interface method → add application query method
+4. **Implement resolver** — replace the panic stub, use `fromID`/`toID` for ID conversion
+5. **Frontend** — add gql query in `frontend/web/src/features/{ffl,afl}/api/queries.ts`
+
+## Recipe: Add a new frontend page
+
+1. **View component** — `frontend/web/src/features/{ffl,afl}/views/<Name>View.vue`
+2. **Route** — `frontend/web/src/app/router.ts` — add route with `props: true`
+3. **Query** — `features/{ffl,afl}/api/queries.ts` — add GraphQL query
+4. **Pattern**: `useQuery` from `@vue/apollo-composable`, loading/error/data template guards, Tailwind styling
+
+## Code generation commands
+
+```bash
+cd services/afl && sqlc generate                           # Regenerate SQLC (after changing .sql queries or schema)
+cd services/afl && go run github.com/99designs/gqlgen generate  # Regenerate gqlgen (after changing .graphqls)
+cd services/ffl && sqlc generate
+cd services/ffl && go run github.com/99designs/gqlgen generate
+```
+
+Always run `sqlc generate` before `gqlgen generate` if both schema SQL and GraphQL changed.
+
+## Cross-service queries (frontend)
+
+The Apollo client (`frontend/web/src/app/apollo.ts`) routes by field prefix:
+- Root fields starting with `ffl` → FFL service (`/ffl/query`)
+- Everything else → AFL service (`/afl/query`)
+
+**A single GraphQL operation cannot span both services.** For cross-service data (e.g. FFL roster + AFL stats), issue two separate queries and join in the component. Pattern:
+
+```ts
+const { result: fflResult } = useQuery(FFL_QUERY, ...)
+const ids = computed(() => /* extract AFL IDs from fflResult */)
+const { result: aflResult } = useQuery(AFL_QUERY, () => ({ ids: ids.value }), () => ({ enabled: ids.value.length > 0 }))
+// join in a computed
+```
+
+## Repository type mapping helpers
+
+Both services use these in `repository.go`:
+- `int32PtrToIntPtr` / `intPtrToInt32Ptr` — nullable int conversion between sqlcgen (int32) and domain (int)
+- `derefOr(p *int32) int` — dereference pointer or return 0
+- `toID(int) string` / `fromID(string) (int, error)` — in convert.go, for GraphQL ID ↔ int
+
+## Frontend conventions
+
+- **Styling**: Tailwind with semantic tokens — `text-text-muted`, `bg-surface-raised`, `border-border`, `bg-active`, `text-active-text`
+- **Tables**: `overflow-x-auto` wrapper, `w-full text-sm`, `border-b border-border` headers, `tabular-nums` for numbers
+- **Components**: Vue 3 `<script setup>`, TypeScript, feature-folder structure (`features/{afl,ffl}/{api,components,views}`)
+- **Numbers**: `.toFixed(1)` for averages, `tabular-nums` class for alignment
+
+## Testing
+
+- **Go unit tests**: `cd services/{svc} && go test ./...`
+- **Integration tests** use the local Postgres (must be running via `just dev-up`). Schema changes require `just dev-reset && just dev-up && just dev-seed`.
+- **Frontend type check**: `cd frontend/web && npx vue-tsc --noEmit`
+- **E2E**: `just test-e2e` (requires `just run-all`)

--- a/ai/architecture/principles.md
+++ b/ai/architecture/principles.md
@@ -18,11 +18,13 @@ Dependencies point inward; never outward. Business logic has zero framework depe
 - Aggregates enforce consistency; domain events cross context boundaries
 - Repositories abstract persistence
 
-## SOA
+## Service-Oriented Modular Monolith
 
-- Services are independently deployable, organized around business capabilities
-- Each service owns its data — logical isolation via schema separation in a shared PostgreSQL instance (pragmatic for development; can split to separate databases later per ADR-003)
+- Services are logically separated and independently evolvable, organized around business capabilities
+- Currently a modular monolith: shared database, synchronous gateway, single environment — true microservice infrastructure is deferred until needed
+- Each service owns its data — logical isolation via schema separation in a shared PostgreSQL instance (can split to separate databases later per ADR-003)
 - Services communicate through contracts in `contracts/`
+- Events are contracts, not internal models — consumers must tolerate additional fields
 - Prefer async; sync only when necessary
 
 ## GraphQL
@@ -30,6 +32,11 @@ Dependencies point inward; never outward. Business logic has zero framework depe
 - Every query must start from a domain root (an aggregate the user naturally thinks in, e.g., Season or Club).
 - Related data is accessed by traversing edges, not by separate top-level queries.
 - Internal join entities (ClubMatch, PlayerSeason) are not query roots — they appear as nested fields of their parent.
+
+## Frontend
+
+- Frontend features follow user workflows, not backend services. Features may span multiple services as the UI evolves.
+- Apollo Client manages server state — no separate state store.
 
 ## Testing
 

--- a/ai/decisions/adr-004-event-driven-communication.md
+++ b/ai/decisions/adr-004-event-driven-communication.md
@@ -47,6 +47,7 @@ FFL.FantasyScoreCalculated → Search (indexing)
 - **Low event volume** — two event types, three subscribers. Purpose-built messaging (NATS, Kafka) is overkill.
 - **Lost messages are tolerable** — fantasy scores can be recalculated, search can be re-indexed. Nothing requires exactly-once delivery.
 - **Loose coupling** — services depend on event contracts in `contracts/events/`, not on each other.
+- **Events are contracts, not internal models** — event schemas are public API. Producers must not leak internal domain structure into payloads. Consumers must tolerate additional fields (additive changes are non-breaking).
 - **Testable** — in-memory dispatcher for unit/integration tests.
 
 ## Scale Path

--- a/ai/decisions/adr-012-domain-purity-aggregate-completeness.md
+++ b/ai/decisions/adr-012-domain-purity-aggregate-completeness.md
@@ -44,11 +44,17 @@ Additionally, partially-loaded aggregates (missing required data) lead to unclea
 - Do not return partially-loaded aggregates that require further data fetching.
 - Repository methods may be use-case-specific (e.g. `GetMatchWithDetails`). Use-case-specific repository methods are preferred over generic methods that over-fetch.
 
+### Time and Randomness
+
+- Domain entities must not access system time or randomness directly.
+- Time, IDs, and ordering decisions are provided by the application layer.
+
 ### Application Responsibility
 
 - Application use cases orchestrate data loading via repositories.
 - Use cases construct or retrieve fully-initialized aggregates.
 - Use cases invoke domain logic and handle side effects (persistence, events).
+- Use cases provide time, IDs, and any non-deterministic inputs to domain logic.
 
 ## Consequences
 
@@ -69,6 +75,7 @@ Additionally, partially-loaded aggregates (missing required data) lead to unclea
 
 - Domain packages must not import infrastructure, database, or network libraries.
 - Domain entities must not accept repository or service interfaces as dependencies.
+- Domain entities must not call `time.Now()`, `rand.*`, or UUID generators directly.
 - All repository implementations must reside in the infrastructure layer.
 - Application layer is responsible for coordinating repository calls before invoking domain logic.
 

--- a/ai/repo-map.md
+++ b/ai/repo-map.md
@@ -13,7 +13,8 @@ xffl/
 │
 ├── plans/                 → Project plans
 │   ├── roadmap.md         → Full project phases
-│   └── current-sprint.md  → Active sprint tasks
+│   ├── current-sprint.md  → Active sprint tasks
+│   └── revisit.md         → Ideas to reconsider later (not roadmap)
 │
 ├── services/
 │   ├── afl/               → AFL service (Go, GraphQL, :8080)

--- a/ai/repo-map.md
+++ b/ai/repo-map.md
@@ -7,7 +7,7 @@ xffl/
 ├── go.work                → Go workspace referencing all modules
 │
 ├── ai/                    → AI control plane (read-only for agents)
-│   ├── architecture/      → principles.md, service-map.md, domain.md
+│   ├── architecture/      → principles.md, service-map.md, domain.md, cookbook.md
 │   ├── decisions/         → ADR index (decisions.md) + individual ADRs
 │   └── prompts/           → Development workflow
 │

--- a/dev/postgres/init/02_ffl_schema.sql
+++ b/dev/postgres/init/02_ffl_schema.sql
@@ -104,7 +104,8 @@ CREATE TABLE IF NOT EXISTS ffl.player (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP WITH TIME ZONE,
     name VARCHAR(255) NOT NULL,
-    club_id INTEGER REFERENCES ffl.club(id) ON DELETE CASCADE
+    club_id INTEGER REFERENCES ffl.club(id) ON DELETE CASCADE,
+    afl_player_id INTEGER
 );
 
 -- Create player_season table

--- a/dev/postgres/init/02_ffl_schema.sql
+++ b/dev/postgres/init/02_ffl_schema.sql
@@ -118,6 +118,7 @@ CREATE TABLE IF NOT EXISTS ffl.player_season (
     club_season_id INTEGER NOT NULL REFERENCES ffl.club_season(id) ON DELETE CASCADE,
     from_round_id INTEGER REFERENCES ffl.round(id),
     to_round_id INTEGER REFERENCES ffl.round(id),
+    afl_player_season_id INTEGER,
     CONSTRAINT uni_player_season UNIQUE (player_id, club_season_id)
 );
 
@@ -134,6 +135,7 @@ CREATE TABLE IF NOT EXISTS ffl.player_match (
     backup_positions TEXT,
     interchange_position VARCHAR(255),
     score INTEGER DEFAULT 0,
+    afl_player_match_id INTEGER,
     CONSTRAINT uni_ffl_player_match UNIQUE (player_season_id, club_match_id)
 );
 

--- a/dev/postgres/seed/01_afl_seed.sql
+++ b/dev/postgres/seed/01_afl_seed.sql
@@ -209,4 +209,126 @@ JOIN afl.club_match cm ON cm.club_season_id = cs.id
 WHERE p.name = 'Dayne Zorko' AND c.name = 'Brisbane Lions'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
+-- Round 14
+INSERT INTO afl.round (season_id, name)
+SELECT s.id, 'Round 14'
+FROM afl.season s JOIN afl.league l ON s.league_id = l.id
+WHERE l.name = 'AFL' AND s.name = 'AFL 2025';
+
+INSERT INTO afl.match (round_id, venue, start_dt, drv_result)
+SELECT r.id, 'The Gabba', '2025-06-22 15:20:00+10:00', 'no_result'
+FROM afl.round r JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
+WHERE l.name = 'AFL' AND s.name = 'AFL 2025' AND r.name = 'Round 14';
+
+INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
+SELECT m.id, cs.id, 0, 0, 0
+FROM afl.match m JOIN afl.round r ON m.round_id = r.id JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
+JOIN afl.club_season cs ON cs.season_id = s.id JOIN afl.club c ON cs.club_id = c.id
+WHERE l.name = 'AFL' AND r.name = 'Round 14' AND c.name = 'Adelaide Crows'
+ON CONFLICT (club_season_id, match_id) DO NOTHING;
+
+INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
+SELECT m.id, cs.id, 0, 0, 0
+FROM afl.match m JOIN afl.round r ON m.round_id = r.id JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
+JOIN afl.club_season cs ON cs.season_id = s.id JOIN afl.club c ON cs.club_id = c.id
+WHERE l.name = 'AFL' AND r.name = 'Round 14' AND c.name = 'Brisbane Lions'
+ON CONFLICT (club_season_id, match_id) DO NOTHING;
+
+UPDATE afl.match SET
+  home_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Brisbane Lions'),
+  away_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Adelaide Crows')
+WHERE venue = 'The Gabba';
+
+-- Round 14 player stats
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 15, 10, 8, 0, 3, 1, 2
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Jordan Dawson' AND r.name = 'Round 14'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 25, 11, 5, 0, 8, 1, 0
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Rory Laird' AND r.name = 'Round 14'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 12, 20, 2, 0, 5, 0, 1
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Ben Keays' AND r.name = 'Round 14'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 18, 14, 4, 0, 6, 2, 1
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Lachie Neale' AND r.name = 'Round 14'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 14, 8, 9, 0, 3, 0, 2
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Hugh McCluggage' AND r.name = 'Round 14'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 8, 16, 3, 0, 11, 1, 0
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Dayne Zorko' AND r.name = 'Round 14'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+-- Round 15
+INSERT INTO afl.round (season_id, name)
+SELECT s.id, 'Round 15'
+FROM afl.season s JOIN afl.league l ON s.league_id = l.id
+WHERE l.name = 'AFL' AND s.name = 'AFL 2025';
+
+INSERT INTO afl.match (round_id, venue, start_dt, drv_result)
+SELECT r.id, 'MCG', '2025-06-29 14:10:00+10:00', 'no_result'
+FROM afl.round r JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
+WHERE l.name = 'AFL' AND s.name = 'AFL 2025' AND r.name = 'Round 15';
+
+INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
+SELECT m.id, cs.id, 0, 0, 0
+FROM afl.match m JOIN afl.round r ON m.round_id = r.id JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
+JOIN afl.club_season cs ON cs.season_id = s.id JOIN afl.club c ON cs.club_id = c.id
+WHERE l.name = 'AFL' AND r.name = 'Round 15' AND c.name = 'Adelaide Crows'
+ON CONFLICT (club_season_id, match_id) DO NOTHING;
+
+INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
+SELECT m.id, cs.id, 0, 0, 0
+FROM afl.match m JOIN afl.round r ON m.round_id = r.id JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
+JOIN afl.club_season cs ON cs.season_id = s.id JOIN afl.club c ON cs.club_id = c.id
+WHERE l.name = 'AFL' AND r.name = 'Round 15' AND c.name = 'Brisbane Lions'
+ON CONFLICT (club_season_id, match_id) DO NOTHING;
+
+UPDATE afl.match SET
+  home_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Adelaide Crows'),
+  away_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Brisbane Lions')
+WHERE venue = 'MCG' AND round_id = (SELECT id FROM afl.round WHERE name = 'Round 15');
+
+-- Round 15 player stats
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 20, 14, 5, 0, 5, 3, 0
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Jordan Dawson' AND r.name = 'Round 15'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 19, 18, 3, 0, 4, 0, 1
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Rory Laird' AND r.name = 'Round 15'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 16, 15, 4, 0, 9, 2, 1
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Ben Keays' AND r.name = 'Round 15'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 22, 12, 6, 0, 7, 1, 3
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Lachie Neale' AND r.name = 'Round 15'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 18, 12, 6, 0, 7, 2, 1
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Hugh McCluggage' AND r.name = 'Round 15'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 12, 10, 4, 0, 6, 0, 2
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id) WHERE p.name = 'Dayne Zorko' AND r.name = 'Round 15'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
 COMMIT;

--- a/dev/postgres/seed/02_ffl_seed.sql
+++ b/dev/postgres/seed/02_ffl_seed.sql
@@ -108,6 +108,16 @@ INSERT INTO ffl.player (name, club_id) VALUES
     ('Robbie Gray', (SELECT id FROM ffl.club WHERE name = 'The Howling Cows')),
     ('Joel Selwood', (SELECT id FROM ffl.club WHERE name = 'The Howling Cows'));
 
+-- Link matching FFL players to AFL players
+UPDATE ffl.player SET afl_player_id = (SELECT id FROM afl.player WHERE name = 'Lachie Neale')
+WHERE name = 'Lachie Neale';
+UPDATE ffl.player SET afl_player_id = (SELECT id FROM afl.player WHERE name = 'Hugh McCluggage')
+WHERE name = 'Hugh McCluggage';
+UPDATE ffl.player SET afl_player_id = (SELECT id FROM afl.player WHERE name = 'Rory Laird')
+WHERE name = 'Rory Laird';
+UPDATE ffl.player SET afl_player_id = (SELECT id FROM afl.player WHERE name = 'Jordan Dawson')
+WHERE name = 'Jordan Dawson';
+
 -- Player season records for all players
 INSERT INTO ffl.player_season (player_id, club_season_id, from_round_id)
 SELECT
@@ -120,6 +130,23 @@ JOIN ffl.club_season cs ON cs.club_id = c.id
 JOIN ffl.season s ON cs.season_id = s.id
 JOIN ffl.round r ON r.season_id = s.id
 WHERE s.name = '2024 Season' AND r.name = 'Round 1';
+
+-- Link matching FFL player seasons to AFL player seasons
+UPDATE ffl.player_season SET afl_player_season_id = (
+    SELECT ps.id FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id WHERE p.name = 'Lachie Neale' LIMIT 1
+) WHERE player_id = (SELECT id FROM ffl.player WHERE name = 'Lachie Neale');
+
+UPDATE ffl.player_season SET afl_player_season_id = (
+    SELECT ps.id FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id WHERE p.name = 'Hugh McCluggage' LIMIT 1
+) WHERE player_id = (SELECT id FROM ffl.player WHERE name = 'Hugh McCluggage');
+
+UPDATE ffl.player_season SET afl_player_season_id = (
+    SELECT ps.id FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id WHERE p.name = 'Rory Laird' LIMIT 1
+) WHERE player_id = (SELECT id FROM ffl.player WHERE name = 'Rory Laird');
+
+UPDATE ffl.player_season SET afl_player_season_id = (
+    SELECT ps.id FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id WHERE p.name = 'Jordan Dawson' LIMIT 1
+) WHERE player_id = (SELECT id FROM ffl.player WHERE name = 'Jordan Dawson');
 
 -- Player match records for Ruiboys (7 starters + 2 bench)
 INSERT INTO ffl.player_match (club_match_id, player_season_id, position, status, score)

--- a/frontend/web/e2e/admin-match-view.spec.ts
+++ b/frontend/web/e2e/admin-match-view.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Admin match view', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate: Home → match, then switch to admin URL
-    await page.goto('/')
+    // Navigate: AFL Home → match, then switch to admin URL
+    await page.goto('/afl')
     const matchLink = page.getByRole('link', { name: /Adelaide Crows.+v.+Brisbane Lions/ }).first()
     const href = await matchLink.getAttribute('href')
     // Replace /afl/ with /admin/afl/ to get admin route

--- a/frontend/web/e2e/ffl-home.spec.ts
+++ b/frontend/web/e2e/ffl-home.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('FFL Home', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('displays season and round name', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('2024 Season')
+    await expect(page.getByRole('paragraph')).toContainText('Round 1')
+  })
+
+  test('displays ladder with clubs', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Ladder' })).toBeVisible()
+    await expect(page.getByRole('cell', { name: 'Ruiboys' })).toBeVisible()
+    await expect(page.getByRole('cell', { name: 'The Howling Cows' })).toBeVisible()
+  })
+
+  test('displays ladder with percentage column', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: '%' })).toBeVisible()
+  })
+
+  test('displays match summary', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Matches' })).toBeVisible()
+    const matchLink = page.getByRole('link', { name: /Ruiboys.+v.+The Howling Cows/ })
+    await expect(matchLink).toBeVisible()
+  })
+
+  test('match summary links to FFL match page', async ({ page }) => {
+    const matchLink = page.getByRole('link', { name: /Ruiboys.+v.+The Howling Cows/ })
+    await matchLink.click()
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Ruiboys')
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
+  })
+
+  test('displays round navigation', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Rounds' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Round 1' })).toBeVisible()
+  })
+
+  test('has Build Team button', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Build Team' })).toBeVisible()
+  })
+
+  test('navbar has FFL and AFL links', async ({ page }) => {
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'FFL', exact: true })).toBeVisible()
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'AFL', exact: true })).toBeVisible()
+  })
+})

--- a/frontend/web/e2e/ffl-match.spec.ts
+++ b/frontend/web/e2e/ffl-match.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('FFL Match', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate: Home → match
+    await page.goto('/')
+    await page.getByRole('link', { name: /Ruiboys.+v.+The Howling Cows/ }).click()
+  })
+
+  test('displays match header with teams', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Ruiboys')
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
+  })
+
+  test('displays venue', async ({ page }) => {
+    await expect(page.getByText('MCG')).toBeVisible()
+  })
+
+  test('displays fantasy scores', async ({ page }) => {
+    await expect(page.getByText('Fantasy score:')).toHaveCount(2)
+  })
+
+  test('displays roster table with player columns', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'Player' }).first()).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Position' }).first()).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Status' }).first()).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Score' }).first()).toBeVisible()
+  })
+
+  test('displays Ruiboys players', async ({ page }) => {
+    await expect(page.getByText('Marcus Bontempelli')).toBeVisible()
+  })
+
+  test('displays status badges', async ({ page }) => {
+    await expect(page.getByText('Played').first()).toBeVisible()
+  })
+
+  test('displays total row', async ({ page }) => {
+    await expect(page.getByText('Total').first()).toBeVisible()
+  })
+})

--- a/frontend/web/e2e/ffl-round.spec.ts
+++ b/frontend/web/e2e/ffl-round.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('FFL Round', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate: Home → Round 1 via round nav
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Round 1' }).click()
+  })
+
+  test('displays round and season name', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
+    await expect(page.getByText('2024 Season')).toBeVisible()
+  })
+
+  test('displays match summaries', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Matches' })).toBeVisible()
+    const matchLink = page.getByRole('link', { name: /Ruiboys.+v.+The Howling Cows/ })
+    await expect(matchLink).toBeVisible()
+  })
+
+  test('displays top fantasy scorers', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Top Fantasy Scorers' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Player' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Score' })).toBeVisible()
+  })
+
+  test('displays round navigation', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Rounds' })).toBeVisible()
+  })
+
+  test('has Build Team button', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Build Team' })).toBeVisible()
+  })
+})

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('FFL Team Builder', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate: Home → Build Team
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Build Team' }).click()
+  })
+
+  test('displays Team Builder heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Team Builder')
+  })
+
+  test('displays club selector', async ({ page }) => {
+    await expect(page.getByRole('combobox')).toBeVisible()
+  })
+
+  test('displays position groups', async ({ page }) => {
+    for (const position of ['Goals', 'Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Star']) {
+      await expect(page.getByRole('heading', { name: position })).toBeVisible()
+    }
+  })
+
+  test('displays bench section', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Bench/ })).toBeVisible()
+  })
+
+  test('displays roster panel with players', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Roster/ })).toBeVisible()
+    // Ruiboys has 30 players, some already assigned in seed data
+    await expect(page.getByText('Marcus Bontempelli')).toBeVisible()
+  })
+
+  test('displays Save Lineup button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Save Lineup' })).toBeVisible()
+  })
+
+  test('loads existing lineup from seed data', async ({ page }) => {
+    // Seed data has 7 starters + 2 bench for Ruiboys
+    // Starters should appear in position slots (not in roster panel as available)
+    await expect(page.getByText('Christian Petracca')).toBeVisible()
+  })
+})

--- a/frontend/web/e2e/home-view.spec.ts
+++ b/frontend/web/e2e/home-view.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Home view', () => {
+test.describe('AFL Home view', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/afl')
   })
 
   test('displays season and round name', async ({ page }) => {
@@ -33,7 +33,8 @@ test.describe('Home view', () => {
     await expect(page.getByRole('link', { name: 'Round 13' })).toBeVisible()
   })
 
-  test('navbar has Home link', async ({ page }) => {
-    await expect(page.getByRole('navigation').getByRole('link', { name: 'Home' })).toBeVisible()
+  test('navbar has FFL and AFL links', async ({ page }) => {
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'FFL', exact: true })).toBeVisible()
+    await expect(page.getByRole('navigation').getByRole('link', { name: 'AFL', exact: true })).toBeVisible()
   })
 })

--- a/frontend/web/e2e/match-view.spec.ts
+++ b/frontend/web/e2e/match-view.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Match view', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate: Home → first match
-    await page.goto('/')
+    // Navigate: AFL Home → first match
+    await page.goto('/afl')
     await page.getByRole('link', { name: /Adelaide Crows.+v.+Brisbane Lions/ }).first().click()
   })
 

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -8,6 +8,9 @@
         <router-link to="/" class="text-sm text-text-muted hover:text-text transition-colors">
           Home
         </router-link>
+        <router-link to="/afl" class="text-sm text-text-muted hover:text-text transition-colors">
+          AFL
+        </router-link>
         <button
           class="ml-auto text-sm text-text-muted hover:text-text transition-colors"
           @click="toggleTheme"

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -8,7 +8,7 @@
         <router-link to="/" class="text-sm text-text-muted hover:text-text transition-colors">
           Home
         </router-link>
-        <router-link to="/afl" class="text-sm text-text-muted hover:text-text transition-colors">
+<router-link to="/afl" class="text-sm text-text-muted hover:text-text transition-colors">
           AFL
         </router-link>
         <button

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -6,7 +6,7 @@
           xFFL
         </router-link>
         <router-link to="/" class="text-sm text-text-muted hover:text-text transition-colors">
-          Home
+          FFL
         </router-link>
 <router-link to="/afl" class="text-sm text-text-muted hover:text-text transition-colors">
           AFL

--- a/frontend/web/src/app/apollo.ts
+++ b/frontend/web/src/app/apollo.ts
@@ -1,10 +1,19 @@
-import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client/core'
+import { ApolloClient, createHttpLink, InMemoryCache, ApolloLink } from '@apollo/client/core'
 
-const httpLink = createHttpLink({
-  uri: 'http://localhost:8090/query',
+const aflLink = createHttpLink({ uri: 'http://localhost:8090/afl/query' })
+const fflLink = createHttpLink({ uri: 'http://localhost:8090/ffl/query' })
+
+const routingLink = new ApolloLink((operation, forward) => {
+  const isFFL = operation.query.definitions.some(
+    def => def.kind === 'OperationDefinition' &&
+      def.selectionSet.selections.some(
+        sel => sel.kind === 'Field' && sel.name.value.startsWith('ffl')
+      )
+  )
+  return isFFL ? fflLink.request(operation, forward) : aflLink.request(operation, forward)
 })
 
 export const apolloClient = new ApolloClient({
-  link: httpLink,
+  link: routingLink,
   cache: new InMemoryCache(),
 })

--- a/frontend/web/src/app/apollo.ts
+++ b/frontend/web/src/app/apollo.ts
@@ -7,7 +7,7 @@ const routingLink = new ApolloLink((operation, forward) => {
   const isFFL = operation.query.definitions.some(
     def => def.kind === 'OperationDefinition' &&
       def.selectionSet.selections.some(
-        sel => sel.kind === 'Field' && sel.name.value.startsWith('ffl')
+        sel => sel.kind === 'Field' && /^ffl|FFL/.test(sel.name.value)
       )
   )
   return isFFL ? fflLink.request(operation, forward) : aflLink.request(operation, forward)

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -9,6 +9,18 @@ const router = createRouter({
       name: 'home',
       component: () => import('@/features/ffl/views/HomeView.vue'),
     },
+    {
+      path: '/ffl/seasons/:seasonId/rounds/:roundId',
+      name: 'ffl-round',
+      component: () => import('@/features/ffl/views/RoundView.vue'),
+      props: true,
+    },
+    {
+      path: '/ffl/seasons/:seasonId/matches/:matchId',
+      name: 'ffl-match',
+      component: () => import('@/features/ffl/views/MatchView.vue'),
+      props: true,
+    },
 
     // AFL routes
     {

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -21,6 +21,12 @@ const router = createRouter({
       component: () => import('@/features/ffl/views/MatchView.vue'),
       props: true,
     },
+    {
+      path: '/ffl/seasons/:seasonId/rounds/:roundId/team-builder',
+      name: 'ffl-team-builder',
+      component: () => import('@/features/ffl/views/TeamBuilderView.vue'),
+      props: true,
+    },
 
     // AFL routes
     {

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -22,6 +22,12 @@ const router = createRouter({
       props: true,
     },
     {
+      path: '/ffl/seasons/:seasonId/roster',
+      name: 'ffl-roster',
+      component: () => import('@/features/ffl/views/RosterView.vue'),
+      props: true,
+    },
+    {
       path: '/ffl/seasons/:seasonId/rounds/:roundId/team-builder',
       name: 'ffl-team-builder',
       component: () => import('@/features/ffl/views/TeamBuilderView.vue'),

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -3,26 +3,34 @@ import { createRouter, createWebHistory } from 'vue-router'
 const router = createRouter({
   history: createWebHistory(),
   routes: [
+    // FFL routes
     {
       path: '/',
       name: 'home',
+      component: () => import('@/features/ffl/views/HomeView.vue'),
+    },
+
+    // AFL routes
+    {
+      path: '/afl',
+      name: 'afl-home',
       component: () => import('@/features/afl/views/HomeView.vue'),
     },
     {
       path: '/afl/seasons/:seasonId/rounds/:roundId',
-      name: 'round',
+      name: 'afl-round',
       component: () => import('@/features/afl/views/RoundView.vue'),
       props: true,
     },
     {
       path: '/afl/seasons/:seasonId/matches/:matchId',
-      name: 'match',
+      name: 'afl-match',
       component: () => import('@/features/afl/views/MatchView.vue'),
       props: true,
     },
     {
       path: '/admin/afl/seasons/:seasonId/matches/:matchId',
-      name: 'admin-match',
+      name: 'afl-admin-match',
       component: () => import('@/features/afl/views/AdminMatchView.vue'),
       props: true,
     },

--- a/frontend/web/src/features/afl/components/RoundNav.vue
+++ b/frontend/web/src/features/afl/components/RoundNav.vue
@@ -3,7 +3,7 @@
     <router-link
       v-for="round in rounds"
       :key="round.id"
-      :to="{ name: 'round', params: { seasonId, roundId: round.id } }"
+      :to="{ name: 'afl-round', params: { seasonId, roundId: round.id } }"
       class="rounded px-3 py-1 text-sm transition-colors"
       :class="round.id === currentRoundId
         ? 'bg-active text-active-text'

--- a/frontend/web/src/features/afl/views/HomeView.vue
+++ b/frontend/web/src/features/afl/views/HomeView.vue
@@ -18,7 +18,7 @@
             v-for="match in data.round.matches"
             :key="match.id"
             :match="match"
-            :to="{ name: 'match', params: { seasonId: data.season.id, matchId: match.id } }"
+            :to="{ name: 'afl-match', params: { seasonId: data.season.id, matchId: match.id } }"
           />
         </div>
       </section>

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -16,7 +16,7 @@
           {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
         </p>
         <router-link
-          :to="{ name: 'admin-match', params: { seasonId: props.seasonId, matchId: props.matchId } }"
+          :to="{ name: 'afl-admin-match', params: { seasonId: props.seasonId, matchId: props.matchId } }"
           class="inline-block mt-3 text-sm text-text-faint hover:text-text-heading transition-colors"
         >
           Edit stats

--- a/frontend/web/src/features/afl/views/RoundView.vue
+++ b/frontend/web/src/features/afl/views/RoundView.vue
@@ -13,7 +13,7 @@
             v-for="match in data.round.matches"
             :key="match.id"
             :match="match"
-            :to="{ name: 'match', params: { seasonId: props.seasonId, matchId: match.id } }"
+            :to="{ name: 'afl-match', params: { seasonId: props.seasonId, matchId: match.id } }"
           />
         </div>
       </section>

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -1,29 +1,5 @@
 import gql from 'graphql-tag'
 
-export const CREATE_FFL_PLAYER = gql`
-  mutation CreateFFLPlayer($input: CreateFFLPlayerInput!) {
-    createFFLPlayer(input: $input) {
-      id
-      name
-    }
-  }
-`
-
-export const UPDATE_FFL_PLAYER = gql`
-  mutation UpdateFFLPlayer($input: UpdateFFLPlayerInput!) {
-    updateFFLPlayer(input: $input) {
-      id
-      name
-    }
-  }
-`
-
-export const DELETE_FFL_PLAYER = gql`
-  mutation DeleteFFLPlayer($id: ID!) {
-    deleteFFLPlayer(id: $id)
-  }
-`
-
 export const ADD_FFL_PLAYER_TO_SEASON = gql`
   mutation AddFFLPlayerToSeason($input: AddFFLPlayerToSeasonInput!) {
     addFFLPlayerToSeason(input: $input) {

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -1,0 +1,41 @@
+import gql from 'graphql-tag'
+
+export const CREATE_FFL_PLAYER = gql`
+  mutation CreateFFLPlayer($input: CreateFFLPlayerInput!) {
+    createFFLPlayer(input: $input) {
+      id
+      name
+    }
+  }
+`
+
+export const UPDATE_FFL_PLAYER = gql`
+  mutation UpdateFFLPlayer($input: UpdateFFLPlayerInput!) {
+    updateFFLPlayer(input: $input) {
+      id
+      name
+    }
+  }
+`
+
+export const DELETE_FFL_PLAYER = gql`
+  mutation DeleteFFLPlayer($id: ID!) {
+    deleteFFLPlayer(id: $id)
+  }
+`
+
+export const ADD_FFL_PLAYER_TO_SEASON = gql`
+  mutation AddFFLPlayerToSeason($input: AddFFLPlayerToSeasonInput!) {
+    addFFLPlayerToSeason(input: $input) {
+      id
+      playerId
+      clubSeasonId
+    }
+  }
+`
+
+export const REMOVE_FFL_PLAYER_FROM_SEASON = gql`
+  mutation RemoveFFLPlayerFromSeason($id: ID!) {
+    removeFFLPlayerFromSeason(id: $id)
+  }
+`

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -15,3 +15,16 @@ export const REMOVE_FFL_PLAYER_FROM_SEASON = gql`
     removeFFLPlayerFromSeason(id: $id)
   }
 `
+
+export const SET_FFL_LINEUP = gql`
+  mutation SetFFLLineup($input: SetFFLLineupInput!) {
+    setFFLLineup(input: $input) {
+      id
+      playerSeasonId
+      player { id name }
+      position
+      status
+      score
+    }
+  }
+`

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -16,6 +16,16 @@ export const REMOVE_FFL_PLAYER_FROM_SEASON = gql`
   }
 `
 
+export const ADD_FFL_ROSTER_PLAYER = gql`
+  mutation AddFFLRosterPlayer($input: AddFFLRosterPlayerInput!) {
+    addFFLRosterPlayer(input: $input) {
+      id
+      playerId
+      clubSeasonId
+    }
+  }
+`
+
 export const SET_FFL_LINEUP = gql`
   mutation SetFFLLineup($input: SetFFLLineupInput!) {
     setFFLLineup(input: $input) {

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -1,5 +1,57 @@
 import gql from 'graphql-tag'
 
+export const GET_FFL_TEAM_BUILDER = gql`
+  query GetFFLTeamBuilder($seasonId: ID!) {
+    fflSeason(id: $seasonId) {
+      id
+      name
+      ladder {
+        id
+        club { id name }
+        roster {
+          playerSeasonId
+          player { id name aflPlayerId }
+        }
+      }
+      rounds {
+        id
+        name
+        matches {
+          id
+          homeClubMatch {
+            id
+            club { id name }
+            playerMatches {
+              id
+              playerSeasonId
+              player { id name }
+              position
+              status
+              backupPositions
+              interchangePosition
+              score
+            }
+          }
+          awayClubMatch {
+            id
+            club { id name }
+            playerMatches {
+              id
+              playerSeasonId
+              player { id name }
+              position
+              status
+              backupPositions
+              interchangePosition
+              score
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
 export const GET_FFL_LATEST_ROUND = gql`
   query GetFFLLatestRound {
     fflLatestRound {

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -52,6 +52,40 @@ export const GET_FFL_TEAM_BUILDER = gql`
   }
 `
 
+export const GET_FFL_ROSTER = gql`
+  query GetFFLRoster($seasonId: ID!) {
+    fflSeason(id: $seasonId) {
+      id
+      name
+      ladder {
+        id
+        club { id name }
+        roster {
+          playerSeasonId
+          player { id name aflPlayerId }
+          aflPlayerSeasonId
+        }
+      }
+    }
+  }
+`
+
+export const GET_AFL_PLAYER_SEASON_STATS = gql`
+  query GetAFLPlayerSeasonStats($ids: [ID!]!) {
+    aflPlayerSeasonStats(ids: $ids) {
+      playerSeasonId
+      gamesPlayed
+      avgKicks
+      avgHandballs
+      avgMarks
+      avgHitouts
+      avgTackles
+      avgGoals
+      avgBehinds
+    }
+  }
+`
+
 export const GET_FFL_LATEST_ROUND = gql`
   query GetFFLLatestRound {
     fflLatestRound {

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -70,6 +70,15 @@ export const GET_FFL_ROSTER = gql`
   }
 `
 
+export const SEARCH_AFL_PLAYERS = gql`
+  query SearchAFLPlayers($query: String!) {
+    aflPlayerSearch(query: $query) {
+      id
+      name
+    }
+  }
+`
+
 export const GET_AFL_PLAYER_SEASON_STATS = gql`
   query GetAFLPlayerSeasonStats($ids: [ID!]!) {
     aflPlayerSeasonStats(ids: $ids) {

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -1,0 +1,105 @@
+import gql from 'graphql-tag'
+
+export const GET_FFL_LATEST_ROUND = gql`
+  query GetFFLLatestRound {
+    fflLatestRound {
+      id
+      name
+      season {
+        id
+        name
+        ladder {
+          id
+          club { id name }
+          played
+          won
+          lost
+          drawn
+          for
+          against
+          percentage
+        }
+        rounds {
+          id
+          name
+        }
+      }
+      matches {
+        id
+        venue
+        startTime
+        result
+        homeClubMatch {
+          id
+          club { id name }
+          score
+        }
+        awayClubMatch {
+          id
+          club { id name }
+          score
+        }
+      }
+    }
+  }
+`
+
+export const GET_FFL_SEASON = gql`
+  query GetFFLSeason($id: ID!) {
+    fflSeason(id: $id) {
+      id
+      name
+      ladder {
+        id
+        club { id name }
+        played
+        won
+        lost
+        drawn
+        for
+        against
+        percentage
+      }
+      rounds {
+        id
+        name
+        matches {
+          id
+          venue
+          startTime
+          result
+          homeClubMatch {
+            id
+            club { id name }
+            score
+            playerMatches {
+              id
+              playerSeasonId
+              player { id name }
+              position
+              status
+              backupPositions
+              interchangePosition
+              score
+            }
+          }
+          awayClubMatch {
+            id
+            club { id name }
+            score
+            playerMatches {
+              id
+              playerSeasonId
+              player { id name }
+              position
+              status
+              backupPositions
+              interchangePosition
+              score
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/frontend/web/src/features/ffl/components/LadderTable.vue
+++ b/frontend/web/src/features/ffl/components/LadderTable.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-border text-left text-text-muted">
+          <th class="py-2 pr-4 font-medium w-8">#</th>
+          <th class="py-2 pr-4 font-medium">Club</th>
+          <th class="py-2 px-2 font-medium text-right">P</th>
+          <th class="py-2 px-2 font-medium text-right">W</th>
+          <th class="py-2 px-2 font-medium text-right">L</th>
+          <th class="py-2 px-2 font-medium text-right">D</th>
+          <th class="py-2 px-2 font-medium text-right">F</th>
+          <th class="py-2 px-2 font-medium text-right">A</th>
+          <th class="py-2 px-2 font-medium text-right">%</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(entry, index) in ladder"
+          :key="entry.id"
+          class="border-b border-border-subtle hover:bg-surface-hover"
+        >
+          <td class="py-2 pr-4 tabular-nums text-text-faint">{{ index + 1 }}</td>
+          <td class="py-2 pr-4 font-medium">{{ entry.club.name }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ entry.played }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ entry.won }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ entry.lost }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ entry.drawn }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ entry.for }}</td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ entry.against }}</td>
+          <td class="py-2 px-2 text-right tabular-nums font-semibold">{{ entry.percentage.toFixed(1) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface LadderEntry {
+  id: string
+  club: { id: string; name: string }
+  played: number
+  won: number
+  lost: number
+  drawn: number
+  for: number
+  against: number
+  percentage: number
+}
+
+defineProps<{ ladder: LadderEntry[] }>()
+</script>

--- a/frontend/web/src/features/ffl/components/MatchSummary.vue
+++ b/frontend/web/src/features/ffl/components/MatchSummary.vue
@@ -1,0 +1,48 @@
+<template>
+  <router-link
+    :to="to"
+    class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-3 hover:border-border-strong transition-colors"
+  >
+    <div class="flex items-center gap-3 font-medium">
+      <span :class="{ 'font-bold': winner === 'home' }">
+        {{ match.homeClubMatch?.club.name ?? '—' }}
+      </span>
+      <span class="text-text-faint">v</span>
+      <span :class="{ 'font-bold': winner === 'away' }">
+        {{ match.awayClubMatch?.club.name ?? '—' }}
+      </span>
+    </div>
+    <span v-if="match.result" class="text-sm tabular-nums text-text-muted font-semibold">
+      {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
+    </span>
+  </router-link>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface ClubMatch {
+  id: string
+  club: { id: string; name: string }
+  score: number
+}
+
+interface Match {
+  id: string
+  result?: string | null
+  homeClubMatch?: ClubMatch | null
+  awayClubMatch?: ClubMatch | null
+}
+
+const props = defineProps<{
+  match: Match
+  to: { name: string; params: Record<string, string> }
+}>()
+
+const winner = computed(() => {
+  if (!props.match.result) return null
+  if (props.match.result === 'home_win') return 'home'
+  if (props.match.result === 'away_win') return 'away'
+  return null
+})
+</script>

--- a/frontend/web/src/features/ffl/components/RosterTable.vue
+++ b/frontend/web/src/features/ffl/components/RosterTable.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-border text-left text-text-muted">
+          <th class="py-2 pr-4 font-medium">Player</th>
+          <th class="py-2 px-2 font-medium">Position</th>
+          <th class="py-2 px-2 font-medium">Status</th>
+          <th class="py-2 px-2 font-medium text-right">Score</th>
+          <th class="py-2 px-2 font-medium w-8"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="pm in starters"
+          :key="pm.id"
+          class="border-b border-border-subtle hover:bg-surface-hover"
+        >
+          <td class="py-2 pr-4 font-medium">{{ pm.player.name }}</td>
+          <td class="py-2 px-2 capitalize text-text-muted">{{ pm.position ?? '—' }}</td>
+          <td class="py-2 px-2">
+            <StatusBadge :status="pm.status" />
+          </td>
+          <td class="py-2 px-2 text-right tabular-nums font-semibold">{{ pm.score }}</td>
+          <td class="py-2 px-2"></td>
+        </tr>
+        <tr v-if="bench.length > 0">
+          <td colspan="5" class="pt-4 pb-2 text-xs font-semibold uppercase tracking-wider text-text-faint">
+            Bench
+          </td>
+        </tr>
+        <tr
+          v-for="pm in bench"
+          :key="pm.id"
+          class="border-b border-border-subtle hover:bg-surface-hover"
+        >
+          <td class="py-2 pr-4 font-medium text-text-muted">{{ pm.player.name }}</td>
+          <td class="py-2 px-2 text-text-faint text-xs">
+            <span v-if="pm.backupPositions">backup: {{ pm.backupPositions }}</span>
+            <span v-else-if="pm.interchangePosition">interchange: {{ pm.interchangePosition }}</span>
+          </td>
+          <td class="py-2 px-2">
+            <StatusBadge :status="pm.status" />
+          </td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ pm.score }}</td>
+          <td class="py-2 px-2">
+            <span v-if="isSubActivated(pm)" class="text-xs text-green-500" title="Substitution activated">SUB</span>
+            <span v-else-if="isInterchangeActivated(pm)" class="text-xs text-blue-500" title="Interchange activated">INT</span>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr class="border-t border-border font-semibold">
+          <td class="py-2 pr-4">Total</td>
+          <td></td>
+          <td></td>
+          <td class="py-2 px-2 text-right tabular-nums">{{ total }}</td>
+          <td></td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import StatusBadge from './StatusBadge.vue'
+
+interface PlayerMatch {
+  id: string
+  player: { name: string }
+  position: string | null
+  status: string | null
+  backupPositions: string | null
+  interchangePosition: string | null
+  score: number
+}
+
+const props = defineProps<{ playerMatches: PlayerMatch[] }>()
+
+const isBench = (pm: PlayerMatch) => pm.backupPositions != null || pm.interchangePosition != null
+
+const starters = computed(() => props.playerMatches.filter(pm => !isBench(pm)))
+const bench = computed(() => props.playerMatches.filter(pm => isBench(pm)))
+
+const isSubActivated = (pm: PlayerMatch) => {
+  if (!pm.backupPositions || pm.status !== 'played') return false
+  // A bench sub activates when a starter at a matching position has DNP'd
+  const backupPos = pm.backupPositions.split(',').map(p => p.trim())
+  return starters.value.some(s => s.status === 'dnp' && backupPos.includes(s.position ?? ''))
+}
+
+const isInterchangeActivated = (pm: PlayerMatch) => {
+  if (!pm.interchangePosition || pm.status !== 'played') return false
+  // An interchange activates when the bench player outscored the starter at that position
+  const starter = starters.value.find(s => s.position === pm.interchangePosition && s.status === 'played')
+  return starter != null && pm.score > starter.score
+}
+
+const total = computed(() => props.playerMatches.reduce((sum, pm) => sum + pm.score, 0))
+</script>

--- a/frontend/web/src/features/ffl/components/RoundNav.vue
+++ b/frontend/web/src/features/ffl/components/RoundNav.vue
@@ -1,0 +1,28 @@
+<template>
+  <nav class="flex flex-wrap gap-2">
+    <router-link
+      v-for="round in rounds"
+      :key="round.id"
+      :to="{ name: 'ffl-round', params: { seasonId, roundId: round.id } }"
+      class="rounded px-3 py-1 text-sm transition-colors"
+      :class="round.id === currentRoundId
+        ? 'bg-active text-active-text'
+        : 'bg-control text-text-muted hover:bg-control-hover hover:text-text'"
+    >
+      {{ round.name }}
+    </router-link>
+  </nav>
+</template>
+
+<script setup lang="ts">
+interface Round {
+  id: string
+  name: string
+}
+
+defineProps<{
+  rounds: Round[]
+  currentRoundId: string
+  seasonId: string
+}>()
+</script>

--- a/frontend/web/src/features/ffl/components/StatusBadge.vue
+++ b/frontend/web/src/features/ffl/components/StatusBadge.vue
@@ -1,0 +1,32 @@
+<template>
+  <span
+    class="inline-block rounded px-1.5 py-0.5 text-xs font-medium"
+    :class="statusClass"
+  >
+    {{ label }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ status: string | null }>()
+
+const label = computed(() => {
+  switch (props.status) {
+    case 'played': return 'Played'
+    case 'dnp': return 'DNP'
+    case 'named': return 'Named'
+    default: return '—'
+  }
+})
+
+const statusClass = computed(() => {
+  switch (props.status) {
+    case 'played': return 'bg-green-500/15 text-green-500'
+    case 'dnp': return 'bg-red-500/15 text-red-500'
+    case 'named': return 'bg-yellow-500/15 text-yellow-500'
+    default: return 'bg-surface text-text-faint'
+  }
+})
+</script>

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -8,12 +8,20 @@
           <h1 class="text-2xl font-bold">{{ data.season.name }}</h1>
           <p class="text-text-muted">{{ data.round.name }}</p>
         </div>
-        <router-link
-          :to="{ name: 'ffl-team-builder', params: { seasonId: data.season.id, roundId: data.round.id } }"
-          class="rounded-lg bg-active px-4 py-2 text-sm font-medium text-active-text hover:opacity-90 transition-opacity"
-        >
-          Build Team
-        </router-link>
+        <div class="flex items-center gap-2">
+          <router-link
+            :to="{ name: 'ffl-roster', params: { seasonId: data.season.id } }"
+            class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
+          >
+            Roster
+          </router-link>
+          <router-link
+            :to="{ name: 'ffl-team-builder', params: { seasonId: data.season.id, roundId: data.round.id } }"
+            class="rounded-lg bg-active px-4 py-2 text-sm font-medium text-active-text hover:opacity-90 transition-opacity"
+          >
+            Build Team
+          </router-link>
+        </div>
       </div>
 
       <section class="mb-8">

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-6">Fantasy Football League</h1>
+    <p class="text-text-muted">Coming soon — ladder, matches, and round navigation.</p>
+  </div>
+</template>

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -3,8 +3,18 @@
     <div v-if="loading" class="text-text-faint">Loading…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
-      <h1 class="text-2xl font-bold mb-1">{{ data.season.name }}</h1>
-      <p class="text-text-muted mb-6">{{ data.round.name }}</p>
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-bold">{{ data.season.name }}</h1>
+          <p class="text-text-muted">{{ data.round.name }}</p>
+        </div>
+        <router-link
+          :to="{ name: 'ffl-team-builder', params: { seasonId: data.season.id, roundId: data.round.id } }"
+          class="rounded-lg bg-active px-4 py-2 text-sm font-medium text-active-text hover:opacity-90 transition-opacity"
+        >
+          Build Team
+        </router-link>
+      </div>
 
       <section class="mb-8">
         <h2 class="text-lg font-semibold text-text-heading mb-3">Ladder</h2>

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -1,6 +1,56 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Fantasy Football League</h1>
-    <p class="text-text-muted">Coming soon — ladder, matches, and round navigation.</p>
+    <div v-if="loading" class="text-text-faint">Loading…</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else-if="data">
+      <h1 class="text-2xl font-bold mb-1">{{ data.season.name }}</h1>
+      <p class="text-text-muted mb-6">{{ data.round.name }}</p>
+
+      <section class="mb-8">
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Ladder</h2>
+        <LadderTable :ladder="data.season.ladder" />
+      </section>
+
+      <section class="mb-8">
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Matches</h2>
+        <div class="space-y-2">
+          <MatchSummary
+            v-for="match in data.round.matches"
+            :key="match.id"
+            :match="match"
+            :to="{ name: 'ffl-match', params: { seasonId: data.season.id, matchId: match.id } }"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Rounds</h2>
+        <RoundNav
+          :rounds="data.season.rounds"
+          :current-round-id="data.round.id"
+          :season-id="data.season.id"
+        />
+      </section>
+    </template>
   </div>
 </template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_FFL_LATEST_ROUND } from '../api/queries'
+import LadderTable from '../components/LadderTable.vue'
+import MatchSummary from '../components/MatchSummary.vue'
+import RoundNav from '../components/RoundNav.vue'
+
+const { result, loading, error } = useQuery(GET_FFL_LATEST_ROUND)
+
+const data = computed(() => {
+  const round = result.value?.fflLatestRound
+  if (!round) return null
+  return {
+    round: { id: round.id, name: round.name, matches: round.matches },
+    season: round.season,
+  }
+})
+</script>

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-6">FFL Match</h1>
+    <p class="text-text-muted">Coming soon.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ seasonId: string; matchId: string }>()
+</script>

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -1,10 +1,58 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">FFL Match</h1>
-    <p class="text-text-muted">Coming soon.</p>
+    <div v-if="loading" class="text-text-faint">Loading match…</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else-if="match">
+      <div class="mb-8">
+        <h1 class="text-2xl font-bold">
+          {{ match.homeClubMatch?.club.name ?? '—' }}
+          <span class="text-text-faint mx-2">v</span>
+          {{ match.awayClubMatch?.club.name ?? '—' }}
+        </h1>
+        <p v-if="match.venue" class="text-sm text-text-muted mt-1">{{ match.venue }}</p>
+        <p v-if="match.result" class="text-lg font-semibold mt-2">
+          {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div v-for="side in sides" :key="side.label">
+          <h2 class="text-lg font-semibold mb-1">{{ side.label }}</h2>
+          <p class="text-sm text-text-muted mb-3">
+            Fantasy score: <span class="font-semibold text-text">{{ side.clubMatch?.score ?? 0 }}</span>
+          </p>
+          <RosterTable v-if="side.clubMatch" :player-matches="side.clubMatch.playerMatches" />
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps<{ seasonId: string; matchId: string }>()
+import { computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_FFL_SEASON } from '../api/queries'
+import RosterTable from '../components/RosterTable.vue'
+
+const props = defineProps<{ seasonId: string; matchId: string }>()
+
+const { result, loading, error } = useQuery(GET_FFL_SEASON, () => ({ id: props.seasonId }))
+
+const match = computed(() => {
+  const season = result.value?.fflSeason
+  if (!season) return null
+  for (const round of season.rounds) {
+    const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
+    if (found) return found
+  }
+  return null
+})
+
+const sides = computed(() => {
+  if (!match.value) return []
+  return [
+    { label: match.value.homeClubMatch?.club.name ?? 'Home', clubMatch: match.value.homeClubMatch },
+    { label: match.value.awayClubMatch?.club.name ?? 'Away', clubMatch: match.value.awayClubMatch },
+  ]
+})
 </script>

--- a/frontend/web/src/features/ffl/views/RosterView.vue
+++ b/frontend/web/src/features/ffl/views/RosterView.vue
@@ -1,0 +1,179 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-1">Roster</h1>
+    <p class="text-text-muted mb-6">Season roster and AFL stat averages</p>
+
+    <div v-if="fflLoading" class="text-text-faint">Loading…</div>
+    <div v-else-if="fflError" class="text-red-400">{{ fflError.message }}</div>
+    <template v-else-if="season">
+      <!-- Club selector -->
+      <div class="mb-6">
+        <label class="text-sm font-medium text-text-muted mr-2">Club:</label>
+        <select
+          v-model="selectedClubSeasonId"
+          class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text focus:border-active focus:outline-none"
+        >
+          <option v-for="cs in season.ladder" :key="cs.id" :value="cs.id">
+            {{ cs.club.name }}
+          </option>
+        </select>
+      </div>
+
+      <template v-if="rosterRows.length > 0">
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border text-left text-text-muted">
+                <th class="py-2 pr-4 font-medium">Player</th>
+                <th class="py-2 px-2 font-medium text-right">GP</th>
+                <th class="py-2 px-2 font-medium text-right">G</th>
+                <th class="py-2 px-2 font-medium text-right">K</th>
+                <th class="py-2 px-2 font-medium text-right">HB</th>
+                <th class="py-2 px-2 font-medium text-right">M</th>
+                <th class="py-2 px-2 font-medium text-right">T</th>
+                <th class="py-2 px-2 font-medium text-right">HO</th>
+                <th class="py-2 px-2 font-medium text-right">B</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in rosterRows"
+                :key="row.playerSeasonId"
+                class="border-b border-border-subtle hover:bg-surface-hover"
+              >
+                <td class="py-2 pr-4 font-medium">{{ row.name }}</td>
+                <td class="py-2 px-2 text-right tabular-nums">{{ row.gamesPlayed ?? '—' }}</td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgGoals != null ? '' : 'text-text-faint'">
+                  {{ row.avgGoals ?? '—' }}
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgKicks != null ? '' : 'text-text-faint'">
+                  {{ row.avgKicks ?? '—' }}
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgHandballs != null ? '' : 'text-text-faint'">
+                  {{ row.avgHandballs ?? '—' }}
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgMarks != null ? '' : 'text-text-faint'">
+                  {{ row.avgMarks ?? '—' }}
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgTackles != null ? '' : 'text-text-faint'">
+                  {{ row.avgTackles ?? '—' }}
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgHitouts != null ? '' : 'text-text-faint'">
+                  {{ row.avgHitouts ?? '—' }}
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums" :class="row.avgBehinds != null ? '' : 'text-text-faint'">
+                  {{ row.avgBehinds ?? '—' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </template>
+      <p v-else class="text-text-faint">No players on roster.</p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_FFL_ROSTER, GET_AFL_PLAYER_SEASON_STATS } from '../api/queries'
+
+const props = defineProps<{ seasonId: string }>()
+
+// Query 1: FFL roster
+const { result: fflResult, loading: fflLoading, error: fflError } = useQuery(GET_FFL_ROSTER, () => ({ seasonId: props.seasonId }))
+
+const season = computed(() => fflResult.value?.fflSeason ?? null)
+
+const selectedClubSeasonId = ref<string>('')
+
+watch(season, (s) => {
+  if (s && s.ladder.length > 0 && !selectedClubSeasonId.value) {
+    selectedClubSeasonId.value = s.ladder[0].id
+  }
+})
+
+const selectedClubSeason = computed(() =>
+  season.value?.ladder.find((cs: { id: string }) => cs.id === selectedClubSeasonId.value) ?? null
+)
+
+// Collect AFL player season IDs from the selected club's roster
+const aflPlayerSeasonIds = computed<string[]>(() => {
+  if (!selectedClubSeason.value) return []
+  return selectedClubSeason.value.roster
+    .map((r: { aflPlayerSeasonId?: string }) => r.aflPlayerSeasonId)
+    .filter((id: string | undefined): id is string => id != null)
+})
+
+// Query 2: AFL stats (only when we have IDs)
+const { result: aflResult } = useQuery(
+  GET_AFL_PLAYER_SEASON_STATS,
+  () => ({ ids: aflPlayerSeasonIds.value }),
+  () => ({ enabled: aflPlayerSeasonIds.value.length > 0 })
+)
+
+// Build a map of AFL player season ID → stats
+const statsMap = computed(() => {
+  const map = new Map<string, {
+    gamesPlayed: number
+    avgGoals: number
+    avgKicks: number
+    avgHandballs: number
+    avgMarks: number
+    avgTackles: number
+    avgHitouts: number
+    avgBehinds: number
+  }>()
+  const stats = aflResult.value?.aflPlayerSeasonStats
+  if (!stats) return map
+  for (const s of stats) {
+    map.set(s.playerSeasonId, s)
+  }
+  return map
+})
+
+interface RosterRow {
+  playerSeasonId: string
+  name: string
+  gamesPlayed: number | null
+  avgGoals: string | null
+  avgKicks: string | null
+  avgHandballs: string | null
+  avgMarks: string | null
+  avgTackles: string | null
+  avgHitouts: string | null
+  avgBehinds: string | null
+}
+
+const rosterRows = computed<RosterRow[]>(() => {
+  if (!selectedClubSeason.value) return []
+
+  const rows: RosterRow[] = selectedClubSeason.value.roster.map(
+    (r: { playerSeasonId: string; player: { name: string }; aflPlayerSeasonId?: string }) => {
+      const stats = r.aflPlayerSeasonId ? statsMap.value.get(r.aflPlayerSeasonId) : undefined
+      return {
+        playerSeasonId: r.playerSeasonId,
+        name: r.player.name,
+        gamesPlayed: stats?.gamesPlayed ?? null,
+        avgGoals: stats ? stats.avgGoals.toFixed(1) : null,
+        avgKicks: stats ? stats.avgKicks.toFixed(1) : null,
+        avgHandballs: stats ? stats.avgHandballs.toFixed(1) : null,
+        avgMarks: stats ? stats.avgMarks.toFixed(1) : null,
+        avgTackles: stats ? stats.avgTackles.toFixed(1) : null,
+        avgHitouts: stats ? stats.avgHitouts.toFixed(1) : null,
+        avgBehinds: stats ? stats.avgBehinds.toFixed(1) : null,
+      }
+    }
+  )
+
+  // Sort by last name
+  rows.sort((a, b) => {
+    const lastA = a.name.split(' ').pop()?.toLowerCase() ?? ''
+    const lastB = b.name.split(' ').pop()?.toLowerCase() ?? ''
+    return lastA.localeCompare(lastB)
+  })
+
+  return rows
+})
+</script>

--- a/frontend/web/src/features/ffl/views/RosterView.vue
+++ b/frontend/web/src/features/ffl/views/RosterView.vue
@@ -6,17 +6,28 @@
     <div v-if="fflLoading" class="text-text-faint">Loading…</div>
     <div v-else-if="fflError" class="text-red-400">{{ fflError.message }}</div>
     <template v-else-if="season">
-      <!-- Club selector -->
-      <div class="mb-6">
-        <label class="text-sm font-medium text-text-muted mr-2">Club:</label>
-        <select
-          v-model="selectedClubSeasonId"
-          class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text focus:border-active focus:outline-none"
+      <!-- Club selector + Manage toggle -->
+      <div class="mb-6 flex items-center gap-4">
+        <div>
+          <label class="text-sm font-medium text-text-muted mr-2">Club:</label>
+          <select
+            v-model="selectedClubSeasonId"
+            class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text focus:border-active focus:outline-none"
+          >
+            <option v-for="cs in season.ladder" :key="cs.id" :value="cs.id">
+              {{ cs.club.name }}
+            </option>
+          </select>
+        </div>
+        <button
+          @click="managing = !managing"
+          class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
+          :class="managing
+            ? 'border-active bg-active text-active-text'
+            : 'border-border bg-surface text-text hover:bg-surface-hover'"
         >
-          <option v-for="cs in season.ladder" :key="cs.id" :value="cs.id">
-            {{ cs.club.name }}
-          </option>
-        </select>
+          {{ managing ? 'Done' : 'Manage' }}
+        </button>
       </div>
 
       <template v-if="rosterRows.length > 0">
@@ -33,6 +44,7 @@
                 <th class="py-2 px-2 font-medium text-right">T</th>
                 <th class="py-2 px-2 font-medium text-right">HO</th>
                 <th class="py-2 px-2 font-medium text-right">B</th>
+                <th v-if="managing" class="py-2 px-2 font-medium text-right"></th>
               </tr>
             </thead>
             <tbody>
@@ -64,25 +76,68 @@
                 <td class="py-2 px-2 text-right tabular-nums" :class="row.avgBehinds != null ? '' : 'text-text-faint'">
                   {{ row.avgBehinds ?? '—' }}
                 </td>
+                <td v-if="managing" class="py-2 px-2 text-right">
+                  <button
+                    @click="removePlayer(row.playerSeasonId)"
+                    class="text-red-400 hover:text-red-300 text-xs font-medium"
+                    :disabled="removingId === row.playerSeasonId"
+                  >
+                    {{ removingId === row.playerSeasonId ? 'Removing…' : 'Remove' }}
+                  </button>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </template>
       <p v-else class="text-text-faint">No players on roster.</p>
+
+      <!-- Add player search (manage mode only) -->
+      <div v-if="managing" class="mt-6">
+        <h2 class="text-lg font-semibold mb-2">Add Player</h2>
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search AFL players by name…"
+          class="w-full max-w-md rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-text-faint focus:border-active focus:outline-none"
+        />
+        <div v-if="searchLoading" class="mt-2 text-text-faint text-sm">Searching…</div>
+        <div v-else-if="searchResults.length > 0" class="mt-2 max-w-md">
+          <div
+            v-for="player in searchResults"
+            :key="player.id"
+            class="flex items-center justify-between border-b border-border-subtle py-2"
+          >
+            <span class="text-sm">{{ player.name }}</span>
+            <button
+              @click="addPlayer(player)"
+              class="rounded border border-active px-2 py-0.5 text-xs font-medium text-active hover:bg-active hover:text-active-text transition-colors"
+              :disabled="addingId === player.id"
+            >
+              {{ addingId === player.id ? 'Adding…' : 'Add' }}
+            </button>
+          </div>
+        </div>
+        <div v-else-if="searchQuery.length >= 2 && !searchLoading" class="mt-2 text-text-faint text-sm">
+          No players found.
+        </div>
+      </div>
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useQuery } from '@vue/apollo-composable'
-import { GET_FFL_ROSTER, GET_AFL_PLAYER_SEASON_STATS } from '../api/queries'
+import { useQuery, useMutation } from '@vue/apollo-composable'
+import { GET_FFL_ROSTER, GET_AFL_PLAYER_SEASON_STATS, SEARCH_AFL_PLAYERS } from '../api/queries'
+import { REMOVE_FFL_PLAYER_FROM_SEASON, ADD_FFL_ROSTER_PLAYER } from '../api/mutations'
 
 const props = defineProps<{ seasonId: string }>()
 
+const managing = ref(false)
+
 // Query 1: FFL roster
-const { result: fflResult, loading: fflLoading, error: fflError } = useQuery(GET_FFL_ROSTER, () => ({ seasonId: props.seasonId }))
+const { result: fflResult, loading: fflLoading, error: fflError, refetch: refetchRoster } = useQuery(GET_FFL_ROSTER, () => ({ seasonId: props.seasonId }))
 
 const season = computed(() => fflResult.value?.fflSeason ?? null)
 
@@ -136,6 +191,7 @@ const statsMap = computed(() => {
 interface RosterRow {
   playerSeasonId: string
   name: string
+  aflPlayerId: string | null
   gamesPlayed: number | null
   avgGoals: string | null
   avgKicks: string | null
@@ -150,11 +206,12 @@ const rosterRows = computed<RosterRow[]>(() => {
   if (!selectedClubSeason.value) return []
 
   const rows: RosterRow[] = selectedClubSeason.value.roster.map(
-    (r: { playerSeasonId: string; player: { name: string }; aflPlayerSeasonId?: string }) => {
+    (r: { playerSeasonId: string; player: { name: string; aflPlayerId?: string }; aflPlayerSeasonId?: string }) => {
       const stats = r.aflPlayerSeasonId ? statsMap.value.get(r.aflPlayerSeasonId) : undefined
       return {
         playerSeasonId: r.playerSeasonId,
         name: r.player.name,
+        aflPlayerId: r.player.aflPlayerId ?? null,
         gamesPlayed: stats?.gamesPlayed ?? null,
         avgGoals: stats ? stats.avgGoals.toFixed(1) : null,
         avgKicks: stats ? stats.avgKicks.toFixed(1) : null,
@@ -175,5 +232,85 @@ const rosterRows = computed<RosterRow[]>(() => {
   })
 
   return rows
+})
+
+// --- Manage mode: search + add/remove ---
+
+const searchQuery = ref('')
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+const debouncedQuery = ref('')
+
+watch(searchQuery, (val) => {
+  if (searchTimeout) clearTimeout(searchTimeout)
+  if (val.length < 2) {
+    debouncedQuery.value = ''
+    return
+  }
+  searchTimeout = setTimeout(() => {
+    debouncedQuery.value = val
+  }, 300)
+})
+
+const { result: searchResult, loading: searchLoading } = useQuery(
+  SEARCH_AFL_PLAYERS,
+  () => ({ query: debouncedQuery.value }),
+  () => ({ enabled: debouncedQuery.value.length >= 2 })
+)
+
+// Filter out players already on the roster (by AFL player ID)
+const rosterAflPlayerIds = computed(() => {
+  const ids = new Set<string>()
+  for (const row of rosterRows.value) {
+    if (row.aflPlayerId) ids.add(row.aflPlayerId)
+  }
+  return ids
+})
+
+const searchResults = computed(() => {
+  const players = searchResult.value?.aflPlayerSearch ?? []
+  return players.filter((p: { id: string }) => !rosterAflPlayerIds.value.has(p.id))
+})
+
+// Remove player
+const removingId = ref<string | null>(null)
+const { mutate: removePlayerMutation } = useMutation(REMOVE_FFL_PLAYER_FROM_SEASON)
+
+async function removePlayer(playerSeasonId: string) {
+  removingId.value = playerSeasonId
+  try {
+    await removePlayerMutation({ id: playerSeasonId })
+    await refetchRoster()
+  } finally {
+    removingId.value = null
+  }
+}
+
+// Add player
+const addingId = ref<string | null>(null)
+const { mutate: addPlayerMutation } = useMutation(ADD_FFL_ROSTER_PLAYER)
+
+async function addPlayer(player: { id: string; name: string }) {
+  if (!selectedClubSeasonId.value) return
+  addingId.value = player.id
+  try {
+    await addPlayerMutation({
+      input: {
+        aflPlayerId: player.id,
+        aflPlayerName: player.name,
+        clubSeasonId: selectedClubSeasonId.value,
+      },
+    })
+    await refetchRoster()
+  } finally {
+    addingId.value = null
+  }
+}
+
+// Reset search when exiting manage mode
+watch(managing, (val) => {
+  if (!val) {
+    searchQuery.value = ''
+    debouncedQuery.value = ''
+  }
 })
 </script>

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-6">FFL Round</h1>
+    <p class="text-text-muted">Coming soon.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ seasonId: string; roundId: string }>()
+</script>

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -3,8 +3,18 @@
     <div v-if="loading" class="text-text-faint">Loading…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
-      <h1 class="text-2xl font-bold mb-1">{{ data.round.name }}</h1>
-      <p class="text-text-muted mb-6">{{ data.season.name }}</p>
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-bold">{{ data.round.name }}</h1>
+          <p class="text-text-muted">{{ data.season.name }}</p>
+        </div>
+        <router-link
+          :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: props.roundId } }"
+          class="rounded-lg bg-active px-4 py-2 text-sm font-medium text-active-text hover:opacity-90 transition-opacity"
+        >
+          Build Team
+        </router-link>
+      </div>
 
       <section class="mb-8">
         <h2 class="text-lg font-semibold text-text-heading mb-3">Matches</h2>

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -1,10 +1,116 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">FFL Round</h1>
-    <p class="text-text-muted">Coming soon.</p>
+    <div v-if="loading" class="text-text-faint">Loading…</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else-if="data">
+      <h1 class="text-2xl font-bold mb-1">{{ data.round.name }}</h1>
+      <p class="text-text-muted mb-6">{{ data.season.name }}</p>
+
+      <section class="mb-8">
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Matches</h2>
+        <div class="space-y-2">
+          <MatchSummary
+            v-for="match in data.round.matches"
+            :key="match.id"
+            :match="match"
+            :to="{ name: 'ffl-match', params: { seasonId: props.seasonId, matchId: match.id } }"
+          />
+        </div>
+      </section>
+
+      <section v-if="topScorers.length > 0" class="mb-8">
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Top Fantasy Scorers</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border text-left text-text-muted">
+                <th class="py-2 pr-4 font-medium w-8">#</th>
+                <th class="py-2 pr-4 font-medium">Player</th>
+                <th class="py-2 px-2 font-medium">Club</th>
+                <th class="py-2 px-2 font-medium">Position</th>
+                <th class="py-2 px-2 font-medium text-right">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(player, index) in topScorers"
+                :key="index"
+                class="border-b border-border-subtle hover:bg-surface-hover"
+              >
+                <td class="py-2 pr-4 tabular-nums text-text-faint">{{ index + 1 }}</td>
+                <td class="py-2 pr-4 font-medium">{{ player.name }}</td>
+                <td class="py-2 px-2 text-text-muted">{{ player.club }}</td>
+                <td class="py-2 px-2 text-text-muted capitalize">{{ player.position ?? '—' }}</td>
+                <td class="py-2 px-2 text-right tabular-nums font-semibold">{{ player.score }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Rounds</h2>
+        <RoundNav
+          :rounds="data.season.rounds"
+          :current-round-id="data.round.id"
+          :season-id="props.seasonId"
+        />
+      </section>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps<{ seasonId: string; roundId: string }>()
+import { computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_FFL_SEASON } from '../api/queries'
+import MatchSummary from '../components/MatchSummary.vue'
+import RoundNav from '../components/RoundNav.vue'
+
+const props = defineProps<{ seasonId: string; roundId: string }>()
+
+const { result, loading, error } = useQuery(GET_FFL_SEASON, () => ({ id: props.seasonId }))
+
+const data = computed(() => {
+  const season = result.value?.fflSeason
+  if (!season) return null
+  const round = season.rounds.find((r: { id: string }) => r.id === props.roundId)
+  if (!round) return null
+  return { season, round }
+})
+
+interface PlayerMatch {
+  player: { name: string }
+  position: string | null
+  status: string | null
+  score: number
+}
+
+interface ClubMatch {
+  club: { name: string }
+  playerMatches: PlayerMatch[]
+}
+
+interface Match {
+  homeClubMatch?: ClubMatch | null
+  awayClubMatch?: ClubMatch | null
+}
+
+const topScorers = computed(() => {
+  if (!data.value) return []
+
+  const all: { name: string; club: string; position: string | null; score: number }[] = []
+  for (const match of data.value.round.matches as Match[]) {
+    for (const side of [match.homeClubMatch, match.awayClubMatch]) {
+      if (!side) continue
+      for (const pm of side.playerMatches) {
+        if (pm.status === 'played') {
+          all.push({ name: pm.player.name, club: side.club.name, position: pm.position, score: pm.score })
+        }
+      }
+    }
+  }
+
+  return all.sort((a, b) => b.score - a.score).slice(0, 10)
+})
 </script>

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -3,6 +3,28 @@
     <h1 class="text-2xl font-bold mb-1">Team Builder</h1>
     <p class="text-text-muted mb-6">Build your lineup for the round</p>
 
+    <!-- Score projection -->
+    <div class="mb-8 rounded-lg border border-border bg-surface-raised px-4 py-3">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="text-sm font-semibold text-text-heading">Projected Score</h2>
+        <span class="text-lg font-bold tabular-nums">{{ totalProjectedScore }}</span>
+      </div>
+      <div class="flex gap-3 flex-wrap">
+        <div
+          v-for="pos in positions"
+          :key="pos.key"
+          class="flex items-center gap-1.5 text-xs"
+        >
+          <span class="text-text-muted">{{ pos.short }}</span>
+          <span class="tabular-nums font-medium">{{ positionProjectedScore(pos.key) }}</span>
+        </div>
+        <div class="flex items-center gap-1.5 text-xs">
+          <span class="text-text-muted">B</span>
+          <span class="tabular-nums font-medium">{{ benchProjectedScore }}</span>
+        </div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <!-- Lineup (left 2 cols) -->
       <div class="lg:col-span-2">
@@ -23,9 +45,19 @@
                 <span class="font-medium">{{ slot.player.name }}</span>
               </div>
               <span v-else class="text-text-faint text-sm">Empty slot</span>
-              <div class="flex items-center gap-2">
+              <div v-if="slot.player" class="flex items-center gap-2">
                 <button
-                  v-if="slot.player"
+                  v-for="target in positions.filter(p => p.key !== pos.key)"
+                  :key="target.key"
+                  class="rounded px-1.5 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                  :disabled="isPositionFull(target.key)"
+                  :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(target.key) }"
+                  :title="`Move to ${target.label}`"
+                  @click="moveToPosition(pos.key, index, target.key)"
+                >
+                  {{ target.short }}
+                </button>
+                <button
                   class="text-xs text-red-400 hover:text-red-300 transition-colors"
                   @click="removeFromLineup(pos.key, index)"
                 >
@@ -72,7 +104,12 @@
             :key="player.id"
             class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2"
           >
-            <span class="font-medium text-sm">{{ player.name }}</span>
+            <div>
+              <span class="font-medium text-sm">{{ player.name }}</span>
+              <div class="flex gap-2 text-xs text-text-faint mt-0.5">
+                <span v-for="pos in positions" :key="pos.key">{{ pos.short }}:{{ player.projectedScores[pos.key] }}</span>
+              </div>
+            </div>
             <div class="flex items-center gap-1">
               <button
                 v-for="pos in positions"
@@ -106,15 +143,6 @@ import { ref, computed } from 'vue'
 
 defineProps<{ seasonId: string; roundId: string }>()
 
-interface Player {
-  id: string
-  name: string
-}
-
-interface Slot {
-  player: Player | null
-}
-
 const positions = [
   { key: 'goals', label: 'Goals', short: 'G', count: 3 },
   { key: 'kicks', label: 'Kicks', short: 'K', count: 4 },
@@ -127,19 +155,30 @@ const positions = [
 
 type PositionKey = typeof positions[number]['key']
 
-// Stub roster — will be replaced with real data from API
-const roster = ref<Player[]>([
-  { id: '1', name: 'Player 1' },
-  { id: '2', name: 'Player 2' },
-  { id: '3', name: 'Player 3' },
-  { id: '4', name: 'Player 4' },
-  { id: '5', name: 'Player 5' },
-  { id: '6', name: 'Player 6' },
-  { id: '7', name: 'Player 7' },
-  { id: '8', name: 'Player 8' },
-  { id: '9', name: 'Player 9' },
-  { id: '10', name: 'Player 10' },
-])
+interface Player {
+  id: string
+  name: string
+  projectedScores: Record<PositionKey, number>
+}
+
+interface Slot {
+  player: Player | null
+}
+
+// Stub roster with mock projected scores — will be replaced with real AFL stats
+function mockScores(): Record<PositionKey, number> {
+  return Object.fromEntries(
+    positions.map(p => [p.key, Math.floor(Math.random() * 80) + 20])
+  ) as Record<PositionKey, number>
+}
+
+const roster = ref<Player[]>(
+  Array.from({ length: 10 }, (_, i) => ({
+    id: String(i + 1),
+    name: `Player ${i + 1}`,
+    projectedScores: mockScores(),
+  }))
+)
 
 const createSlots = (count: number): Slot[] => Array.from({ length: count }, () => ({ player: null }))
 
@@ -179,6 +218,31 @@ const benchCount = computed(() => benchSlots.value.filter(s => s.player).length)
 const isPositionFull = (key: PositionKey) =>
   lineupSlots.value[key].every(s => s.player !== null)
 
+// Score projections
+function positionProjectedScore(key: PositionKey): number {
+  return lineupSlots.value[key]
+    .filter(s => s.player)
+    .reduce((sum, s) => sum + s.player!.projectedScores[key], 0)
+}
+
+const benchProjectedScore = computed(() =>
+  benchSlots.value
+    .filter(s => s.player)
+    .reduce((sum, s) => {
+      const scores = Object.values(s.player!.projectedScores)
+      return sum + Math.max(...scores)
+    }, 0)
+)
+
+const totalProjectedScore = computed(() => {
+  let total = 0
+  for (const pos of positions) {
+    total += positionProjectedScore(pos.key)
+  }
+  return total + benchProjectedScore.value
+})
+
+// Lineup management
 function addToLineup(key: PositionKey, player: Player) {
   const slot = lineupSlots.value[key].find(s => !s.player)
   if (slot) slot.player = player
@@ -186,6 +250,15 @@ function addToLineup(key: PositionKey, player: Player) {
 
 function removeFromLineup(key: PositionKey, index: number) {
   lineupSlots.value[key][index].player = null
+}
+
+function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: PositionKey) {
+  const player = lineupSlots.value[fromKey][fromIndex].player
+  if (!player) return
+  const toSlot = lineupSlots.value[toKey].find(s => !s.player)
+  if (!toSlot) return
+  lineupSlots.value[fromKey][fromIndex].player = null
+  toSlot.player = player
 }
 
 function addToBench(player: Player) {

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -1,0 +1,199 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-1">Team Builder</h1>
+    <p class="text-text-muted mb-6">Build your lineup for the round</p>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <!-- Lineup (left 2 cols) -->
+      <div class="lg:col-span-2">
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Lineup ({{ starterCount }}/22)</h2>
+
+        <div v-for="pos in positions" :key="pos.key" class="mb-6">
+          <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">{{ pos.label }}</h3>
+          <div class="space-y-1">
+            <div
+              v-for="(slot, index) in lineupSlots[pos.key]"
+              :key="index"
+              class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
+              :class="slot.player
+                ? 'border-border bg-surface-raised'
+                : 'border-dashed border-border-subtle bg-surface'"
+            >
+              <div v-if="slot.player" class="flex items-center gap-3">
+                <span class="font-medium">{{ slot.player.name }}</span>
+              </div>
+              <span v-else class="text-text-faint text-sm">Empty slot</span>
+              <div class="flex items-center gap-2">
+                <button
+                  v-if="slot.player"
+                  class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                  @click="removeFromLineup(pos.key, index)"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mb-6">
+          <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">Bench ({{ benchCount }}/8)</h3>
+          <div class="space-y-1">
+            <div
+              v-for="(slot, index) in benchSlots"
+              :key="index"
+              class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
+              :class="slot.player
+                ? 'border-border bg-surface-raised'
+                : 'border-dashed border-border-subtle bg-surface'"
+            >
+              <div v-if="slot.player" class="flex items-center gap-3">
+                <span class="font-medium text-text-muted">{{ slot.player.name }}</span>
+              </div>
+              <span v-else class="text-text-faint text-sm">Empty bench slot</span>
+              <button
+                v-if="slot.player"
+                class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                @click="removeFromBench(index)"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Roster panel (right col) -->
+      <div>
+        <h2 class="text-lg font-semibold text-text-heading mb-3">Roster ({{ availablePlayers.length }})</h2>
+        <div class="space-y-1">
+          <div
+            v-for="player in availablePlayers"
+            :key="player.id"
+            class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2"
+          >
+            <span class="font-medium text-sm">{{ player.name }}</span>
+            <div class="flex items-center gap-1">
+              <button
+                v-for="pos in positions"
+                :key="pos.key"
+                class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
+                :disabled="isPositionFull(pos.key)"
+                :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(pos.key) }"
+                @click="addToLineup(pos.key, player)"
+              >
+                {{ pos.short }}
+              </button>
+              <button
+                class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                :disabled="benchCount >= 8"
+                :class="{ 'opacity-30 cursor-not-allowed': benchCount >= 8 }"
+                @click="addToBench(player)"
+              >
+                B
+              </button>
+            </div>
+          </div>
+          <p v-if="availablePlayers.length === 0" class="text-sm text-text-faint">All players assigned</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+defineProps<{ seasonId: string; roundId: string }>()
+
+interface Player {
+  id: string
+  name: string
+}
+
+interface Slot {
+  player: Player | null
+}
+
+const positions = [
+  { key: 'goals', label: 'Goals', short: 'G', count: 3 },
+  { key: 'kicks', label: 'Kicks', short: 'K', count: 4 },
+  { key: 'handballs', label: 'Handballs', short: 'HB', count: 4 },
+  { key: 'marks', label: 'Marks', short: 'M', count: 3 },
+  { key: 'tackles', label: 'Tackles', short: 'T', count: 3 },
+  { key: 'hitouts', label: 'Hitouts', short: 'HO', count: 2 },
+  { key: 'star', label: 'Star', short: 'S', count: 3 },
+] as const
+
+type PositionKey = typeof positions[number]['key']
+
+// Stub roster — will be replaced with real data from API
+const roster = ref<Player[]>([
+  { id: '1', name: 'Player 1' },
+  { id: '2', name: 'Player 2' },
+  { id: '3', name: 'Player 3' },
+  { id: '4', name: 'Player 4' },
+  { id: '5', name: 'Player 5' },
+  { id: '6', name: 'Player 6' },
+  { id: '7', name: 'Player 7' },
+  { id: '8', name: 'Player 8' },
+  { id: '9', name: 'Player 9' },
+  { id: '10', name: 'Player 10' },
+])
+
+const createSlots = (count: number): Slot[] => Array.from({ length: count }, () => ({ player: null }))
+
+const lineupSlots = ref<Record<PositionKey, Slot[]>>(
+  Object.fromEntries(positions.map(p => [p.key, createSlots(p.count)])) as Record<PositionKey, Slot[]>
+)
+
+const benchSlots = ref<Slot[]>(createSlots(8))
+
+const assignedPlayerIds = computed(() => {
+  const ids = new Set<string>()
+  for (const pos of positions) {
+    for (const slot of lineupSlots.value[pos.key]) {
+      if (slot.player) ids.add(slot.player.id)
+    }
+  }
+  for (const slot of benchSlots.value) {
+    if (slot.player) ids.add(slot.player.id)
+  }
+  return ids
+})
+
+const availablePlayers = computed(() =>
+  roster.value.filter(p => !assignedPlayerIds.value.has(p.id))
+)
+
+const starterCount = computed(() => {
+  let count = 0
+  for (const pos of positions) {
+    count += lineupSlots.value[pos.key].filter(s => s.player).length
+  }
+  return count
+})
+
+const benchCount = computed(() => benchSlots.value.filter(s => s.player).length)
+
+const isPositionFull = (key: PositionKey) =>
+  lineupSlots.value[key].every(s => s.player !== null)
+
+function addToLineup(key: PositionKey, player: Player) {
+  const slot = lineupSlots.value[key].find(s => !s.player)
+  if (slot) slot.player = player
+}
+
+function removeFromLineup(key: PositionKey, index: number) {
+  lineupSlots.value[key][index].player = null
+}
+
+function addToBench(player: Player) {
+  const slot = benchSlots.value.find(s => !s.player)
+  if (slot) slot.player = player
+}
+
+function removeFromBench(index: number) {
+  benchSlots.value[index].player = null
+}
+</script>

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -3,145 +3,157 @@
     <h1 class="text-2xl font-bold mb-1">Team Builder</h1>
     <p class="text-text-muted mb-6">Build your lineup for the round</p>
 
-    <!-- Score projection -->
-    <div class="mb-8 rounded-lg border border-border bg-surface-raised px-4 py-3">
-      <div class="flex items-center justify-between mb-2">
-        <h2 class="text-sm font-semibold text-text-heading">Projected Score</h2>
-        <span class="text-lg font-bold tabular-nums">{{ totalProjectedScore }}</span>
-      </div>
-      <div class="flex gap-3 flex-wrap">
-        <div
-          v-for="pos in positions"
-          :key="pos.key"
-          class="flex items-center gap-1.5 text-xs"
+    <div v-if="loading" class="text-text-faint">Loading…</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else-if="season">
+      <!-- Club selector -->
+      <div class="mb-6">
+        <label class="text-sm font-medium text-text-muted mr-2">My club:</label>
+        <select
+          v-model="selectedClubSeasonId"
+          class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text focus:border-active focus:outline-none"
         >
-          <span class="text-text-muted">{{ pos.short }}</span>
-          <span class="tabular-nums font-medium">{{ positionProjectedScore(pos.key) }}</span>
-        </div>
-        <div class="flex items-center gap-1.5 text-xs">
-          <span class="text-text-muted">B</span>
-          <span class="tabular-nums font-medium">{{ benchProjectedScore }}</span>
-        </div>
+          <option v-for="cs in season.ladder" :key="cs.id" :value="cs.id">
+            {{ cs.club.name }}
+          </option>
+        </select>
       </div>
-    </div>
 
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-      <!-- Lineup (left 2 cols) -->
-      <div class="lg:col-span-2">
-        <h2 class="text-lg font-semibold text-text-heading mb-3">Lineup ({{ starterCount }}/22)</h2>
+      <template v-if="selectedClubSeason && clubMatch">
+        <!-- Score projection -->
+        <div class="mb-8 rounded-lg border border-border bg-surface-raised px-4 py-3">
+          <div class="flex items-center justify-between mb-2">
+            <h2 class="text-sm font-semibold text-text-heading">Lineup</h2>
+            <span class="text-sm tabular-nums">{{ starterCount }}/22 starters, {{ benchCount }}/8 bench</span>
+          </div>
+        </div>
 
-        <div v-for="pos in positions" :key="pos.key" class="mb-6">
-          <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">{{ pos.label }}</h3>
-          <div class="space-y-1">
-            <div
-              v-for="(slot, index) in lineupSlots[pos.key]"
-              :key="index"
-              class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
-              :class="slot.player
-                ? 'border-border bg-surface-raised'
-                : 'border-dashed border-border-subtle bg-surface'"
-            >
-              <div v-if="slot.player" class="flex items-center gap-3">
-                <span class="font-medium">{{ slot.player.name }}</span>
-              </div>
-              <span v-else class="text-text-faint text-sm">Empty slot</span>
-              <div v-if="slot.player" class="flex items-center gap-2">
-                <button
-                  v-for="target in positions.filter(p => p.key !== pos.key)"
-                  :key="target.key"
-                  class="rounded px-1.5 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
-                  :disabled="isPositionFull(target.key)"
-                  :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(target.key) }"
-                  :title="`Move to ${target.label}`"
-                  @click="moveToPosition(pos.key, index, target.key)"
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <!-- Lineup (left 2 cols) -->
+          <div class="lg:col-span-2">
+            <div v-for="pos in positions" :key="pos.key" class="mb-6">
+              <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">{{ pos.label }}</h3>
+              <div class="space-y-1">
+                <div
+                  v-for="(slot, index) in lineupSlots[pos.key]"
+                  :key="index"
+                  class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
+                  :class="slot.player
+                    ? 'border-border bg-surface-raised'
+                    : 'border-dashed border-border-subtle bg-surface'"
                 >
-                  {{ target.short }}
-                </button>
-                <button
-                  class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                  @click="removeFromLineup(pos.key, index)"
+                  <div v-if="slot.player" class="flex items-center gap-3">
+                    <span class="font-medium">{{ slot.player.name }}</span>
+                  </div>
+                  <span v-else class="text-text-faint text-sm">Empty slot</span>
+                  <div v-if="slot.player" class="flex items-center gap-2">
+                    <button
+                      v-for="target in positions.filter(p => p.key !== pos.key)"
+                      :key="target.key"
+                      class="rounded px-1.5 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                      :disabled="isPositionFull(target.key)"
+                      :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(target.key) }"
+                      :title="`Move to ${target.label}`"
+                      @click="moveToPosition(pos.key, index, target.key)"
+                    >
+                      {{ target.short }}
+                    </button>
+                    <button
+                      class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                      @click="removeFromLineup(pos.key, index)"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-6">
+              <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">Bench ({{ benchCount }}/8)</h3>
+              <div class="space-y-1">
+                <div
+                  v-for="(slot, index) in benchSlots"
+                  :key="index"
+                  class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
+                  :class="slot.player
+                    ? 'border-border bg-surface-raised'
+                    : 'border-dashed border-border-subtle bg-surface'"
                 >
-                  Remove
-                </button>
+                  <div v-if="slot.player" class="flex items-center gap-3">
+                    <span class="font-medium text-text-muted">{{ slot.player.name }}</span>
+                  </div>
+                  <span v-else class="text-text-faint text-sm">Empty bench slot</span>
+                  <button
+                    v-if="slot.player"
+                    class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                    @click="removeFromBench(index)"
+                  >
+                    Remove
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
 
-        <div class="mb-6">
-          <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">Bench ({{ benchCount }}/8)</h3>
-          <div class="space-y-1">
-            <div
-              v-for="(slot, index) in benchSlots"
-              :key="index"
-              class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
-              :class="slot.player
-                ? 'border-border bg-surface-raised'
-                : 'border-dashed border-border-subtle bg-surface'"
+            <!-- Submit -->
+            <button
+              class="rounded-lg bg-active px-6 py-2 text-sm font-medium text-active-text hover:opacity-90 transition-opacity disabled:opacity-30 disabled:cursor-not-allowed"
+              :disabled="submitting || starterCount === 0"
+              @click="submitLineup"
             >
-              <div v-if="slot.player" class="flex items-center gap-3">
-                <span class="font-medium text-text-muted">{{ slot.player.name }}</span>
-              </div>
-              <span v-else class="text-text-faint text-sm">Empty bench slot</span>
-              <button
-                v-if="slot.player"
-                class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                @click="removeFromBench(index)"
-              >
-                Remove
-              </button>
-            </div>
+              {{ submitting ? 'Saving…' : 'Save Lineup' }}
+            </button>
+            <span v-if="submitMessage" class="ml-3 text-sm text-green-500">{{ submitMessage }}</span>
           </div>
-        </div>
-      </div>
 
-      <!-- Roster panel (right col) -->
-      <div>
-        <h2 class="text-lg font-semibold text-text-heading mb-3">Roster ({{ availablePlayers.length }})</h2>
-        <div class="space-y-1">
-          <div
-            v-for="player in availablePlayers"
-            :key="player.id"
-            class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2"
-          >
-            <div>
-              <span class="font-medium text-sm">{{ player.name }}</span>
-              <div class="flex gap-2 text-xs text-text-faint mt-0.5">
-                <span v-for="pos in positions" :key="pos.key">{{ pos.short }}:{{ player.projectedScores[pos.key] }}</span>
+          <!-- Roster panel (right col) -->
+          <div>
+            <h2 class="text-lg font-semibold text-text-heading mb-3">Roster ({{ availablePlayers.length }})</h2>
+            <div class="space-y-1">
+              <div
+                v-for="player in availablePlayers"
+                :key="player.playerSeasonId"
+                class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2"
+              >
+                <span class="font-medium text-sm">{{ player.name }}</span>
+                <div class="flex items-center gap-1">
+                  <button
+                    v-for="pos in positions"
+                    :key="pos.key"
+                    class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
+                    :disabled="isPositionFull(pos.key)"
+                    :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(pos.key) }"
+                    @click="addToLineup(pos.key, player)"
+                  >
+                    {{ pos.short }}
+                  </button>
+                  <button
+                    class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                    :disabled="benchCount >= 8"
+                    :class="{ 'opacity-30 cursor-not-allowed': benchCount >= 8 }"
+                    @click="addToBench(player)"
+                  >
+                    B
+                  </button>
+                </div>
               </div>
-            </div>
-            <div class="flex items-center gap-1">
-              <button
-                v-for="pos in positions"
-                :key="pos.key"
-                class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
-                :disabled="isPositionFull(pos.key)"
-                :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(pos.key) }"
-                @click="addToLineup(pos.key, player)"
-              >
-                {{ pos.short }}
-              </button>
-              <button
-                class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
-                :disabled="benchCount >= 8"
-                :class="{ 'opacity-30 cursor-not-allowed': benchCount >= 8 }"
-                @click="addToBench(player)"
-              >
-                B
-              </button>
+              <p v-if="availablePlayers.length === 0" class="text-sm text-text-faint">All players assigned</p>
             </div>
           </div>
-          <p v-if="availablePlayers.length === 0" class="text-sm text-text-faint">All players assigned</p>
         </div>
-      </div>
-    </div>
+      </template>
+      <p v-else class="text-text-faint">Select a club to build your lineup.</p>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
+import { useQuery, useMutation } from '@vue/apollo-composable'
+import { GET_FFL_TEAM_BUILDER } from '../api/queries'
+import { SET_FFL_LINEUP } from '../api/mutations'
 
-defineProps<{ seasonId: string; roundId: string }>()
+const props = defineProps<{ seasonId: string; roundId: string }>()
 
 const positions = [
   { key: 'goals', label: 'Goals', short: 'G', count: 3 },
@@ -155,31 +167,56 @@ const positions = [
 
 type PositionKey = typeof positions[number]['key']
 
-interface Player {
-  id: string
+interface RosterPlayer {
+  playerSeasonId: string
   name: string
-  projectedScores: Record<PositionKey, number>
 }
 
 interface Slot {
-  player: Player | null
+  player: RosterPlayer | null
 }
 
-// Stub roster with mock projected scores — will be replaced with real AFL stats
-function mockScores(): Record<PositionKey, number> {
-  return Object.fromEntries(
-    positions.map(p => [p.key, Math.floor(Math.random() * 80) + 20])
-  ) as Record<PositionKey, number>
-}
+// Data loading
+const { result, loading, error } = useQuery(GET_FFL_TEAM_BUILDER, () => ({ seasonId: props.seasonId }))
 
-const roster = ref<Player[]>(
-  Array.from({ length: 10 }, (_, i) => ({
-    id: String(i + 1),
-    name: `Player ${i + 1}`,
-    projectedScores: mockScores(),
-  }))
+const season = computed(() => result.value?.fflSeason ?? null)
+
+const selectedClubSeasonId = ref<string>('')
+
+// Auto-select first club when data loads
+watch(season, (s) => {
+  if (s && s.ladder.length > 0 && !selectedClubSeasonId.value) {
+    selectedClubSeasonId.value = s.ladder[0].id
+  }
+})
+
+const selectedClubSeason = computed(() =>
+  season.value?.ladder.find((cs: { id: string }) => cs.id === selectedClubSeasonId.value) ?? null
 )
 
+// Find the club match for the selected club in the current round
+const clubMatch = computed(() => {
+  if (!season.value || !selectedClubSeason.value) return null
+  const round = season.value.rounds.find((r: { id: string }) => r.id === props.roundId)
+  if (!round) return null
+  const clubId = selectedClubSeason.value.club.id
+  for (const match of round.matches) {
+    if (match.homeClubMatch?.club.id === clubId) return match.homeClubMatch
+    if (match.awayClubMatch?.club.id === clubId) return match.awayClubMatch
+  }
+  return null
+})
+
+// Roster from club season
+const roster = computed<RosterPlayer[]>(() => {
+  if (!selectedClubSeason.value) return []
+  return selectedClubSeason.value.roster.map((r: { playerSeasonId: string; player: { name: string } }) => ({
+    playerSeasonId: r.playerSeasonId,
+    name: r.player.name,
+  }))
+})
+
+// Lineup state
 const createSlots = (count: number): Slot[] => Array.from({ length: count }, () => ({ player: null }))
 
 const lineupSlots = ref<Record<PositionKey, Slot[]>>(
@@ -188,21 +225,48 @@ const lineupSlots = ref<Record<PositionKey, Slot[]>>(
 
 const benchSlots = ref<Slot[]>(createSlots(8))
 
-const assignedPlayerIds = computed(() => {
+// Load existing lineup from club match player matches
+watch(clubMatch, (cm) => {
+  // Reset slots
+  for (const pos of positions) {
+    lineupSlots.value[pos.key] = createSlots(pos.count)
+  }
+  benchSlots.value = createSlots(8)
+
+  if (!cm?.playerMatches) return
+
+  for (const pm of cm.playerMatches) {
+    const player: RosterPlayer = { playerSeasonId: pm.playerSeasonId, name: pm.player.name }
+    const isBench = pm.backupPositions != null || pm.interchangePosition != null
+
+    if (isBench) {
+      const slot = benchSlots.value.find((s: Slot) => !s.player)
+      if (slot) slot.player = player
+    } else if (pm.position) {
+      const posSlots = lineupSlots.value[pm.position as PositionKey]
+      if (posSlots) {
+        const slot = posSlots.find((s: Slot) => !s.player)
+        if (slot) slot.player = player
+      }
+    }
+  }
+})
+
+const assignedPlayerSeasonIds = computed(() => {
   const ids = new Set<string>()
   for (const pos of positions) {
     for (const slot of lineupSlots.value[pos.key]) {
-      if (slot.player) ids.add(slot.player.id)
+      if (slot.player) ids.add(slot.player.playerSeasonId)
     }
   }
   for (const slot of benchSlots.value) {
-    if (slot.player) ids.add(slot.player.id)
+    if (slot.player) ids.add(slot.player.playerSeasonId)
   }
   return ids
 })
 
 const availablePlayers = computed(() =>
-  roster.value.filter(p => !assignedPlayerIds.value.has(p.id))
+  roster.value.filter(p => !assignedPlayerSeasonIds.value.has(p.playerSeasonId))
 )
 
 const starterCount = computed(() => {
@@ -218,32 +282,8 @@ const benchCount = computed(() => benchSlots.value.filter(s => s.player).length)
 const isPositionFull = (key: PositionKey) =>
   lineupSlots.value[key].every(s => s.player !== null)
 
-// Score projections
-function positionProjectedScore(key: PositionKey): number {
-  return lineupSlots.value[key]
-    .filter(s => s.player)
-    .reduce((sum, s) => sum + s.player!.projectedScores[key], 0)
-}
-
-const benchProjectedScore = computed(() =>
-  benchSlots.value
-    .filter(s => s.player)
-    .reduce((sum, s) => {
-      const scores = Object.values(s.player!.projectedScores)
-      return sum + Math.max(...scores)
-    }, 0)
-)
-
-const totalProjectedScore = computed(() => {
-  let total = 0
-  for (const pos of positions) {
-    total += positionProjectedScore(pos.key)
-  }
-  return total + benchProjectedScore.value
-})
-
 // Lineup management
-function addToLineup(key: PositionKey, player: Player) {
+function addToLineup(key: PositionKey, player: RosterPlayer) {
   const slot = lineupSlots.value[key].find(s => !s.player)
   if (slot) slot.player = player
 }
@@ -261,12 +301,49 @@ function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: Position
   toSlot.player = player
 }
 
-function addToBench(player: Player) {
+function addToBench(player: RosterPlayer) {
   const slot = benchSlots.value.find(s => !s.player)
   if (slot) slot.player = player
 }
 
 function removeFromBench(index: number) {
   benchSlots.value[index].player = null
+}
+
+// Submit lineup
+const { mutate: setLineup } = useMutation(SET_FFL_LINEUP)
+const submitting = ref(false)
+const submitMessage = ref('')
+
+async function submitLineup() {
+  if (!clubMatch.value) return
+  submitting.value = true
+  submitMessage.value = ''
+
+  const players: { playerSeasonId: string; position: string; backupPositions?: string; interchangePosition?: string }[] = []
+
+  for (const pos of positions) {
+    for (const slot of lineupSlots.value[pos.key]) {
+      if (slot.player) {
+        players.push({ playerSeasonId: slot.player.playerSeasonId, position: pos.key })
+      }
+    }
+  }
+
+  for (const slot of benchSlots.value) {
+    if (slot.player) {
+      // Bench players get first available position as backup
+      players.push({ playerSeasonId: slot.player.playerSeasonId, position: 'kicks', backupPositions: 'kicks' })
+    }
+  }
+
+  try {
+    await setLineup({ input: { clubMatchId: clubMatch.value.id, players } })
+    submitMessage.value = 'Lineup saved!'
+  } catch (e) {
+    submitMessage.value = 'Failed to save lineup'
+  } finally {
+    submitting.value = false
+  }
 }
 </script>

--- a/justfile
+++ b/justfile
@@ -64,6 +64,16 @@ run-all:
     just run-frontend &
     wait
 
+# Stop all running services (AFL, FFL, gateway, frontend)
+stop-all:
+    #!/usr/bin/env bash
+    for port in 8080 8081 8090 3000; do
+        pid=$(lsof -ti :$port 2>/dev/null)
+        if [ -n "$pid" ]; then
+            kill $pid 2>/dev/null && echo "Stopped process on :$port (PID $pid)"
+        fi
+    done
+
 # Run AFL service tests
 test-afl:
     cd services/afl && go test ./...

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -1,64 +1,58 @@
 # Current Sprint
 
-**Sprint goal:** Phase 5 — FFL Service (Fantasy Football League backend)
+**Sprint goal:** Phase 6 — FFL Frontend
 
-Build the FFL service following the same clean architecture patterns as the AFL service: domain entities with business logic, sqlc for data access, gqlgen for GraphQL, and integration tests against a real database. The FFL service mirrors the AFL service's structure (league/season/round/match/club/player hierarchy) but adds fantasy scoring. Event subscription (AFL→FFL) is deferred to a later task.
+Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry point. Primary audience is FFL team managers (club owners). Two money-shot views: Match (watching scores roll in) and Team Builder (building weekly lineup). See `plans/ffl-frontend-pages.md` for full page inventory.
 
 ## Tasks
 
-### 1. Domain layer
-- [x] Core entities: League, Season, Round, Match, ClubSeason, ClubMatch, Player, PlayerSeason, PlayerMatch
-- [x] Position-based scoring: goals(5/goal), kicks(1/kick), handballs(1/handball), marks(2/mark), tackles(4/tackle), hitouts(1/hitout), star(5/goal+1/kick+1/handball+2/mark+4/tackle)
-- [x] PlayerMatch fields: position, status, backup_positions (nullable string), interchange_position (nullable string), score
-- [x] Domain methods: PlayerMatch.CalculateScore(aflStats), ClubMatch.Score(), ClubSeason.Percentage()
-- [x] Bench/sub logic: sub only when starter DNPs, interchange auto-swaps if bench outscores starter
-- [x] Repository interfaces on each entity
-- [x] Unit tests for scoring by position, percentage, bench substitution rules
+### 1. Routing restructure
+- [ ] FFL Home becomes `/` (app front door)
+- [ ] AFL views move under `/afl/...`
+- [ ] Navigation updated (FFL primary, AFL linked)
 
-### 2. Application layer
-- [x] Queries: clubs, players, seasons, rounds, matches, ladder, player matches
-- [x] Commands: ManagePlayers (CRUD), CalculateFantasyScore
-- [x] TxManager interface (same pattern as AFL)
+### 2. FFL Home page
+- [ ] FFL ladder for current season
+- [ ] Current round's matches with fantasy scores
+- [ ] Round navigation
+- [ ] Link to AFL section
 
-### 3. Infrastructure — sqlc + Postgres
-- [x] SQL query files for all entities (ffl schema)
-- [x] sqlc config and code generation
-- [x] Repository implementations mapping sqlcgen → domain
-- [x] Transaction manager implementation
+### 3. FFL Round page
+- [ ] All matches in round with scores
+- [ ] Top fantasy scorers across the round
+- [ ] Round navigation
 
-### 4. Interface — GraphQL
-- [x] Schema: queries (clubs, players, seasons, ladder, matches) + mutations (CRUD players, update player match)
-- [x] gqlgen config and code generation
-- [x] Query/mutation resolvers + field resolvers for nested types
-- [x] Converter layer (domain ↔ GraphQL)
+### 4. FFL Match page (money shot)
+- [ ] Head-to-head: two club rosters side by side
+- [ ] Player details: name, FFL position, status, fantasy score
+- [ ] Bench/sub/interchange indicators
+- [ ] Club fantasy score totals
 
-### 5. Service wiring
-- [x] cmd/main.go: DB pool → repos → queries/commands → resolver → HTTP server (port 8081)
-- [x] go.mod with pgx, gqlgen dependencies
-- [x] Health endpoint
+### 5. FFL Team Builder (money shot — stubbed)
+- [ ] Layout with position slots and roster panel
+- [ ] Display roster (30 players)
+- [ ] Assign players to positions (local state only)
+- [ ] Compare lineup arrangements
+- [ ] No persistence yet — stub UI only
 
-### 6. Gateway routing
-- [x] Add FFL service proxy to gateway (route FFL queries to :8081)
-- [x] Update run-all in justfile to include FFL service
+### 6. FFL Players page
+- [ ] Player CRUD (create, edit, delete)
+- [ ] Assign/remove players to/from club seasons
 
-### 7. Integration tests
-- [x] GraphQL integration tests (queries + mutations) against real DB
-- [x] Test helpers: seed data, server setup, query execution
-- [x] Fantasy score calculation test
+### 7. Backend wiring (end of sprint)
+- [ ] Add `aflPlayerId` to FFL Player (domain + schema + migration)
+- [ ] `setFFLLineup` mutation (batch upsert PlayerMatch)
+- [ ] Roster query via GraphQL
+- [ ] Wire Team Builder UI to real data
 
-### 8. Validate end-to-end
-- [x] `just dev-up && just dev-seed` loads FFL data
-- [x] `just run-ffl` starts and serves GraphQL playground
-- [x] Gateway proxies FFL queries correctly
-- [x] All tests pass
+### 8. Playwright tests
+- [ ] FFL Home tests
+- [ ] FFL Round tests
+- [ ] FFL Match tests
+- [ ] FFL Team Builder tests
+- [ ] FFL Players tests
 
-## Design constraint: event integration is next
-The AFL service already publishes `AFL.PlayerMatchUpdated` events. The next sprint will wire up the FFL service to subscribe to these events and auto-calculate fantasy scores. This sprint should ensure:
-- `PlayerMatch.CalculateScore(aflStats)` is a pure domain function, callable from a future event handler
-- The application layer command for calculating scores doesn't assume where the AFL stats come from
-
-## Out of scope (deferred)
-- Event subscription (AFL.PlayerMatchUpdated → FFL.FantasyScoreCalculated) — Phase 7
-- Event publishing (FFL.FantasyScoreCalculated) — Phase 7
-- Frontend FFL views — Phase 6
+## Out of scope
+- Event subscription (AFL→FFL) — Phase 7
 - Draft/trade mechanics — future phase
+- Pulling AFL stats from external source — future phase

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -38,7 +38,7 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 ### 6. FFL Players / Roster management
 - [x] ~~Player CRUD~~ — scrapped, FFL players are AFL players
 - [x] Roster query on FFLClubSeason (via backend roster field)
-- [ ] Roster management UI (add/remove AFL players to club season)
+- [x] Roster management UI (add/remove AFL players to club season)
 
 ### 7. Backend wiring (end of sprint)
 - [x] Add `aflPlayerId` to FFL Player (domain + schema + migration)

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -7,33 +7,33 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 ## Tasks
 
 ### 1. Routing restructure
-- [ ] FFL Home becomes `/` (app front door)
-- [ ] AFL views move under `/afl/...`
-- [ ] Navigation updated (FFL primary, AFL linked)
+- [x] FFL Home becomes `/` (app front door)
+- [x] AFL views move under `/afl/...`
+- [x] Navigation updated (FFL primary, AFL linked)
 
 ### 2. FFL Home page
-- [ ] FFL ladder for current season
-- [ ] Current round's matches with fantasy scores
-- [ ] Round navigation
-- [ ] Link to AFL section
+- [x] FFL ladder for current season
+- [x] Current round's matches with fantasy scores
+- [x] Round navigation
+- [x] Link to AFL section
 
 ### 3. FFL Round page
-- [ ] All matches in round with scores
-- [ ] Top fantasy scorers across the round
-- [ ] Round navigation
+- [x] All matches in round with scores
+- [x] Top fantasy scorers across the round
+- [x] Round navigation
 
 ### 4. FFL Match page (money shot)
-- [ ] Head-to-head: two club rosters side by side
-- [ ] Player details: name, FFL position, status, fantasy score
-- [ ] Bench/sub/interchange indicators
-- [ ] Club fantasy score totals
+- [x] Head-to-head: two club rosters side by side
+- [x] Player details: name, FFL position, status, fantasy score
+- [x] Bench/sub/interchange indicators
+- [x] Club fantasy score totals
 
 ### 5. FFL Team Builder (money shot — stubbed)
-- [ ] Layout with position slots and roster panel
-- [ ] Display roster (30 players)
-- [ ] Assign players to positions (local state only)
+- [x] Layout with position slots and roster panel
+- [x] Display roster (30 players)
+- [x] Assign players to positions (local state only)
 - [ ] Compare lineup arrangements
-- [ ] No persistence yet — stub UI only
+- [x] No persistence yet — stub UI only
 
 ### 6. FFL Players page
 - [ ] Player CRUD (create, edit, delete)

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -35,15 +35,16 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 - [x] Compare lineup arrangements
 - [x] No persistence yet — stub UI only
 
-### 6. FFL Players page
-- [x] Player CRUD (create, edit, delete)
-- [ ] Assign/remove players to/from club seasons
+### 6. FFL Players / Roster management
+- [x] ~~Player CRUD~~ — scrapped, FFL players are AFL players
+- [x] Roster query on FFLClubSeason (via backend roster field)
+- [ ] Roster management UI (add/remove AFL players to club season)
 
 ### 7. Backend wiring (end of sprint)
 - [x] Add `aflPlayerId` to FFL Player (domain + schema + migration)
-- [ ] `setFFLLineup` mutation (batch upsert PlayerMatch)
-- [ ] Roster query via GraphQL
-- [ ] Wire Team Builder UI to real data
+- [x] `setFFLLineup` mutation (batch upsert PlayerMatch)
+- [x] Roster query via GraphQL
+- [x] Wire Team Builder UI to real data
 
 ### 8. Playwright tests
 - [ ] FFL Home tests

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -54,9 +54,6 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 - [x] AFL tests updated for new routing
 - [ ] ~~FFL Players tests~~ — no Players page
 
-### 9. Justfile tidy-up
-- [ ] Review and clean up justfile recipes
-
 ## Out of scope
 - Event subscription (AFL→FFL) — Phase 7
 - Draft/trade mechanics — future phase

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -36,11 +36,11 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 - [x] No persistence yet — stub UI only
 
 ### 6. FFL Players page
-- [ ] Player CRUD (create, edit, delete)
+- [x] Player CRUD (create, edit, delete)
 - [ ] Assign/remove players to/from club seasons
 
 ### 7. Backend wiring (end of sprint)
-- [ ] Add `aflPlayerId` to FFL Player (domain + schema + migration)
+- [x] Add `aflPlayerId` to FFL Player (domain + schema + migration)
 - [ ] `setFFLLineup` mutation (batch upsert PlayerMatch)
 - [ ] Roster query via GraphQL
 - [ ] Wire Team Builder UI to real data
@@ -51,6 +51,9 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 - [ ] FFL Match tests
 - [ ] FFL Team Builder tests
 - [ ] FFL Players tests
+
+### 9. Justfile tidy-up
+- [ ] Review and clean up justfile recipes
 
 ## Out of scope
 - Event subscription (AFL→FFL) — Phase 7

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -47,11 +47,12 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 - [x] Wire Team Builder UI to real data
 
 ### 8. Playwright tests
-- [ ] FFL Home tests
-- [ ] FFL Round tests
-- [ ] FFL Match tests
-- [ ] FFL Team Builder tests
-- [ ] FFL Players tests
+- [x] FFL Home tests (9 tests)
+- [x] FFL Round tests (5 tests)
+- [x] FFL Match tests (8 tests)
+- [x] FFL Team Builder tests (7 tests)
+- [x] AFL tests updated for new routing
+- [ ] ~~FFL Players tests~~ — no Players page
 
 ### 9. Justfile tidy-up
 - [ ] Review and clean up justfile recipes

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -32,7 +32,7 @@ Build FFL views in the existing Vue 3 frontend. FFL becomes the app's main entry
 - [x] Layout with position slots and roster panel
 - [x] Display roster (30 players)
 - [x] Assign players to positions (local state only)
-- [ ] Compare lineup arrangements
+- [x] Compare lineup arrangements
 - [x] No persistence yet — stub UI only
 
 ### 6. FFL Players page

--- a/plans/ffl-frontend-pages.md
+++ b/plans/ffl-frontend-pages.md
@@ -1,0 +1,62 @@
+# FFL Frontend — Page Inventory
+
+**Primary audience:** FFL team managers (club owners)
+
+## Pages
+
+### 1. Home (`/`)
+
+FFL becomes the app's front door. AFL moves to `/afl`.
+
+- FFL ladder for current season
+- Current round's matches with fantasy scores
+- Round navigation
+- Link to AFL section
+
+### 2. Round (`/ffl/seasons/:seasonId/rounds/:roundId`)
+
+- All matches in the round with scores
+- Top fantasy scorers across the round
+- Round navigation
+
+### 3. Match (`/ffl/seasons/:seasonId/matches/:matchId`) — money shot
+
+Head-to-head match detail, the view managers watch as scores roll in.
+
+- Two club rosters side by side
+- Each player: name, FFL position, status (played/DNP/named), fantasy score
+- Bench/sub/interchange indicators (did a sub fire? did an interchange swap?)
+- Club fantasy score totals
+
+### 4. Team Builder (`/ffl/seasons/:seasonId/rounds/:roundId/team-builder`) — money shot
+
+Where managers build their 22-player lineup each week from their 30-player roster.
+
+- View roster (30 players) with AFL stats from recent rounds
+- Assign players to FFL positions (goals, kicks, handballs, marks, tackles, hitouts, star)
+- Designate starters (22) vs bench (8) with backup/interchange positions
+- Compare different lineup arrangements
+- Submit lineup
+
+**v1 (this sprint):** Stub UI with layout, position slots, roster display. No persistence.
+**v2 (backend wiring):** Add `aflPlayerId` to FFL Player, `setFFLLineup` mutation, roster query. Wire UI to real data.
+
+### 5. Players (`/ffl/players`)
+
+Admin/setup view for player management.
+
+- CRUD: create, edit, delete FFL players
+- Assign/remove players to/from club seasons (roster management)
+
+### 6. AFL Section (existing, re-routed)
+
+- AFL Home → `/afl`
+- AFL Round → `/afl/seasons/:seasonId/rounds/:roundId`
+- AFL Match → `/afl/seasons/:seasonId/matches/:matchId`
+- AFL Admin Match → `/admin/afl/seasons/:seasonId/matches/:matchId`
+
+## Backend changes needed (end of sprint)
+
+1. **`aflPlayerId` on FFL Player** — domain + schema + migration to link FFL players to AFL players
+2. **`setFFLLineup` mutation** — upsert batch of PlayerMatch entries for a club match
+3. **Roster query** — expose club's PlayerSeason entries via GraphQL (with linked AFL player data)

--- a/plans/revisit.md
+++ b/plans/revisit.md
@@ -10,6 +10,12 @@ Revisit whether "roster" is the right term for the list of players on an FFL clu
 
 ---
 
+### Apollo client routing by field name
+
+The Apollo client routes operations to AFL vs FFL services by regex-matching field names (`/^ffl|FFL/`). This is fragile — a mutation named without `FFL` in it silently goes to the wrong service (happened with `addAFLPlayerToRoster`). Consider replacing with something more explicit (e.g. operation-level directive, a routing map, or just federation). Likely tied to the federation decision below.
+
+---
+
 ### Federating the graph
 
 Currently the two GraphQL services (AFL and FFL) are completely isolated behind a dumb reverse proxy. The frontend has to issue separate queries to each service and join client-side (e.g. the Roster page dual-queries FFL for roster data and AFL for stats). Consider whether Apollo Federation or a similar approach would be worth the complexity — it would let the frontend write a single query that spans both services, with the gateway handling the stitching. Trade-offs: simpler frontend queries vs. added infrastructure and coupling at the gateway layer.

--- a/plans/revisit.md
+++ b/plans/revisit.md
@@ -1,0 +1,15 @@
+# Revisit
+
+Things to reconsider later. Not roadmap items — just thoughts to dump and come back to.
+
+---
+
+### Naming: "Roster"
+
+Revisit whether "roster" is the right term for the list of players on an FFL club season. It currently refers to the 30-player pool a manager picks their weekly 22 from, but the word may not land right. Consider alternatives (squad, list, pool, etc.) and whether the term should change across the codebase or just in the UI.
+
+---
+
+### Federating the graph
+
+Currently the two GraphQL services (AFL and FFL) are completely isolated behind a dumb reverse proxy. The frontend has to issue separate queries to each service and join client-side (e.g. the Roster page dual-queries FFL for roster data and AFL for stats). Consider whether Apollo Federation or a similar approach would be worth the complexity — it would let the frontend write a single query that spans both services, with the gateway handling the stitching. Trade-offs: simpler frontend queries vs. added infrastructure and coupling at the gateway layer.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -53,20 +53,19 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 
 **Goal:** FFL service as standalone CRUD with position-based fantasy scoring
 
-- [ ] Domain layer — League, Season, Round, Match, ClubSeason, ClubMatch, Player, PlayerSeason, PlayerMatch entities; position-based scoring (goals/kicks/handballs/marks/tackles/hitouts/star); bench + interchange substitution logic; repository interfaces
-- [ ] Application layer — ManagePlayers (CRUD), QueryLadder, CalculateFantasyScore use cases
-- [ ] Infrastructure layer — sqlc queries, DB repositories, transaction manager
-- [ ] Interface layer — GraphQL schema + resolvers
-- [ ] Add FFL routing to gateway
-- [ ] Tests — unit (scoring by position, percentage, substitution) + integration (GraphQL with real DB)
+- [x] Domain layer — League, Season, Round, Match, ClubSeason, ClubMatch, Player, PlayerSeason, PlayerMatch entities; position-based scoring (goals/kicks/handballs/marks/tackles/hitouts/star); bench + interchange substitution logic; repository interfaces
+- [x] Application layer — ManagePlayers (CRUD), QueryLadder, CalculateFantasyScore use cases
+- [x] Infrastructure layer — sqlc queries, DB repositories, transaction manager
+- [x] Interface layer — GraphQL schema + resolvers
+- [x] Add FFL routing to gateway
+- [x] Tests — unit (scoring by position, percentage, substitution) + integration (GraphQL with real DB)
 
 ## Phase 6: FFL Frontend
 
 **Goal:** FFL views added to existing frontend
 
-- [ ] FFL Players view — full CRUD
-- [ ] FFL Ladder view — standings table
-- [ ] Playwright tests
+- [x] FFL Players view
+- [x] Playwright tests
 
 ## Phase 7: FFL Event Integration
 

--- a/services/afl/api/graphql/query.graphqls
+++ b/services/afl/api/graphql/query.graphqls
@@ -4,6 +4,19 @@ type Query {
   aflSeasons: [AFLSeason!]!
   aflSeason(id: ID!): AFLSeason!
   aflLatestRound: AFLRound!
+  aflPlayerSeasonStats(ids: [ID!]!): [AFLPlayerSeasonStats!]!
+}
+
+type AFLPlayerSeasonStats {
+  playerSeasonId: ID!
+  gamesPlayed: Int!
+  avgKicks: Float!
+  avgHandballs: Float!
+  avgMarks: Float!
+  avgHitouts: Float!
+  avgTackles: Float!
+  avgGoals: Float!
+  avgBehinds: Float!
 }
 
 type AFLClub {

--- a/services/afl/api/graphql/query.graphqls
+++ b/services/afl/api/graphql/query.graphqls
@@ -5,6 +5,7 @@ type Query {
   aflSeason(id: ID!): AFLSeason!
   aflLatestRound: AFLRound!
   aflPlayerSeasonStats(ids: [ID!]!): [AFLPlayerSeasonStats!]!
+  aflPlayerSearch(query: String!): [AFLPlayer!]!
 }
 
 type AFLPlayerSeasonStats {

--- a/services/afl/internal/application/queries.go
+++ b/services/afl/internal/application/queries.go
@@ -107,6 +107,10 @@ func (q *Queries) GetPlayer(ctx context.Context, id int) (domain.Player, error) 
 	return q.players.FindByID(ctx, id)
 }
 
+func (q *Queries) SearchPlayers(ctx context.Context, query string) ([]domain.Player, error) {
+	return q.players.Search(ctx, query)
+}
+
 // GetClubForClubSeason resolves the club for a club_season record.
 func (q *Queries) GetClubForClubSeason(ctx context.Context, clubSeasonID int) (domain.Club, error) {
 	cs, err := q.clubSeasons.FindByID(ctx, clubSeasonID)

--- a/services/afl/internal/application/queries.go
+++ b/services/afl/internal/application/queries.go
@@ -116,6 +116,10 @@ func (q *Queries) GetClubForClubSeason(ctx context.Context, clubSeasonID int) (d
 	return q.clubs.FindByID(ctx, cs.ClubID)
 }
 
+func (q *Queries) GetPlayerSeasonStats(ctx context.Context, ids []int) ([]domain.PlayerSeasonStats, error) {
+	return q.playerMatches.FindStatsByPlayerSeasonIDs(ctx, ids)
+}
+
 // GetPlayerForPlayerSeason resolves the player for a player_season record.
 func (q *Queries) GetPlayerForPlayerSeason(ctx context.Context, playerSeasonID int) (domain.Player, error) {
 	ps, err := q.playerSeasons.FindByID(ctx, playerSeasonID)

--- a/services/afl/internal/domain/player.go
+++ b/services/afl/internal/domain/player.go
@@ -11,4 +11,5 @@ type Player struct {
 type PlayerRepository interface {
 	FindByClubID(ctx context.Context, clubID int) ([]Player, error)
 	FindByID(ctx context.Context, id int) (Player, error)
+	Search(ctx context.Context, query string) ([]Player, error)
 }

--- a/services/afl/internal/domain/player_match.go
+++ b/services/afl/internal/domain/player_match.go
@@ -42,8 +42,22 @@ type UpsertPlayerMatchParams struct {
 	Behinds        *int
 }
 
+// PlayerSeasonStats holds aggregated match statistics for a player across a season.
+type PlayerSeasonStats struct {
+	PlayerSeasonID int
+	GamesPlayed    int
+	AvgKicks       float64
+	AvgHandballs   float64
+	AvgMarks       float64
+	AvgHitouts     float64
+	AvgTackles     float64
+	AvgGoals       float64
+	AvgBehinds     float64
+}
+
 type PlayerMatchRepository interface {
 	FindByClubMatchID(ctx context.Context, clubMatchID int) ([]PlayerMatch, error)
 	FindByID(ctx context.Context, id int) (PlayerMatch, error)
 	Upsert(ctx context.Context, params UpsertPlayerMatchParams) (PlayerMatch, error)
+	FindStatsByPlayerSeasonIDs(ctx context.Context, ids []int) ([]PlayerSeasonStats, error)
 }

--- a/services/afl/internal/infrastructure/postgres/repository.go
+++ b/services/afl/internal/infrastructure/postgres/repository.go
@@ -337,6 +337,18 @@ func (r *PlayerRepository) FindByID(ctx context.Context, id int) (domain.Player,
 	return domain.Player{ID: int(row.ID), Name: row.Name, ClubID: int(row.ClubID)}, nil
 }
 
+func (r *PlayerRepository) Search(ctx context.Context, query string) ([]domain.Player, error) {
+	rows, err := r.q.SearchPlayersByName(ctx, &query)
+	if err != nil {
+		return nil, err
+	}
+	players := make([]domain.Player, len(rows))
+	for i, row := range rows {
+		players[i] = domain.Player{ID: int(row.ID), Name: row.Name, ClubID: int(row.ClubID)}
+	}
+	return players, nil
+}
+
 // --- PlayerMatch ---
 
 type PlayerMatchRepository struct{ q *sqlcgen.Queries }

--- a/services/afl/internal/infrastructure/postgres/repository.go
+++ b/services/afl/internal/infrastructure/postgres/repository.go
@@ -416,6 +416,32 @@ func (r *PlayerMatchRepository) Upsert(ctx context.Context, params domain.Upsert
 	}, nil
 }
 
+func (r *PlayerMatchRepository) FindStatsByPlayerSeasonIDs(ctx context.Context, ids []int) ([]domain.PlayerSeasonStats, error) {
+	int32IDs := make([]int32, len(ids))
+	for i, id := range ids {
+		int32IDs[i] = int32(id)
+	}
+	rows, err := r.q.FindPlayerMatchStatsByPlayerSeasonIDs(ctx, int32IDs)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.PlayerSeasonStats, len(rows))
+	for i, row := range rows {
+		out[i] = domain.PlayerSeasonStats{
+			PlayerSeasonID: int(row.PlayerSeasonID),
+			GamesPlayed:    int(row.GamesPlayed),
+			AvgKicks:       row.AvgKicks,
+			AvgHandballs:   row.AvgHandballs,
+			AvgMarks:       row.AvgMarks,
+			AvgHitouts:     row.AvgHitouts,
+			AvgTackles:     row.AvgTackles,
+			AvgGoals:       row.AvgGoals,
+			AvgBehinds:     row.AvgBehinds,
+		}
+	}
+	return out, nil
+}
+
 // --- PlayerSeason ---
 
 type PlayerSeasonRepository struct{ q *sqlcgen.Queries }

--- a/services/afl/internal/infrastructure/postgres/sqlc/player.sql
+++ b/services/afl/internal/infrastructure/postgres/sqlc/player.sql
@@ -10,3 +10,10 @@ ORDER BY p.name;
 SELECT id, name, COALESCE(club_id, 0) AS club_id
 FROM afl.player
 WHERE id = $1 AND deleted_at IS NULL;
+
+-- name: SearchPlayersByName :many
+SELECT id, name, COALESCE(club_id, 0) AS club_id
+FROM afl.player
+WHERE name ILIKE '%' || @query || '%' AND deleted_at IS NULL
+ORDER BY name
+LIMIT 20;

--- a/services/afl/internal/infrastructure/postgres/sqlc/player_match.sql
+++ b/services/afl/internal/infrastructure/postgres/sqlc/player_match.sql
@@ -10,6 +10,20 @@ SELECT id, club_match_id, player_season_id,
 FROM afl.player_match
 WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: FindPlayerMatchStatsByPlayerSeasonIDs :many
+SELECT player_season_id,
+       COUNT(*)::INTEGER AS games_played,
+       AVG(kicks)::FLOAT8 AS avg_kicks,
+       AVG(handballs)::FLOAT8 AS avg_handballs,
+       AVG(marks)::FLOAT8 AS avg_marks,
+       AVG(hitouts)::FLOAT8 AS avg_hitouts,
+       AVG(tackles)::FLOAT8 AS avg_tackles,
+       AVG(goals)::FLOAT8 AS avg_goals,
+       AVG(behinds)::FLOAT8 AS avg_behinds
+FROM afl.player_match
+WHERE player_season_id = ANY(@player_season_ids::int[]) AND deleted_at IS NULL
+GROUP BY player_season_id;
+
 -- name: UpsertPlayerMatch :one
 INSERT INTO afl.player_match (club_match_id, player_season_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/player.sql.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/player.sql.go
@@ -62,3 +62,37 @@ func (q *Queries) FindPlayersByClubID(ctx context.Context, clubID *int32) ([]Fin
 	}
 	return items, nil
 }
+
+const searchPlayersByName = `-- name: SearchPlayersByName :many
+SELECT id, name, COALESCE(club_id, 0) AS club_id
+FROM afl.player
+WHERE name ILIKE '%' || $1 || '%' AND deleted_at IS NULL
+ORDER BY name
+LIMIT 20
+`
+
+type SearchPlayersByNameRow struct {
+	ID     int32
+	Name   string
+	ClubID int32
+}
+
+func (q *Queries) SearchPlayersByName(ctx context.Context, query *string) ([]SearchPlayersByNameRow, error) {
+	rows, err := q.db.Query(ctx, searchPlayersByName, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SearchPlayersByNameRow{}
+	for rows.Next() {
+		var i SearchPlayersByNameRow
+		if err := rows.Scan(&i.ID, &i.Name, &i.ClubID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
@@ -47,6 +47,63 @@ func (q *Queries) FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayer
 	return i, err
 }
 
+const findPlayerMatchStatsByPlayerSeasonIDs = `-- name: FindPlayerMatchStatsByPlayerSeasonIDs :many
+SELECT player_season_id,
+       COUNT(*)::INTEGER AS games_played,
+       AVG(kicks)::FLOAT8 AS avg_kicks,
+       AVG(handballs)::FLOAT8 AS avg_handballs,
+       AVG(marks)::FLOAT8 AS avg_marks,
+       AVG(hitouts)::FLOAT8 AS avg_hitouts,
+       AVG(tackles)::FLOAT8 AS avg_tackles,
+       AVG(goals)::FLOAT8 AS avg_goals,
+       AVG(behinds)::FLOAT8 AS avg_behinds
+FROM afl.player_match
+WHERE player_season_id = ANY($1::int[]) AND deleted_at IS NULL
+GROUP BY player_season_id
+`
+
+type FindPlayerMatchStatsByPlayerSeasonIDsRow struct {
+	PlayerSeasonID int32
+	GamesPlayed    int32
+	AvgKicks       float64
+	AvgHandballs   float64
+	AvgMarks       float64
+	AvgHitouts     float64
+	AvgTackles     float64
+	AvgGoals       float64
+	AvgBehinds     float64
+}
+
+func (q *Queries) FindPlayerMatchStatsByPlayerSeasonIDs(ctx context.Context, playerSeasonIds []int32) ([]FindPlayerMatchStatsByPlayerSeasonIDsRow, error) {
+	rows, err := q.db.Query(ctx, findPlayerMatchStatsByPlayerSeasonIDs, playerSeasonIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindPlayerMatchStatsByPlayerSeasonIDsRow{}
+	for rows.Next() {
+		var i FindPlayerMatchStatsByPlayerSeasonIDsRow
+		if err := rows.Scan(
+			&i.PlayerSeasonID,
+			&i.GamesPlayed,
+			&i.AvgKicks,
+			&i.AvgHandballs,
+			&i.AvgMarks,
+			&i.AvgHitouts,
+			&i.AvgTackles,
+			&i.AvgGoals,
+			&i.AvgBehinds,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findPlayerMatchesByClubMatchID = `-- name: FindPlayerMatchesByClubMatchID :many
 SELECT id, club_match_id, player_season_id,
        kicks, handballs, marks, hitouts, tackles, goals, behinds

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -28,6 +28,7 @@ type Querier interface {
 	FindRoundByID(ctx context.Context, id int32) (FindRoundByIDRow, error)
 	FindRoundsBySeasonID(ctx context.Context, seasonID int32) ([]FindRoundsBySeasonIDRow, error)
 	FindSeasonByID(ctx context.Context, id int32) (FindSeasonByIDRow, error)
+	SearchPlayersByName(ctx context.Context, query *string) ([]SearchPlayersByNameRow, error)
 	UpdateClubMatchScore(ctx context.Context, arg UpdateClubMatchScoreParams) error
 	UpsertPlayerMatch(ctx context.Context, arg UpsertPlayerMatchParams) (UpsertPlayerMatchRow, error)
 }

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -21,6 +21,7 @@ type Querier interface {
 	FindMatchesByRoundID(ctx context.Context, roundID int32) ([]FindMatchesByRoundIDRow, error)
 	FindPlayerByID(ctx context.Context, id int32) (FindPlayerByIDRow, error)
 	FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayerMatchByIDRow, error)
+	FindPlayerMatchStatsByPlayerSeasonIDs(ctx context.Context, playerSeasonIds []int32) ([]FindPlayerMatchStatsByPlayerSeasonIDsRow, error)
 	FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) ([]FindPlayerMatchesByClubMatchIDRow, error)
 	FindPlayerSeasonByID(ctx context.Context, id int32) (FindPlayerSeasonByIDRow, error)
 	FindPlayersByClubID(ctx context.Context, clubID *int32) ([]FindPlayersByClubIDRow, error)

--- a/services/afl/internal/interface/graphql/generated.go
+++ b/services/afl/internal/interface/graphql/generated.go
@@ -94,6 +94,18 @@ type ComplexityRoot struct {
 		Tackles        func(childComplexity int) int
 	}
 
+	AFLPlayerSeasonStats struct {
+		AvgBehinds     func(childComplexity int) int
+		AvgGoals       func(childComplexity int) int
+		AvgHandballs   func(childComplexity int) int
+		AvgHitouts     func(childComplexity int) int
+		AvgKicks       func(childComplexity int) int
+		AvgMarks       func(childComplexity int) int
+		AvgTackles     func(childComplexity int) int
+		GamesPlayed    func(childComplexity int) int
+		PlayerSeasonID func(childComplexity int) int
+	}
+
 	AFLRound struct {
 		ID      func(childComplexity int) int
 		Matches func(childComplexity int) int
@@ -113,11 +125,12 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		AflClub        func(childComplexity int, id string) int
-		AflClubs       func(childComplexity int) int
-		AflLatestRound func(childComplexity int) int
-		AflSeason      func(childComplexity int, id string) int
-		AflSeasons     func(childComplexity int) int
+		AflClub              func(childComplexity int, id string) int
+		AflClubs             func(childComplexity int) int
+		AflLatestRound       func(childComplexity int) int
+		AflPlayerSeasonStats func(childComplexity int, ids []string) int
+		AflSeason            func(childComplexity int, id string) int
+		AflSeasons           func(childComplexity int) int
 	}
 }
 
@@ -148,6 +161,7 @@ type QueryResolver interface {
 	AflSeasons(ctx context.Context) ([]*AFLSeason, error)
 	AflSeason(ctx context.Context, id string) (*AFLSeason, error)
 	AflLatestRound(ctx context.Context) (*AFLRound, error)
+	AflPlayerSeasonStats(ctx context.Context, ids []string) ([]*AFLPlayerSeasonStats, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -392,6 +406,61 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.AFLPlayerMatch.Tackles(childComplexity), true
 
+	case "AFLPlayerSeasonStats.avgBehinds":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgBehinds == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgBehinds(childComplexity), true
+	case "AFLPlayerSeasonStats.avgGoals":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgGoals == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgGoals(childComplexity), true
+	case "AFLPlayerSeasonStats.avgHandballs":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgHandballs == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgHandballs(childComplexity), true
+	case "AFLPlayerSeasonStats.avgHitouts":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgHitouts == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgHitouts(childComplexity), true
+	case "AFLPlayerSeasonStats.avgKicks":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgKicks == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgKicks(childComplexity), true
+	case "AFLPlayerSeasonStats.avgMarks":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgMarks == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgMarks(childComplexity), true
+	case "AFLPlayerSeasonStats.avgTackles":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.AvgTackles == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.AvgTackles(childComplexity), true
+	case "AFLPlayerSeasonStats.gamesPlayed":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.GamesPlayed == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.GamesPlayed(childComplexity), true
+	case "AFLPlayerSeasonStats.playerSeasonId":
+		if e.ComplexityRoot.AFLPlayerSeasonStats.PlayerSeasonID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeasonStats.PlayerSeasonID(childComplexity), true
+
 	case "AFLRound.id":
 		if e.ComplexityRoot.AFLRound.ID == nil {
 			break
@@ -477,6 +546,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.AflLatestRound(childComplexity), true
+	case "Query.aflPlayerSeasonStats":
+		if e.ComplexityRoot.Query.AflPlayerSeasonStats == nil {
+			break
+		}
+
+		args, err := ec.field_Query_aflPlayerSeasonStats_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.AflPlayerSeasonStats(childComplexity, args["ids"].([]string)), true
 	case "Query.aflSeason":
 		if e.ComplexityRoot.Query.AflSeason == nil {
 			break
@@ -601,6 +681,19 @@ input UpdateAFLPlayerMatchInput {
   aflSeasons: [AFLSeason!]!
   aflSeason(id: ID!): AFLSeason!
   aflLatestRound: AFLRound!
+  aflPlayerSeasonStats(ids: [ID!]!): [AFLPlayerSeasonStats!]!
+}
+
+type AFLPlayerSeasonStats {
+  playerSeasonId: ID!
+  gamesPlayed: Int!
+  avgKicks: Float!
+  avgHandballs: Float!
+  avgMarks: Float!
+  avgHitouts: Float!
+  avgTackles: Float!
+  avgGoals: Float!
+  avgBehinds: Float!
 }
 
 type AFLClub {
@@ -709,6 +802,17 @@ func (ec *executionContext) field_Query_aflClub_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_aflPlayerSeasonStats_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "ids", ec.unmarshalNID2ᚕstringᚄ)
+	if err != nil {
+		return nil, err
+	}
+	args["ids"] = arg0
 	return args, nil
 }
 
@@ -1926,6 +2030,267 @@ func (ec *executionContext) fieldContext_AFLPlayerMatch_score(_ context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _AFLPlayerSeasonStats_playerSeasonId(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_playerSeasonId,
+		func(ctx context.Context) (any, error) {
+			return obj.PlayerSeasonID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_playerSeasonId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_gamesPlayed(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_gamesPlayed,
+		func(ctx context.Context) (any, error) {
+			return obj.GamesPlayed, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_gamesPlayed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgKicks(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgKicks,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgKicks, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgKicks(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgHandballs(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgHandballs,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgHandballs, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgHandballs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgMarks(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgMarks,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgMarks, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgMarks(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgHitouts(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgHitouts,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgHitouts, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgHitouts(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgTackles(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgTackles,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgTackles, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgTackles(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgGoals(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgGoals,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgGoals, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgGoals(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLPlayerSeasonStats_avgBehinds(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeasonStats) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeasonStats_avgBehinds,
+		func(ctx context.Context) (any, error) {
+			return obj.AvgBehinds, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeasonStats_avgBehinds(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeasonStats",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AFLRound_id(ctx context.Context, field graphql.CollectedField, obj *AFLRound) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2490,6 +2855,67 @@ func (ec *executionContext) fieldContext_Query_aflLatestRound(_ context.Context,
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AFLRound", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_aflPlayerSeasonStats(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_aflPlayerSeasonStats,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().AflPlayerSeasonStats(ctx, fc.Args["ids"].([]string))
+		},
+		nil,
+		ec.marshalNAFLPlayerSeasonStats2ᚕᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLPlayerSeasonStatsᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_aflPlayerSeasonStats(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "playerSeasonId":
+				return ec.fieldContext_AFLPlayerSeasonStats_playerSeasonId(ctx, field)
+			case "gamesPlayed":
+				return ec.fieldContext_AFLPlayerSeasonStats_gamesPlayed(ctx, field)
+			case "avgKicks":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgKicks(ctx, field)
+			case "avgHandballs":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgHandballs(ctx, field)
+			case "avgMarks":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgMarks(ctx, field)
+			case "avgHitouts":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgHitouts(ctx, field)
+			case "avgTackles":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgTackles(ctx, field)
+			case "avgGoals":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgGoals(ctx, field)
+			case "avgBehinds":
+				return ec.fieldContext_AFLPlayerSeasonStats_avgBehinds(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AFLPlayerSeasonStats", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_aflPlayerSeasonStats_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -4640,6 +5066,85 @@ func (ec *executionContext) _AFLPlayerMatch(ctx context.Context, sel ast.Selecti
 	return out
 }
 
+var aFLPlayerSeasonStatsImplementors = []string{"AFLPlayerSeasonStats"}
+
+func (ec *executionContext) _AFLPlayerSeasonStats(ctx context.Context, sel ast.SelectionSet, obj *AFLPlayerSeasonStats) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, aFLPlayerSeasonStatsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AFLPlayerSeasonStats")
+		case "playerSeasonId":
+			out.Values[i] = ec._AFLPlayerSeasonStats_playerSeasonId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "gamesPlayed":
+			out.Values[i] = ec._AFLPlayerSeasonStats_gamesPlayed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgKicks":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgKicks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgHandballs":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgHandballs(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgMarks":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgMarks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgHitouts":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgHitouts(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgTackles":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgTackles(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgGoals":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgGoals(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "avgBehinds":
+			out.Values[i] = ec._AFLPlayerSeasonStats_avgBehinds(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var aFLRoundImplementors = []string{"AFLRound"}
 
 func (ec *executionContext) _AFLRound(ctx context.Context, sel ast.SelectionSet, obj *AFLRound) graphql.Marshaler {
@@ -5038,6 +5543,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_aflLatestRound(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "aflPlayerSeasonStats":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_aflPlayerSeasonStats(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -5554,6 +6081,32 @@ func (ec *executionContext) marshalNAFLPlayerMatch2ᚖxfflᚋservicesᚋaflᚋin
 	return ec._AFLPlayerMatch(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNAFLPlayerSeasonStats2ᚕᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLPlayerSeasonStatsᚄ(ctx context.Context, sel ast.SelectionSet, v []*AFLPlayerSeasonStats) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNAFLPlayerSeasonStats2ᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLPlayerSeasonStats(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNAFLPlayerSeasonStats2ᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLPlayerSeasonStats(ctx context.Context, sel ast.SelectionSet, v *AFLPlayerSeasonStats) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AFLPlayerSeasonStats(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNAFLRound2xfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLRound(ctx context.Context, sel ast.SelectionSet, v AFLRound) graphql.Marshaler {
 	return ec._AFLRound(ctx, sel, &v)
 }
@@ -5630,6 +6183,22 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v any) (float64, error) {
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalFloatContext(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return graphql.WrapContextMarshaler(ctx, res)
+}
+
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v any) (string, error) {
 	res, err := graphql.UnmarshalID(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -5644,6 +6213,36 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNID2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNID2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNID2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNID2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v any) (int, error) {

--- a/services/afl/internal/interface/graphql/generated.go
+++ b/services/afl/internal/interface/graphql/generated.go
@@ -128,6 +128,7 @@ type ComplexityRoot struct {
 		AflClub              func(childComplexity int, id string) int
 		AflClubs             func(childComplexity int) int
 		AflLatestRound       func(childComplexity int) int
+		AflPlayerSearch      func(childComplexity int, query string) int
 		AflPlayerSeasonStats func(childComplexity int, ids []string) int
 		AflSeason            func(childComplexity int, id string) int
 		AflSeasons           func(childComplexity int) int
@@ -162,6 +163,7 @@ type QueryResolver interface {
 	AflSeason(ctx context.Context, id string) (*AFLSeason, error)
 	AflLatestRound(ctx context.Context) (*AFLRound, error)
 	AflPlayerSeasonStats(ctx context.Context, ids []string) ([]*AFLPlayerSeasonStats, error)
+	AflPlayerSearch(ctx context.Context, query string) ([]*AFLPlayer, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -546,6 +548,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.AflLatestRound(childComplexity), true
+	case "Query.aflPlayerSearch":
+		if e.ComplexityRoot.Query.AflPlayerSearch == nil {
+			break
+		}
+
+		args, err := ec.field_Query_aflPlayerSearch_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.AflPlayerSearch(childComplexity, args["query"].(string)), true
 	case "Query.aflPlayerSeasonStats":
 		if e.ComplexityRoot.Query.AflPlayerSeasonStats == nil {
 			break
@@ -682,6 +695,7 @@ input UpdateAFLPlayerMatchInput {
   aflSeason(id: ID!): AFLSeason!
   aflLatestRound: AFLRound!
   aflPlayerSeasonStats(ids: [ID!]!): [AFLPlayerSeasonStats!]!
+  aflPlayerSearch(query: String!): [AFLPlayer!]!
 }
 
 type AFLPlayerSeasonStats {
@@ -802,6 +816,17 @@ func (ec *executionContext) field_Query_aflClub_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_aflPlayerSearch_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "query", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["query"] = arg0
 	return args, nil
 }
 
@@ -2914,6 +2939,53 @@ func (ec *executionContext) fieldContext_Query_aflPlayerSeasonStats(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_aflPlayerSeasonStats_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_aflPlayerSearch(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_aflPlayerSearch,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().AflPlayerSearch(ctx, fc.Args["query"].(string))
+		},
+		nil,
+		ec.marshalNAFLPlayer2ᚕᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLPlayerᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_aflPlayerSearch(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AFLPlayer_id(ctx, field)
+			case "name":
+				return ec.fieldContext_AFLPlayer_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AFLPlayer", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_aflPlayerSearch_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5565,6 +5637,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_aflPlayerSeasonStats(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "aflPlayerSearch":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_aflPlayerSearch(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/services/afl/internal/interface/graphql/integration_test.go
+++ b/services/afl/internal/interface/graphql/integration_test.go
@@ -846,6 +846,55 @@ func TestAflLatestRound_MultipleSeasons(t *testing.T) {
 	}
 }
 
+func TestAflPlayerSearch(t *testing.T) {
+	pool := connectDB(t)
+	seedTestData(t, pool) // seeds "Test Player"
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	// Search matching
+	result := execQuery(t, server, `{ aflPlayerSearch(query: "Test") { id name } }`)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	var data struct {
+		AflPlayerSearch []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"aflPlayerSearch"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal data: %v", err)
+	}
+
+	if len(data.AflPlayerSearch) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(data.AflPlayerSearch))
+	}
+	if data.AflPlayerSearch[0].Name != "Test Player" {
+		t.Errorf("expected 'Test Player', got %s", data.AflPlayerSearch[0].Name)
+	}
+
+	// Search not matching
+	result2 := execQuery(t, server, `{ aflPlayerSearch(query: "Nonexistent") { id name } }`)
+	if len(result2.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result2.Errors)
+	}
+
+	var data2 struct {
+		AflPlayerSearch []struct {
+			ID string `json:"id"`
+		} `json:"aflPlayerSearch"`
+	}
+	if err := json.Unmarshal(result2.Data, &data2); err != nil {
+		t.Fatalf("failed to unmarshal data: %v", err)
+	}
+
+	if len(data2.AflPlayerSearch) != 0 {
+		t.Errorf("expected 0 results for non-matching search, got %d", len(data2.AflPlayerSearch))
+	}
+}
+
 func TestUpdatePlayerMatch_InvalidPlayerSeasonID(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)

--- a/services/afl/internal/interface/graphql/models_gen.go
+++ b/services/afl/internal/interface/graphql/models_gen.go
@@ -57,6 +57,18 @@ type AFLPlayerMatch struct {
 	Score          int        `json:"score"`
 }
 
+type AFLPlayerSeasonStats struct {
+	PlayerSeasonID string  `json:"playerSeasonId"`
+	GamesPlayed    int     `json:"gamesPlayed"`
+	AvgKicks       float64 `json:"avgKicks"`
+	AvgHandballs   float64 `json:"avgHandballs"`
+	AvgMarks       float64 `json:"avgMarks"`
+	AvgHitouts     float64 `json:"avgHitouts"`
+	AvgTackles     float64 `json:"avgTackles"`
+	AvgGoals       float64 `json:"avgGoals"`
+	AvgBehinds     float64 `json:"avgBehinds"`
+}
+
 type AFLRound struct {
 	ID      string      `json:"id"`
 	Name    string      `json:"name"`

--- a/services/afl/internal/interface/graphql/query.resolvers.go
+++ b/services/afl/internal/interface/graphql/query.resolvers.go
@@ -240,6 +240,15 @@ func (r *queryResolver) AflPlayerSeasonStats(ctx context.Context, ids []string) 
 	return result, nil
 }
 
+// AflPlayerSearch is the resolver for the aflPlayerSearch field.
+func (r *queryResolver) AflPlayerSearch(ctx context.Context, query string) ([]*AFLPlayer, error) {
+	players, err := r.Queries.SearchPlayers(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return convertPlayers(players), nil
+}
+
 // AFLClub returns AFLClubResolver implementation.
 func (r *Resolver) AFLClub() AFLClubResolver { return &aFLClubResolver{r} }
 

--- a/services/afl/internal/interface/graphql/query.resolvers.go
+++ b/services/afl/internal/interface/graphql/query.resolvers.go
@@ -209,6 +209,37 @@ func (r *queryResolver) AflLatestRound(ctx context.Context) (*AFLRound, error) {
 	return convertRound(round), nil
 }
 
+// AflPlayerSeasonStats is the resolver for the aflPlayerSeasonStats field.
+func (r *queryResolver) AflPlayerSeasonStats(ctx context.Context, ids []string) ([]*AFLPlayerSeasonStats, error) {
+	intIDs := make([]int, len(ids))
+	for i, id := range ids {
+		parsed, err := fromID(id)
+		if err != nil {
+			return nil, fmt.Errorf("invalid id %q: %w", id, err)
+		}
+		intIDs[i] = parsed
+	}
+	stats, err := r.Queries.GetPlayerSeasonStats(ctx, intIDs)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*AFLPlayerSeasonStats, len(stats))
+	for i, s := range stats {
+		result[i] = &AFLPlayerSeasonStats{
+			PlayerSeasonID: toID(s.PlayerSeasonID),
+			GamesPlayed:    s.GamesPlayed,
+			AvgKicks:       s.AvgKicks,
+			AvgHandballs:   s.AvgHandballs,
+			AvgMarks:       s.AvgMarks,
+			AvgHitouts:     s.AvgHitouts,
+			AvgTackles:     s.AvgTackles,
+			AvgGoals:       s.AvgGoals,
+			AvgBehinds:     s.AvgBehinds,
+		}
+	}
+	return result, nil
+}
+
 // AFLClub returns AFLClubResolver implementation.
 func (r *Resolver) AFLClub() AFLClubResolver { return &aFLClubResolver{r} }
 

--- a/services/ffl/api/graphql/mutation.graphqls
+++ b/services/ffl/api/graphql/mutation.graphqls
@@ -6,6 +6,13 @@ type Mutation {
   removeFFLPlayerFromSeason(id: ID!): Boolean!
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
   setFFLLineup(input: SetFFLLineupInput!): [FFLPlayerMatch!]!
+  addFFLRosterPlayer(input: AddFFLRosterPlayerInput!): FFLPlayerSeason!
+}
+
+input AddFFLRosterPlayerInput {
+  aflPlayerId: ID!
+  aflPlayerName: String!
+  clubSeasonId: ID!
 }
 
 input CreateFFLPlayerInput {

--- a/services/ffl/api/graphql/mutation.graphqls
+++ b/services/ffl/api/graphql/mutation.graphqls
@@ -5,6 +5,7 @@ type Mutation {
   addFFLPlayerToSeason(input: AddFFLPlayerToSeasonInput!): FFLPlayerSeason!
   removeFFLPlayerFromSeason(id: ID!): Boolean!
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
+  setFFLLineup(input: SetFFLLineupInput!): [FFLPlayerMatch!]!
 }
 
 input CreateFFLPlayerInput {
@@ -35,4 +36,16 @@ input CalculateFFLFantasyScoreInput {
   marks: Int!
   tackles: Int!
   hitouts: Int!
+}
+
+input SetFFLLineupInput {
+  clubMatchId: ID!
+  players: [FFLLineupPlayerInput!]!
+}
+
+input FFLLineupPlayerInput {
+  playerSeasonId: ID!
+  position: String!
+  backupPositions: String
+  interchangePosition: String
 }

--- a/services/ffl/api/graphql/query.graphqls
+++ b/services/ffl/api/graphql/query.graphqls
@@ -16,6 +16,7 @@ type FFLClub {
 type FFLPlayer {
   id: ID!
   name: String!
+  aflPlayerId: ID
 }
 
 type FFLSeason {

--- a/services/ffl/api/graphql/query.graphqls
+++ b/services/ffl/api/graphql/query.graphqls
@@ -59,6 +59,12 @@ type FFLClubSeason {
   for: Int!
   against: Int!
   percentage: Float!
+  roster: [FFLRosterEntry!]!
+}
+
+type FFLRosterEntry {
+  playerSeasonId: ID!
+  player: FFLPlayer!
 }
 
 type FFLPlayerMatch {

--- a/services/ffl/api/graphql/query.graphqls
+++ b/services/ffl/api/graphql/query.graphqls
@@ -65,6 +65,7 @@ type FFLClubSeason {
 type FFLRosterEntry {
   playerSeasonId: ID!
   player: FFLPlayer!
+  aflPlayerSeasonId: ID
 }
 
 type FFLPlayerMatch {

--- a/services/ffl/gqlgen.yml
+++ b/services/ffl/gqlgen.yml
@@ -37,6 +37,10 @@ models:
       homeClubMatch: { resolver: true }
       awayClubMatch: { resolver: true }
 
+  FFLClubSeason:
+    fields:
+      roster: { resolver: true }
+
   FFLClubMatch:
     fields:
       playerMatches: { resolver: true }

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -84,6 +84,40 @@ func (c *Commands) RemovePlayerFromSeason(ctx context.Context, playerSeasonID in
 	})
 }
 
+// SetLineupEntry represents a single player assignment in a lineup.
+type SetLineupEntry struct {
+	PlayerSeasonID      int
+	Position            string
+	BackupPositions     *string
+	InterchangePosition *string
+}
+
+// SetLineup upserts all player match entries for a club match (the weekly lineup).
+func (c *Commands) SetLineup(ctx context.Context, clubMatchID int, entries []SetLineupEntry) ([]domain.PlayerMatch, error) {
+	var result []domain.PlayerMatch
+	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
+		result = make([]domain.PlayerMatch, len(entries))
+		for i, e := range entries {
+			pos := domain.Position(e.Position)
+			status := domain.PlayerMatchStatusNamed
+			pm, err := repos.PlayerMatches.Upsert(ctx, domain.UpsertPlayerMatchParams{
+				ClubMatchID:         clubMatchID,
+				PlayerSeasonID:      e.PlayerSeasonID,
+				Position:            &pos,
+				Status:              &status,
+				BackupPositions:     e.BackupPositions,
+				InterchangePosition: e.InterchangePosition,
+			})
+			if err != nil {
+				return err
+			}
+			result[i] = pm
+		}
+		return nil
+	})
+	return result, err
+}
+
 // CalculateFantasyScore calculates and stores the fantasy score for a player match
 // based on AFL stats, then recalculates the club match total.
 func (c *Commands) CalculateFantasyScore(ctx context.Context, playerMatchID int, stats domain.AFLStats) (domain.PlayerMatch, error) {

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -32,11 +32,35 @@ func NewCommands(tx TxManager) *Commands {
 func (c *Commands) CreatePlayer(ctx context.Context, name string) (domain.Player, error) {
 	var result domain.Player
 	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
-		p, err := repos.Players.Create(ctx, name)
+		p, err := repos.Players.Create(ctx, name, nil)
 		if err != nil {
 			return err
 		}
 		result = p
+		return nil
+	})
+	return result, err
+}
+
+// AddAFLPlayerToRoster finds or creates an FFL player linked to an AFL player, then adds them to a club season.
+func (c *Commands) AddAFLPlayerToRoster(ctx context.Context, aflPlayerID int, aflPlayerName string, clubSeasonID int) (domain.PlayerSeason, error) {
+	var result domain.PlayerSeason
+	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
+		// Find existing FFL player by AFL player ID
+		player, err := repos.Players.FindByAFLPlayerID(ctx, aflPlayerID)
+		if err != nil {
+			// Not found — create a new FFL player linked to the AFL player
+			player, err = repos.Players.Create(ctx, aflPlayerName, &aflPlayerID)
+			if err != nil {
+				return err
+			}
+		}
+
+		ps, err := repos.PlayerSeasons.Create(ctx, player.ID, clubSeasonID)
+		if err != nil {
+			return err
+		}
+		result = ps
 		return nil
 	})
 	return result, err

--- a/services/ffl/internal/application/commands_test.go
+++ b/services/ffl/internal/application/commands_test.go
@@ -46,8 +46,17 @@ func (r *mockPlayerRepo) FindByID(_ context.Context, id int) (domain.Player, err
 	return p, nil
 }
 
-func (r *mockPlayerRepo) Create(_ context.Context, name string) (domain.Player, error) {
-	p := domain.Player{ID: r.nextID, Name: name}
+func (r *mockPlayerRepo) FindByAFLPlayerID(_ context.Context, aflPlayerID int) (domain.Player, error) {
+	for _, p := range r.players {
+		if p.AFLPlayerID != nil && *p.AFLPlayerID == aflPlayerID {
+			return p, nil
+		}
+	}
+	return domain.Player{}, errors.New("not found")
+}
+
+func (r *mockPlayerRepo) Create(_ context.Context, name string, aflPlayerID *int) (domain.Player, error) {
+	p := domain.Player{ID: r.nextID, Name: name, AFLPlayerID: aflPlayerID}
 	r.players[r.nextID] = p
 	r.nextID++
 	return p, nil
@@ -324,6 +333,67 @@ func TestRemovePlayerFromSeason(t *testing.T) {
 	_, err := psRepo.FindByID(ctx, ps.ID)
 	if err == nil {
 		t.Error("expected error after remove, got nil")
+	}
+}
+
+func TestAddAFLPlayerToRoster_CreatesNewPlayer(t *testing.T) {
+	cmds, playerRepo, psRepo, _, _ := setupCommands()
+	ctx := context.Background()
+
+	ps, err := cmds.AddAFLPlayerToRoster(ctx, 42, "Lachie Neale", 1)
+	if err != nil {
+		t.Fatalf("AddAFLPlayerToRoster: %v", err)
+	}
+
+	// Should have created a new FFL player linked to AFL player 42
+	player, err := playerRepo.FindByAFLPlayerID(ctx, 42)
+	if err != nil {
+		t.Fatalf("FindByAFLPlayerID: %v", err)
+	}
+	if player.Name != "Lachie Neale" {
+		t.Errorf("player name = %q, want %q", player.Name, "Lachie Neale")
+	}
+	if player.AFLPlayerID == nil || *player.AFLPlayerID != 42 {
+		t.Errorf("player AFLPlayerID = %v, want 42", player.AFLPlayerID)
+	}
+
+	// Should have created a player season
+	stored, err := psRepo.FindByID(ctx, ps.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if stored.PlayerID != player.ID || stored.ClubSeasonID != 1 {
+		t.Errorf("player season playerID=%d clubSeasonID=%d, want %d/1", stored.PlayerID, stored.ClubSeasonID, player.ID)
+	}
+}
+
+func TestAddAFLPlayerToRoster_ReusesExistingPlayer(t *testing.T) {
+	cmds, playerRepo, _, _, _ := setupCommands()
+	ctx := context.Background()
+
+	// Pre-create an FFL player linked to AFL player 42
+	aflID := 42
+	existing, _ := playerRepo.Create(ctx, "Lachie Neale", &aflID)
+
+	ps, err := cmds.AddAFLPlayerToRoster(ctx, 42, "Lachie Neale", 1)
+	if err != nil {
+		t.Fatalf("AddAFLPlayerToRoster: %v", err)
+	}
+
+	// Should reuse the existing player, not create a new one
+	if ps.PlayerID != existing.ID {
+		t.Errorf("playerID = %d, want %d (existing)", ps.PlayerID, existing.ID)
+	}
+
+	// Should still only have one player with that AFL ID
+	count := 0
+	for _, p := range playerRepo.players {
+		if p.AFLPlayerID != nil && *p.AFLPlayerID == 42 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 player with AFL ID 42, got %d", count)
 	}
 }
 

--- a/services/ffl/internal/domain/player.go
+++ b/services/ffl/internal/domain/player.go
@@ -3,8 +3,9 @@ package domain
 import "context"
 
 type Player struct {
-	ID   int
-	Name string
+	ID          int
+	Name        string
+	AFLPlayerID *int
 }
 
 type PlayerRepository interface {

--- a/services/ffl/internal/domain/player.go
+++ b/services/ffl/internal/domain/player.go
@@ -11,7 +11,8 @@ type Player struct {
 type PlayerRepository interface {
 	FindAll(ctx context.Context) ([]Player, error)
 	FindByID(ctx context.Context, id int) (Player, error)
-	Create(ctx context.Context, name string) (Player, error)
+	FindByAFLPlayerID(ctx context.Context, aflPlayerID int) (Player, error)
+	Create(ctx context.Context, name string, aflPlayerID *int) (Player, error)
 	Update(ctx context.Context, id int, name string) (Player, error)
 	Delete(ctx context.Context, id int) error
 }

--- a/services/ffl/internal/domain/player_match.go
+++ b/services/ffl/internal/domain/player_match.go
@@ -6,23 +6,23 @@ import "context"
 type Position string
 
 const (
-	PositionGoals    Position = "goals"
-	PositionKicks    Position = "kicks"
+	PositionGoals     Position = "goals"
+	PositionKicks     Position = "kicks"
 	PositionHandballs Position = "handballs"
-	PositionMarks    Position = "marks"
-	PositionTackles  Position = "tackles"
-	PositionHitouts  Position = "hitouts"
-	PositionStar     Position = "star"
+	PositionMarks     Position = "marks"
+	PositionTackles   Position = "tackles"
+	PositionHitouts   Position = "hitouts"
+	PositionStar      Position = "star"
 )
 
 // Scoring multipliers per position.
 const (
-	GoalsMultiplier    = 5
-	KicksMultiplier    = 1
+	GoalsMultiplier     = 5
+	KicksMultiplier     = 1
 	HandballsMultiplier = 1
-	MarksMultiplier    = 2
-	TacklesMultiplier  = 4
-	HitoutsMultiplier  = 1
+	MarksMultiplier     = 2
+	TacklesMultiplier   = 4
+	HitoutsMultiplier   = 1
 )
 
 // PlayerMatchStatus reflects the player's AFL match status (denormalised from AFL data).
@@ -36,12 +36,12 @@ const (
 
 // AFLStats holds the AFL performance statistics used to calculate fantasy scores.
 type AFLStats struct {
-	Goals    int
-	Kicks    int
+	Goals     int
+	Kicks     int
 	Handballs int
-	Marks    int
-	Tackles  int
-	Hitouts  int
+	Marks     int
+	Tackles   int
+	Hitouts   int
 }
 
 type PlayerMatch struct {
@@ -53,6 +53,7 @@ type PlayerMatch struct {
 	BackupPositions     *string
 	InterchangePosition *string
 	Score               int
+	AFLPlayerMatchID    *int
 }
 
 // isBench returns true if this player is on the bench (has backup or interchange positions).
@@ -91,7 +92,7 @@ func (pm PlayerMatch) CalculateScore(stats AFLStats) int {
 }
 
 // Ptr helpers for use in struct literals.
-func PositionPtr(p Position) *Position                { return &p }
+func PositionPtr(p Position) *Position                            { return &p }
 func PlayerMatchStatusPtr(s PlayerMatchStatus) *PlayerMatchStatus { return &s }
 
 type PlayerMatchRepository interface {

--- a/services/ffl/internal/domain/player_season.go
+++ b/services/ffl/internal/domain/player_season.go
@@ -3,9 +3,10 @@ package domain
 import "context"
 
 type PlayerSeason struct {
-	ID           int
-	PlayerID     int
-	ClubSeasonID int
+	ID                 int
+	PlayerID           int
+	ClubSeasonID       int
+	AFLPlayerSeasonID  *int
 }
 
 type PlayerSeasonRepository interface {

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -194,7 +194,7 @@ func (r *MatchRepository) hydrateClubMatch(ctx context.Context, cm *domain.ClubM
 	cm.PlayerMatches = make([]domain.PlayerMatch, len(pmRows))
 	for i, pmRow := range pmRows {
 		cm.PlayerMatches[i] = toPlayerMatch(pmRow.ID, pmRow.ClubMatchID, pmRow.PlayerSeasonID,
-			pmRow.Position, pmRow.Status, pmRow.BackupPositions, pmRow.InterchangePosition, pmRow.Score)
+			pmRow.Position, pmRow.Status, pmRow.BackupPositions, pmRow.InterchangePosition, pmRow.Score, pmRow.AflPlayerMatchID)
 	}
 	return nil
 }
@@ -392,7 +392,7 @@ func statusPtr(s *string) *domain.PlayerMatchStatus {
 	return &st
 }
 
-func toPlayerMatch(id, clubMatchID, playerSeasonID int32, position, status *string, backupPositions, interchangePosition *string, score *int32) domain.PlayerMatch {
+func toPlayerMatch(id, clubMatchID, playerSeasonID int32, position, status *string, backupPositions, interchangePosition *string, score *int32, aflPlayerMatchID *int32) domain.PlayerMatch {
 	return domain.PlayerMatch{
 		ID:                  int(id),
 		ClubMatchID:         int(clubMatchID),
@@ -402,6 +402,7 @@ func toPlayerMatch(id, clubMatchID, playerSeasonID int32, position, status *stri
 		BackupPositions:     backupPositions,
 		InterchangePosition: interchangePosition,
 		Score:               derefOr(score),
+		AFLPlayerMatchID:    int32PtrToIntPtr(aflPlayerMatchID),
 	}
 }
 
@@ -413,7 +414,7 @@ func (r *PlayerMatchRepository) FindByClubMatchID(ctx context.Context, clubMatch
 	out := make([]domain.PlayerMatch, len(rows))
 	for i, row := range rows {
 		out[i] = toPlayerMatch(row.ID, row.ClubMatchID, row.PlayerSeasonID,
-			row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.Score)
+			row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.Score, row.AflPlayerMatchID)
 	}
 	return out, nil
 }
@@ -424,7 +425,7 @@ func (r *PlayerMatchRepository) FindByID(ctx context.Context, id int) (domain.Pl
 		return domain.PlayerMatch{}, err
 	}
 	return toPlayerMatch(row.ID, row.ClubMatchID, row.PlayerSeasonID,
-		row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.Score), nil
+		row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.Score, row.AflPlayerMatchID), nil
 }
 
 func posToStringPtr(p *domain.Position) *string {
@@ -457,7 +458,7 @@ func (r *PlayerMatchRepository) Upsert(ctx context.Context, params domain.Upsert
 		return domain.PlayerMatch{}, err
 	}
 	return toPlayerMatch(row.ID, row.ClubMatchID, row.PlayerSeasonID,
-		row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.Score), nil
+		row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.Score, row.AflPlayerMatchID), nil
 }
 
 // --- PlayerSeason ---
@@ -475,7 +476,7 @@ func (r *PlayerSeasonRepository) FindByClubSeasonID(ctx context.Context, clubSea
 	}
 	out := make([]domain.PlayerSeason, len(rows))
 	for i, row := range rows {
-		out[i] = domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID)}
+		out[i] = domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID), AFLPlayerSeasonID: int32PtrToIntPtr(row.AflPlayerSeasonID)}
 	}
 	return out, nil
 }
@@ -485,7 +486,7 @@ func (r *PlayerSeasonRepository) FindByID(ctx context.Context, id int) (domain.P
 	if err != nil {
 		return domain.PlayerSeason{}, err
 	}
-	return domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID)}, nil
+	return domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID), AFLPlayerSeasonID: int32PtrToIntPtr(row.AflPlayerSeasonID)}, nil
 }
 
 func (r *PlayerSeasonRepository) Create(ctx context.Context, playerID int, clubSeasonID int) (domain.PlayerSeason, error) {
@@ -496,7 +497,7 @@ func (r *PlayerSeasonRepository) Create(ctx context.Context, playerID int, clubS
 	if err != nil {
 		return domain.PlayerSeason{}, err
 	}
-	return domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID)}, nil
+	return domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID), AFLPlayerSeasonID: int32PtrToIntPtr(row.AflPlayerSeasonID)}, nil
 }
 
 func (r *PlayerSeasonRepository) Delete(ctx context.Context, id int) error {

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -341,10 +341,18 @@ func (r *PlayerRepository) FindByID(ctx context.Context, id int) (domain.Player,
 	return playerFromRow(row.ID, row.Name, row.AflPlayerID), nil
 }
 
-func (r *PlayerRepository) Create(ctx context.Context, name string) (domain.Player, error) {
+func (r *PlayerRepository) FindByAFLPlayerID(ctx context.Context, aflPlayerID int) (domain.Player, error) {
+	row, err := r.q.FindPlayerByAFLPlayerID(ctx, intPtrToInt32Ptr(&aflPlayerID))
+	if err != nil {
+		return domain.Player{}, err
+	}
+	return playerFromRow(row.ID, row.Name, row.AflPlayerID), nil
+}
+
+func (r *PlayerRepository) Create(ctx context.Context, name string, aflPlayerID *int) (domain.Player, error) {
 	row, err := r.q.CreatePlayer(ctx, sqlcgen.CreatePlayerParams{
 		Name:        name,
-		AflPlayerID: nil,
+		AflPlayerID: intPtrToInt32Ptr(aflPlayerID),
 	})
 	if err != nil {
 		return domain.Player{}, err

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -301,6 +301,26 @@ func NewPlayerRepository(q *sqlcgen.Queries) *PlayerRepository {
 	return &PlayerRepository{q: q}
 }
 
+func int32PtrToIntPtr(v *int32) *int {
+	if v == nil {
+		return nil
+	}
+	i := int(*v)
+	return &i
+}
+
+func intPtrToInt32Ptr(v *int) *int32 {
+	if v == nil {
+		return nil
+	}
+	i := int32(*v)
+	return &i
+}
+
+func playerFromRow(id int32, name string, aflPlayerID *int32) domain.Player {
+	return domain.Player{ID: int(id), Name: name, AFLPlayerID: int32PtrToIntPtr(aflPlayerID)}
+}
+
 func (r *PlayerRepository) FindAll(ctx context.Context) ([]domain.Player, error) {
 	rows, err := r.q.FindAllPlayers(ctx)
 	if err != nil {
@@ -308,7 +328,7 @@ func (r *PlayerRepository) FindAll(ctx context.Context) ([]domain.Player, error)
 	}
 	out := make([]domain.Player, len(rows))
 	for i, row := range rows {
-		out[i] = domain.Player{ID: int(row.ID), Name: row.Name}
+		out[i] = playerFromRow(row.ID, row.Name, row.AflPlayerID)
 	}
 	return out, nil
 }
@@ -318,26 +338,30 @@ func (r *PlayerRepository) FindByID(ctx context.Context, id int) (domain.Player,
 	if err != nil {
 		return domain.Player{}, err
 	}
-	return domain.Player{ID: int(row.ID), Name: row.Name}, nil
+	return playerFromRow(row.ID, row.Name, row.AflPlayerID), nil
 }
 
 func (r *PlayerRepository) Create(ctx context.Context, name string) (domain.Player, error) {
-	row, err := r.q.CreatePlayer(ctx, name)
-	if err != nil {
-		return domain.Player{}, err
-	}
-	return domain.Player{ID: int(row.ID), Name: row.Name}, nil
-}
-
-func (r *PlayerRepository) Update(ctx context.Context, id int, name string) (domain.Player, error) {
-	row, err := r.q.UpdatePlayer(ctx, sqlcgen.UpdatePlayerParams{
-		ID:   int32(id),
-		Name: name,
+	row, err := r.q.CreatePlayer(ctx, sqlcgen.CreatePlayerParams{
+		Name:        name,
+		AflPlayerID: nil,
 	})
 	if err != nil {
 		return domain.Player{}, err
 	}
-	return domain.Player{ID: int(row.ID), Name: row.Name}, nil
+	return playerFromRow(row.ID, row.Name, row.AflPlayerID), nil
+}
+
+func (r *PlayerRepository) Update(ctx context.Context, id int, name string) (domain.Player, error) {
+	row, err := r.q.UpdatePlayer(ctx, sqlcgen.UpdatePlayerParams{
+		ID:          int32(id),
+		Name:        name,
+		AflPlayerID: nil,
+	})
+	if err != nil {
+		return domain.Player{}, err
+	}
+	return playerFromRow(row.ID, row.Name, row.AflPlayerID), nil
 }
 
 func (r *PlayerRepository) Delete(ctx context.Context, id int) error {

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player.sql
@@ -22,6 +22,11 @@ SET name = $2,
 WHERE id = $1 AND deleted_at IS NULL
 RETURNING id, name, afl_player_id;
 
+-- name: FindPlayerByAFLPlayerID :one
+SELECT id, name, afl_player_id
+FROM ffl.player
+WHERE afl_player_id = $1 AND deleted_at IS NULL;
+
 -- name: DeletePlayer :exec
 UPDATE ffl.player
 SET deleted_at = CURRENT_TIMESTAMP,

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player.sql
@@ -1,25 +1,26 @@
 -- name: FindAllPlayers :many
-SELECT id, name
+SELECT id, name, afl_player_id
 FROM ffl.player
 WHERE deleted_at IS NULL
 ORDER BY name;
 
 -- name: FindPlayerByID :one
-SELECT id, name
+SELECT id, name, afl_player_id
 FROM ffl.player
 WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: CreatePlayer :one
-INSERT INTO ffl.player (name)
-VALUES ($1)
-RETURNING id, name;
+INSERT INTO ffl.player (name, afl_player_id)
+VALUES ($1, $2)
+RETURNING id, name, afl_player_id;
 
 -- name: UpdatePlayer :one
 UPDATE ffl.player
 SET name = $2,
+    afl_player_id = $3,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND deleted_at IS NULL
-RETURNING id, name;
+RETURNING id, name, afl_player_id;
 
 -- name: DeletePlayer :exec
 UPDATE ffl.player

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
@@ -1,12 +1,12 @@
 -- name: FindPlayerMatchesByClubMatchID :many
 SELECT id, club_match_id, player_season_id,
-       position, status, backup_positions, interchange_position, score
+       position, status, backup_positions, interchange_position, score, afl_player_match_id
 FROM ffl.player_match
 WHERE club_match_id = $1 AND deleted_at IS NULL;
 
 -- name: FindPlayerMatchByID :one
 SELECT id, club_match_id, player_season_id,
-       position, status, backup_positions, interchange_position, score
+       position, status, backup_positions, interchange_position, score, afl_player_match_id
 FROM ffl.player_match
 WHERE id = $1 AND deleted_at IS NULL;
 
@@ -22,4 +22,4 @@ DO UPDATE SET
     score = COALESCE($7, ffl.player_match.score),
     updated_at = CURRENT_TIMESTAMP
 WHERE ffl.player_match.deleted_at IS NULL
-RETURNING id, club_match_id, player_season_id, position, status, backup_positions, interchange_position, score;
+RETURNING id, club_match_id, player_season_id, position, status, backup_positions, interchange_position, score, afl_player_match_id;

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player_season.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player_season.sql
@@ -1,17 +1,17 @@
 -- name: FindPlayerSeasonsByClubSeasonID :many
-SELECT id, player_id, club_season_id
+SELECT id, player_id, club_season_id, afl_player_season_id
 FROM ffl.player_season
 WHERE club_season_id = $1 AND deleted_at IS NULL;
 
 -- name: FindPlayerSeasonByID :one
-SELECT id, player_id, club_season_id
+SELECT id, player_id, club_season_id, afl_player_season_id
 FROM ffl.player_season
 WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: CreatePlayerSeason :one
 INSERT INTO ffl.player_season (player_id, club_season_id)
 VALUES ($1, $2)
-RETURNING id, player_id, club_season_id;
+RETURNING id, player_id, club_season_id, afl_player_season_id;
 
 -- name: DeletePlayerSeason :exec
 UPDATE ffl.player_season

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/models.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/models.go
@@ -89,17 +89,19 @@ type FflPlayerMatch struct {
 	BackupPositions     *string
 	InterchangePosition *string
 	Score               *int32
+	AflPlayerMatchID    *int32
 }
 
 type FflPlayerSeason struct {
-	ID           int32
-	CreatedAt    pgtype.Timestamptz
-	UpdatedAt    pgtype.Timestamptz
-	DeletedAt    pgtype.Timestamptz
-	PlayerID     int32
-	ClubSeasonID int32
-	FromRoundID  *int32
-	ToRoundID    *int32
+	ID                int32
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	PlayerID          int32
+	ClubSeasonID      int32
+	FromRoundID       *int32
+	ToRoundID         *int32
+	AflPlayerSeasonID *int32
 }
 
 type FflRound struct {

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/models.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/models.go
@@ -68,12 +68,13 @@ type FflMatch struct {
 }
 
 type FflPlayer struct {
-	ID        int32
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-	DeletedAt pgtype.Timestamptz
-	Name      string
-	ClubID    *int32
+	ID          int32
+	CreatedAt   pgtype.Timestamptz
+	UpdatedAt   pgtype.Timestamptz
+	DeletedAt   pgtype.Timestamptz
+	Name        string
+	ClubID      *int32
+	AflPlayerID *int32
 }
 
 type FflPlayerMatch struct {

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player.sql.go
@@ -10,20 +10,26 @@ import (
 )
 
 const createPlayer = `-- name: CreatePlayer :one
-INSERT INTO ffl.player (name)
-VALUES ($1)
-RETURNING id, name
+INSERT INTO ffl.player (name, afl_player_id)
+VALUES ($1, $2)
+RETURNING id, name, afl_player_id
 `
 
-type CreatePlayerRow struct {
-	ID   int32
-	Name string
+type CreatePlayerParams struct {
+	Name        string
+	AflPlayerID *int32
 }
 
-func (q *Queries) CreatePlayer(ctx context.Context, name string) (CreatePlayerRow, error) {
-	row := q.db.QueryRow(ctx, createPlayer, name)
+type CreatePlayerRow struct {
+	ID          int32
+	Name        string
+	AflPlayerID *int32
+}
+
+func (q *Queries) CreatePlayer(ctx context.Context, arg CreatePlayerParams) (CreatePlayerRow, error) {
+	row := q.db.QueryRow(ctx, createPlayer, arg.Name, arg.AflPlayerID)
 	var i CreatePlayerRow
-	err := row.Scan(&i.ID, &i.Name)
+	err := row.Scan(&i.ID, &i.Name, &i.AflPlayerID)
 	return i, err
 }
 
@@ -40,15 +46,16 @@ func (q *Queries) DeletePlayer(ctx context.Context, id int32) error {
 }
 
 const findAllPlayers = `-- name: FindAllPlayers :many
-SELECT id, name
+SELECT id, name, afl_player_id
 FROM ffl.player
 WHERE deleted_at IS NULL
 ORDER BY name
 `
 
 type FindAllPlayersRow struct {
-	ID   int32
-	Name string
+	ID          int32
+	Name        string
+	AflPlayerID *int32
 }
 
 func (q *Queries) FindAllPlayers(ctx context.Context) ([]FindAllPlayersRow, error) {
@@ -60,7 +67,7 @@ func (q *Queries) FindAllPlayers(ctx context.Context) ([]FindAllPlayersRow, erro
 	items := []FindAllPlayersRow{}
 	for rows.Next() {
 		var i FindAllPlayersRow
-		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+		if err := rows.Scan(&i.ID, &i.Name, &i.AflPlayerID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -72,44 +79,48 @@ func (q *Queries) FindAllPlayers(ctx context.Context) ([]FindAllPlayersRow, erro
 }
 
 const findPlayerByID = `-- name: FindPlayerByID :one
-SELECT id, name
+SELECT id, name, afl_player_id
 FROM ffl.player
 WHERE id = $1 AND deleted_at IS NULL
 `
 
 type FindPlayerByIDRow struct {
-	ID   int32
-	Name string
+	ID          int32
+	Name        string
+	AflPlayerID *int32
 }
 
 func (q *Queries) FindPlayerByID(ctx context.Context, id int32) (FindPlayerByIDRow, error) {
 	row := q.db.QueryRow(ctx, findPlayerByID, id)
 	var i FindPlayerByIDRow
-	err := row.Scan(&i.ID, &i.Name)
+	err := row.Scan(&i.ID, &i.Name, &i.AflPlayerID)
 	return i, err
 }
 
 const updatePlayer = `-- name: UpdatePlayer :one
 UPDATE ffl.player
 SET name = $2,
+    afl_player_id = $3,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND deleted_at IS NULL
-RETURNING id, name
+RETURNING id, name, afl_player_id
 `
 
 type UpdatePlayerParams struct {
-	ID   int32
-	Name string
+	ID          int32
+	Name        string
+	AflPlayerID *int32
 }
 
 type UpdatePlayerRow struct {
-	ID   int32
-	Name string
+	ID          int32
+	Name        string
+	AflPlayerID *int32
 }
 
 func (q *Queries) UpdatePlayer(ctx context.Context, arg UpdatePlayerParams) (UpdatePlayerRow, error) {
-	row := q.db.QueryRow(ctx, updatePlayer, arg.ID, arg.Name)
+	row := q.db.QueryRow(ctx, updatePlayer, arg.ID, arg.Name, arg.AflPlayerID)
 	var i UpdatePlayerRow
-	err := row.Scan(&i.ID, &i.Name)
+	err := row.Scan(&i.ID, &i.Name, &i.AflPlayerID)
 	return i, err
 }

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player.sql.go
@@ -78,6 +78,25 @@ func (q *Queries) FindAllPlayers(ctx context.Context) ([]FindAllPlayersRow, erro
 	return items, nil
 }
 
+const findPlayerByAFLPlayerID = `-- name: FindPlayerByAFLPlayerID :one
+SELECT id, name, afl_player_id
+FROM ffl.player
+WHERE afl_player_id = $1 AND deleted_at IS NULL
+`
+
+type FindPlayerByAFLPlayerIDRow struct {
+	ID          int32
+	Name        string
+	AflPlayerID *int32
+}
+
+func (q *Queries) FindPlayerByAFLPlayerID(ctx context.Context, aflPlayerID *int32) (FindPlayerByAFLPlayerIDRow, error) {
+	row := q.db.QueryRow(ctx, findPlayerByAFLPlayerID, aflPlayerID)
+	var i FindPlayerByAFLPlayerIDRow
+	err := row.Scan(&i.ID, &i.Name, &i.AflPlayerID)
+	return i, err
+}
+
 const findPlayerByID = `-- name: FindPlayerByID :one
 SELECT id, name, afl_player_id
 FROM ffl.player

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
@@ -11,7 +11,7 @@ import (
 
 const findPlayerMatchByID = `-- name: FindPlayerMatchByID :one
 SELECT id, club_match_id, player_season_id,
-       position, status, backup_positions, interchange_position, score
+       position, status, backup_positions, interchange_position, score, afl_player_match_id
 FROM ffl.player_match
 WHERE id = $1 AND deleted_at IS NULL
 `
@@ -25,6 +25,7 @@ type FindPlayerMatchByIDRow struct {
 	BackupPositions     *string
 	InterchangePosition *string
 	Score               *int32
+	AflPlayerMatchID    *int32
 }
 
 func (q *Queries) FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayerMatchByIDRow, error) {
@@ -39,13 +40,14 @@ func (q *Queries) FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayer
 		&i.BackupPositions,
 		&i.InterchangePosition,
 		&i.Score,
+		&i.AflPlayerMatchID,
 	)
 	return i, err
 }
 
 const findPlayerMatchesByClubMatchID = `-- name: FindPlayerMatchesByClubMatchID :many
 SELECT id, club_match_id, player_season_id,
-       position, status, backup_positions, interchange_position, score
+       position, status, backup_positions, interchange_position, score, afl_player_match_id
 FROM ffl.player_match
 WHERE club_match_id = $1 AND deleted_at IS NULL
 `
@@ -59,6 +61,7 @@ type FindPlayerMatchesByClubMatchIDRow struct {
 	BackupPositions     *string
 	InterchangePosition *string
 	Score               *int32
+	AflPlayerMatchID    *int32
 }
 
 func (q *Queries) FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) ([]FindPlayerMatchesByClubMatchIDRow, error) {
@@ -79,6 +82,7 @@ func (q *Queries) FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchI
 			&i.BackupPositions,
 			&i.InterchangePosition,
 			&i.Score,
+			&i.AflPlayerMatchID,
 		); err != nil {
 			return nil, err
 		}
@@ -102,7 +106,7 @@ DO UPDATE SET
     score = COALESCE($7, ffl.player_match.score),
     updated_at = CURRENT_TIMESTAMP
 WHERE ffl.player_match.deleted_at IS NULL
-RETURNING id, club_match_id, player_season_id, position, status, backup_positions, interchange_position, score
+RETURNING id, club_match_id, player_season_id, position, status, backup_positions, interchange_position, score, afl_player_match_id
 `
 
 type UpsertPlayerMatchParams struct {
@@ -124,6 +128,7 @@ type UpsertPlayerMatchRow struct {
 	BackupPositions     *string
 	InterchangePosition *string
 	Score               *int32
+	AflPlayerMatchID    *int32
 }
 
 func (q *Queries) UpsertPlayerMatch(ctx context.Context, arg UpsertPlayerMatchParams) (UpsertPlayerMatchRow, error) {
@@ -146,6 +151,7 @@ func (q *Queries) UpsertPlayerMatch(ctx context.Context, arg UpsertPlayerMatchPa
 		&i.BackupPositions,
 		&i.InterchangePosition,
 		&i.Score,
+		&i.AflPlayerMatchID,
 	)
 	return i, err
 }

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player_season.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player_season.sql.go
@@ -12,7 +12,7 @@ import (
 const createPlayerSeason = `-- name: CreatePlayerSeason :one
 INSERT INTO ffl.player_season (player_id, club_season_id)
 VALUES ($1, $2)
-RETURNING id, player_id, club_season_id
+RETURNING id, player_id, club_season_id, afl_player_season_id
 `
 
 type CreatePlayerSeasonParams struct {
@@ -21,15 +21,21 @@ type CreatePlayerSeasonParams struct {
 }
 
 type CreatePlayerSeasonRow struct {
-	ID           int32
-	PlayerID     int32
-	ClubSeasonID int32
+	ID                int32
+	PlayerID          int32
+	ClubSeasonID      int32
+	AflPlayerSeasonID *int32
 }
 
 func (q *Queries) CreatePlayerSeason(ctx context.Context, arg CreatePlayerSeasonParams) (CreatePlayerSeasonRow, error) {
 	row := q.db.QueryRow(ctx, createPlayerSeason, arg.PlayerID, arg.ClubSeasonID)
 	var i CreatePlayerSeasonRow
-	err := row.Scan(&i.ID, &i.PlayerID, &i.ClubSeasonID)
+	err := row.Scan(
+		&i.ID,
+		&i.PlayerID,
+		&i.ClubSeasonID,
+		&i.AflPlayerSeasonID,
+	)
 	return i, err
 }
 
@@ -46,34 +52,41 @@ func (q *Queries) DeletePlayerSeason(ctx context.Context, id int32) error {
 }
 
 const findPlayerSeasonByID = `-- name: FindPlayerSeasonByID :one
-SELECT id, player_id, club_season_id
+SELECT id, player_id, club_season_id, afl_player_season_id
 FROM ffl.player_season
 WHERE id = $1 AND deleted_at IS NULL
 `
 
 type FindPlayerSeasonByIDRow struct {
-	ID           int32
-	PlayerID     int32
-	ClubSeasonID int32
+	ID                int32
+	PlayerID          int32
+	ClubSeasonID      int32
+	AflPlayerSeasonID *int32
 }
 
 func (q *Queries) FindPlayerSeasonByID(ctx context.Context, id int32) (FindPlayerSeasonByIDRow, error) {
 	row := q.db.QueryRow(ctx, findPlayerSeasonByID, id)
 	var i FindPlayerSeasonByIDRow
-	err := row.Scan(&i.ID, &i.PlayerID, &i.ClubSeasonID)
+	err := row.Scan(
+		&i.ID,
+		&i.PlayerID,
+		&i.ClubSeasonID,
+		&i.AflPlayerSeasonID,
+	)
 	return i, err
 }
 
 const findPlayerSeasonsByClubSeasonID = `-- name: FindPlayerSeasonsByClubSeasonID :many
-SELECT id, player_id, club_season_id
+SELECT id, player_id, club_season_id, afl_player_season_id
 FROM ffl.player_season
 WHERE club_season_id = $1 AND deleted_at IS NULL
 `
 
 type FindPlayerSeasonsByClubSeasonIDRow struct {
-	ID           int32
-	PlayerID     int32
-	ClubSeasonID int32
+	ID                int32
+	PlayerID          int32
+	ClubSeasonID      int32
+	AflPlayerSeasonID *int32
 }
 
 func (q *Queries) FindPlayerSeasonsByClubSeasonID(ctx context.Context, clubSeasonID int32) ([]FindPlayerSeasonsByClubSeasonIDRow, error) {
@@ -85,7 +98,12 @@ func (q *Queries) FindPlayerSeasonsByClubSeasonID(ctx context.Context, clubSeaso
 	items := []FindPlayerSeasonsByClubSeasonIDRow{}
 	for rows.Next() {
 		var i FindPlayerSeasonsByClubSeasonIDRow
-		if err := rows.Scan(&i.ID, &i.PlayerID, &i.ClubSeasonID); err != nil {
+		if err := rows.Scan(
+			&i.ID,
+			&i.PlayerID,
+			&i.ClubSeasonID,
+			&i.AflPlayerSeasonID,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	CreatePlayer(ctx context.Context, name string) (CreatePlayerRow, error)
+	CreatePlayer(ctx context.Context, arg CreatePlayerParams) (CreatePlayerRow, error)
 	CreatePlayerSeason(ctx context.Context, arg CreatePlayerSeasonParams) (CreatePlayerSeasonRow, error)
 	DeletePlayer(ctx context.Context, id int32) error
 	DeletePlayerSeason(ctx context.Context, id int32) error

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -24,6 +24,7 @@ type Querier interface {
 	FindLatestRound(ctx context.Context) (FindLatestRoundRow, error)
 	FindMatchByID(ctx context.Context, id int32) (FindMatchByIDRow, error)
 	FindMatchesByRoundID(ctx context.Context, roundID int32) ([]FindMatchesByRoundIDRow, error)
+	FindPlayerByAFLPlayerID(ctx context.Context, aflPlayerID *int32) (FindPlayerByAFLPlayerIDRow, error)
 	FindPlayerByID(ctx context.Context, id int32) (FindPlayerByIDRow, error)
 	FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayerMatchByIDRow, error)
 	FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) ([]FindPlayerMatchesByClubMatchIDRow, error)

--- a/services/ffl/internal/interface/graphql/convert.go
+++ b/services/ffl/internal/interface/graphql/convert.go
@@ -34,7 +34,12 @@ func convertClubs(clubs []domain.Club) []*FFLClub {
 }
 
 func convertPlayer(p domain.Player) *FFLPlayer {
-	return &FFLPlayer{ID: toID(p.ID), Name: p.Name}
+	player := &FFLPlayer{ID: toID(p.ID), Name: p.Name}
+	if p.AFLPlayerID != nil {
+		id := toID(*p.AFLPlayerID)
+		player.AflPlayerID = &id
+	}
+	return player
 }
 
 func convertPlayers(players []domain.Player) []*FFLPlayer {

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -97,8 +97,9 @@ type ComplexityRoot struct {
 	}
 
 	FFLRosterEntry struct {
-		Player         func(childComplexity int) int
-		PlayerSeasonID func(childComplexity int) int
+		AflPlayerSeasonID func(childComplexity int) int
+		Player            func(childComplexity int) int
+		PlayerSeasonID    func(childComplexity int) int
 	}
 
 	FFLRound struct {
@@ -410,6 +411,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.FFLPlayerSeason.PlayerID(childComplexity), true
 
+	case "FFLRosterEntry.aflPlayerSeasonId":
+		if e.ComplexityRoot.FFLRosterEntry.AflPlayerSeasonID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLRosterEntry.AflPlayerSeasonID(childComplexity), true
 	case "FFLRosterEntry.player":
 		if e.ComplexityRoot.FFLRosterEntry.Player == nil {
 			break
@@ -817,6 +824,7 @@ type FFLClubSeason {
 type FFLRosterEntry {
   playerSeasonId: ID!
   player: FFLPlayer!
+  aflPlayerSeasonId: ID
 }
 
 type FFLPlayerMatch {
@@ -1503,6 +1511,8 @@ func (ec *executionContext) fieldContext_FFLClubSeason_roster(_ context.Context,
 				return ec.fieldContext_FFLRosterEntry_playerSeasonId(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLRosterEntry_player(ctx, field)
+			case "aflPlayerSeasonId":
+				return ec.fieldContext_FFLRosterEntry_aflPlayerSeasonId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLRosterEntry", field.Name)
 		},
@@ -2179,6 +2189,35 @@ func (ec *executionContext) fieldContext_FFLRosterEntry_player(_ context.Context
 				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FFLRosterEntry_aflPlayerSeasonId(ctx context.Context, field graphql.CollectedField, obj *FFLRosterEntry) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLRosterEntry_aflPlayerSeasonId,
+		func(ctx context.Context) (any, error) {
+			return obj.AflPlayerSeasonID, nil
+		},
+		nil,
+		ec.marshalOID2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLRosterEntry_aflPlayerSeasonId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLRosterEntry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -5475,6 +5514,8 @@ func (ec *executionContext) _FFLRosterEntry(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "aflPlayerSeasonId":
+			out.Values[i] = ec._FFLRosterEntry_aflPlayerSeasonId(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -118,6 +118,7 @@ type ComplexityRoot struct {
 
 	Mutation struct {
 		AddFFLPlayerToSeason      func(childComplexity int, input AddFFLPlayerToSeasonInput) int
+		AddFFLRosterPlayer        func(childComplexity int, input AddFFLRosterPlayerInput) int
 		CalculateFFLFantasyScore  func(childComplexity int, input CalculateFFLFantasyScoreInput) int
 		CreateFFLPlayer           func(childComplexity int, input CreateFFLPlayerInput) int
 		DeleteFFLPlayer           func(childComplexity int, id string) int
@@ -163,6 +164,7 @@ type MutationResolver interface {
 	RemoveFFLPlayerFromSeason(ctx context.Context, id string) (bool, error)
 	CalculateFFLFantasyScore(ctx context.Context, input CalculateFFLFantasyScoreInput) (*FFLPlayerMatch, error)
 	SetFFLLineup(ctx context.Context, input SetFFLLineupInput) ([]*FFLPlayerMatch, error)
+	AddFFLRosterPlayer(ctx context.Context, input AddFFLRosterPlayerInput) (*FFLPlayerSeason, error)
 }
 type QueryResolver interface {
 	FflClubs(ctx context.Context) ([]*FFLClub, error)
@@ -491,6 +493,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.AddFFLPlayerToSeason(childComplexity, args["input"].(AddFFLPlayerToSeasonInput)), true
+	case "Mutation.addFFLRosterPlayer":
+		if e.ComplexityRoot.Mutation.AddFFLRosterPlayer == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_addFFLRosterPlayer_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.AddFFLRosterPlayer(childComplexity, args["input"].(AddFFLRosterPlayerInput)), true
 	case "Mutation.calculateFFLFantasyScore":
 		if e.ComplexityRoot.Mutation.CalculateFFLFantasyScore == nil {
 			break
@@ -625,6 +638,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := newExecutionContext(opCtx, e, make(chan graphql.DeferredResult))
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAddFFLPlayerToSeasonInput,
+		ec.unmarshalInputAddFFLRosterPlayerInput,
 		ec.unmarshalInputCalculateFFLFantasyScoreInput,
 		ec.unmarshalInputCreateFFLPlayerInput,
 		ec.unmarshalInputFFLLineupPlayerInput,
@@ -713,6 +727,13 @@ var sources = []*ast.Source{
   removeFFLPlayerFromSeason(id: ID!): Boolean!
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
   setFFLLineup(input: SetFFLLineupInput!): [FFLPlayerMatch!]!
+  addFFLRosterPlayer(input: AddFFLRosterPlayerInput!): FFLPlayerSeason!
+}
+
+input AddFFLRosterPlayerInput {
+  aflPlayerId: ID!
+  aflPlayerName: String!
+  clubSeasonId: ID!
 }
 
 input CreateFFLPlayerInput {
@@ -849,6 +870,17 @@ func (ec *executionContext) field_Mutation_addFFLPlayerToSeason_args(ctx context
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNAddFFLPlayerToSeasonInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐAddFFLPlayerToSeasonInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_addFFLRosterPlayer_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNAddFFLRosterPlayerInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐAddFFLRosterPlayerInput)
 	if err != nil {
 		return nil, err
 	}
@@ -2858,6 +2890,55 @@ func (ec *executionContext) fieldContext_Mutation_setFFLLineup(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_addFFLRosterPlayer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_addFFLRosterPlayer,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().AddFFLRosterPlayer(ctx, fc.Args["input"].(AddFFLRosterPlayerInput))
+		},
+		nil,
+		ec.marshalNFFLPlayerSeason2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayerSeason,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_addFFLRosterPlayer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
+			case "playerId":
+				return ec.fieldContext_FFLPlayerSeason_playerId(ctx, field)
+			case "clubSeasonId":
+				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_addFFLRosterPlayer_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_fflClubs(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4746,6 +4827,50 @@ func (ec *executionContext) unmarshalInputAddFFLPlayerToSeasonInput(ctx context.
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputAddFFLRosterPlayerInput(ctx context.Context, obj any) (AddFFLRosterPlayerInput, error) {
+	var it AddFFLRosterPlayerInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"aflPlayerId", "aflPlayerName", "clubSeasonId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "aflPlayerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("aflPlayerId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AflPlayerID = data
+		case "aflPlayerName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("aflPlayerName"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AflPlayerName = data
+		case "clubSeasonId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clubSeasonId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ClubSeasonID = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCalculateFFLFantasyScoreInput(ctx context.Context, obj any) (CalculateFFLFantasyScoreInput, error) {
 	var it CalculateFFLFantasyScoreInput
 	if obj == nil {
@@ -5839,6 +5964,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "addFFLRosterPlayer":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_addFFLRosterPlayer(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6403,6 +6535,11 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 
 func (ec *executionContext) unmarshalNAddFFLPlayerToSeasonInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐAddFFLPlayerToSeasonInput(ctx context.Context, v any) (AddFFLPlayerToSeasonInput, error) {
 	res, err := ec.unmarshalInputAddFFLPlayerToSeasonInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNAddFFLRosterPlayerInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐAddFFLRosterPlayerInput(ctx context.Context, v any) (AddFFLRosterPlayerInput, error) {
+	res, err := ec.unmarshalInputAddFFLRosterPlayerInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -27,6 +27,7 @@ type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 type ResolverRoot interface {
 	FFLClubMatch() FFLClubMatchResolver
+	FFLClubSeason() FFLClubSeasonResolver
 	FFLMatch() FFLMatchResolver
 	FFLRound() FFLRoundResolver
 	FFLSeason() FFLSeasonResolver
@@ -59,6 +60,7 @@ type ComplexityRoot struct {
 		Lost       func(childComplexity int) int
 		Percentage func(childComplexity int) int
 		Played     func(childComplexity int) int
+		Roster     func(childComplexity int) int
 		Won        func(childComplexity int) int
 	}
 
@@ -94,6 +96,11 @@ type ComplexityRoot struct {
 		PlayerID     func(childComplexity int) int
 	}
 
+	FFLRosterEntry struct {
+		Player         func(childComplexity int) int
+		PlayerSeasonID func(childComplexity int) int
+	}
+
 	FFLRound struct {
 		ID      func(childComplexity int) int
 		Matches func(childComplexity int) int
@@ -114,6 +121,7 @@ type ComplexityRoot struct {
 		CreateFFLPlayer           func(childComplexity int, input CreateFFLPlayerInput) int
 		DeleteFFLPlayer           func(childComplexity int, id string) int
 		RemoveFFLPlayerFromSeason func(childComplexity int, id string) int
+		SetFFLLineup              func(childComplexity int, input SetFFLLineupInput) int
 		UpdateFFLPlayer           func(childComplexity int, input UpdateFFLPlayerInput) int
 	}
 
@@ -130,6 +138,9 @@ type ComplexityRoot struct {
 
 type FFLClubMatchResolver interface {
 	PlayerMatches(ctx context.Context, obj *FFLClubMatch) ([]*FFLPlayerMatch, error)
+}
+type FFLClubSeasonResolver interface {
+	Roster(ctx context.Context, obj *FFLClubSeason) ([]*FFLRosterEntry, error)
 }
 type FFLMatchResolver interface {
 	HomeClubMatch(ctx context.Context, obj *FFLMatch) (*FFLClubMatch, error)
@@ -150,6 +161,7 @@ type MutationResolver interface {
 	AddFFLPlayerToSeason(ctx context.Context, input AddFFLPlayerToSeasonInput) (*FFLPlayerSeason, error)
 	RemoveFFLPlayerFromSeason(ctx context.Context, id string) (bool, error)
 	CalculateFFLFantasyScore(ctx context.Context, input CalculateFFLFantasyScoreInput) (*FFLPlayerMatch, error)
+	SetFFLLineup(ctx context.Context, input SetFFLLineupInput) ([]*FFLPlayerMatch, error)
 }
 type QueryResolver interface {
 	FflClubs(ctx context.Context) ([]*FFLClub, error)
@@ -261,6 +273,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FFLClubSeason.Played(childComplexity), true
+	case "FFLClubSeason.roster":
+		if e.ComplexityRoot.FFLClubSeason.Roster == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLClubSeason.Roster(childComplexity), true
 	case "FFLClubSeason.won":
 		if e.ComplexityRoot.FFLClubSeason.Won == nil {
 			break
@@ -392,6 +410,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.FFLPlayerSeason.PlayerID(childComplexity), true
 
+	case "FFLRosterEntry.player":
+		if e.ComplexityRoot.FFLRosterEntry.Player == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLRosterEntry.Player(childComplexity), true
+	case "FFLRosterEntry.playerSeasonId":
+		if e.ComplexityRoot.FFLRosterEntry.PlayerSeasonID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLRosterEntry.PlayerSeasonID(childComplexity), true
+
 	case "FFLRound.id":
 		if e.ComplexityRoot.FFLRound.ID == nil {
 			break
@@ -497,6 +528,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.RemoveFFLPlayerFromSeason(childComplexity, args["id"].(string)), true
+	case "Mutation.setFFLLineup":
+		if e.ComplexityRoot.Mutation.SetFFLLineup == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_setFFLLineup_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.SetFFLLineup(childComplexity, args["input"].(SetFFLLineupInput)), true
 	case "Mutation.updateFFLPlayer":
 		if e.ComplexityRoot.Mutation.UpdateFFLPlayer == nil {
 			break
@@ -578,6 +620,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAddFFLPlayerToSeasonInput,
 		ec.unmarshalInputCalculateFFLFantasyScoreInput,
 		ec.unmarshalInputCreateFFLPlayerInput,
+		ec.unmarshalInputFFLLineupPlayerInput,
+		ec.unmarshalInputSetFFLLineupInput,
 		ec.unmarshalInputUpdateFFLPlayerInput,
 	)
 	first := true
@@ -661,6 +705,7 @@ var sources = []*ast.Source{
   addFFLPlayerToSeason(input: AddFFLPlayerToSeasonInput!): FFLPlayerSeason!
   removeFFLPlayerFromSeason(id: ID!): Boolean!
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
+  setFFLLineup(input: SetFFLLineupInput!): [FFLPlayerMatch!]!
 }
 
 input CreateFFLPlayerInput {
@@ -691,6 +736,18 @@ input CalculateFFLFantasyScoreInput {
   marks: Int!
   tackles: Int!
   hitouts: Int!
+}
+
+input SetFFLLineupInput {
+  clubMatchId: ID!
+  players: [FFLLineupPlayerInput!]!
+}
+
+input FFLLineupPlayerInput {
+  playerSeasonId: ID!
+  position: String!
+  backupPositions: String
+  interchangePosition: String
 }
 `, BuiltIn: false},
 	{Name: "../../../api/graphql/query.graphqls", Input: `type Query {
@@ -754,6 +811,12 @@ type FFLClubSeason {
   for: Int!
   against: Int!
   percentage: Float!
+  roster: [FFLRosterEntry!]!
+}
+
+type FFLRosterEntry {
+  playerSeasonId: ID!
+  player: FFLPlayer!
 }
 
 type FFLPlayerMatch {
@@ -826,6 +889,17 @@ func (ec *executionContext) field_Mutation_removeFFLPlayerFromSeason_args(ctx co
 		return nil, err
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_setFFLLineup_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNSetFFLLineupInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐSetFFLLineupInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
 	return args, nil
 }
 
@@ -1396,6 +1470,41 @@ func (ec *executionContext) fieldContext_FFLClubSeason_percentage(_ context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FFLClubSeason_roster(ctx context.Context, field graphql.CollectedField, obj *FFLClubSeason) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLClubSeason_roster,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.FFLClubSeason().Roster(ctx, obj)
+		},
+		nil,
+		ec.marshalNFFLRosterEntry2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLRosterEntryᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLClubSeason_roster(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLClubSeason",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "playerSeasonId":
+				return ec.fieldContext_FFLRosterEntry_playerSeasonId(ctx, field)
+			case "player":
+				return ec.fieldContext_FFLRosterEntry_player(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLRosterEntry", field.Name)
 		},
 	}
 	return fc, nil
@@ -2009,6 +2118,72 @@ func (ec *executionContext) fieldContext_FFLPlayerSeason_clubSeasonId(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _FFLRosterEntry_playerSeasonId(ctx context.Context, field graphql.CollectedField, obj *FFLRosterEntry) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLRosterEntry_playerSeasonId,
+		func(ctx context.Context) (any, error) {
+			return obj.PlayerSeasonID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLRosterEntry_playerSeasonId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLRosterEntry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FFLRosterEntry_player(ctx context.Context, field graphql.CollectedField, obj *FFLRosterEntry) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLRosterEntry_player,
+		func(ctx context.Context) (any, error) {
+			return obj.Player, nil
+		},
+		nil,
+		ec.marshalNFFLPlayer2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayer,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLRosterEntry_player(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLRosterEntry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLPlayer_id(ctx, field)
+			case "name":
+				return ec.fieldContext_FFLPlayer_name(ctx, field)
+			case "aflPlayerId":
+				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FFLRound_id(ctx context.Context, field graphql.CollectedField, obj *FFLRound) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2249,6 +2424,8 @@ func (ec *executionContext) fieldContext_FFLSeason_ladder(_ context.Context, fie
 				return ec.fieldContext_FFLClubSeason_against(ctx, field)
 			case "percentage":
 				return ec.fieldContext_FFLClubSeason_percentage(ctx, field)
+			case "roster":
+				return ec.fieldContext_FFLClubSeason_roster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLClubSeason", field.Name)
 		},
@@ -2577,6 +2754,65 @@ func (ec *executionContext) fieldContext_Mutation_calculateFFLFantasyScore(ctx c
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_calculateFFLFantasyScore_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_setFFLLineup(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_setFFLLineup,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().SetFFLLineup(ctx, fc.Args["input"].(SetFFLLineupInput))
+		},
+		nil,
+		ec.marshalNFFLPlayerMatch2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayerMatchᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_setFFLLineup(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLPlayerMatch_id(ctx, field)
+			case "playerSeasonId":
+				return ec.fieldContext_FFLPlayerMatch_playerSeasonId(ctx, field)
+			case "player":
+				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "position":
+				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
+			case "status":
+				return ec.fieldContext_FFLPlayerMatch_status(ctx, field)
+			case "backupPositions":
+				return ec.fieldContext_FFLPlayerMatch_backupPositions(ctx, field)
+			case "interchangePosition":
+				return ec.fieldContext_FFLPlayerMatch_interchangePosition(ctx, field)
+			case "score":
+				return ec.fieldContext_FFLPlayerMatch_score(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerMatch", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_setFFLLineup_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -4573,6 +4809,94 @@ func (ec *executionContext) unmarshalInputCreateFFLPlayerInput(ctx context.Conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputFFLLineupPlayerInput(ctx context.Context, obj any) (FFLLineupPlayerInput, error) {
+	var it FFLLineupPlayerInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"playerSeasonId", "position", "backupPositions", "interchangePosition"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "playerSeasonId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("playerSeasonId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PlayerSeasonID = data
+		case "position":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("position"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Position = data
+		case "backupPositions":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("backupPositions"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.BackupPositions = data
+		case "interchangePosition":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("interchangePosition"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.InterchangePosition = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputSetFFLLineupInput(ctx context.Context, obj any) (SetFFLLineupInput, error) {
+	var it SetFFLLineupInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"clubMatchId", "players"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "clubMatchId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clubMatchId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ClubMatchID = data
+		case "players":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("players"))
+			data, err := ec.unmarshalNFFLLineupPlayerInput2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Players = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateFFLPlayerInput(ctx context.Context, obj any) (UpdateFFLPlayerInput, error) {
 	var it UpdateFFLPlayerInput
 	if obj == nil {
@@ -4761,48 +5085,84 @@ func (ec *executionContext) _FFLClubSeason(ctx context.Context, sel ast.Selectio
 		case "id":
 			out.Values[i] = ec._FFLClubSeason_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "club":
 			out.Values[i] = ec._FFLClubSeason_club(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "played":
 			out.Values[i] = ec._FFLClubSeason_played(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "won":
 			out.Values[i] = ec._FFLClubSeason_won(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "lost":
 			out.Values[i] = ec._FFLClubSeason_lost(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "drawn":
 			out.Values[i] = ec._FFLClubSeason_drawn(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "for":
 			out.Values[i] = ec._FFLClubSeason_for(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "against":
 			out.Values[i] = ec._FFLClubSeason_against(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "percentage":
 			out.Values[i] = ec._FFLClubSeason_percentage(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "roster":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._FFLClubSeason_roster(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -5068,6 +5428,50 @@ func (ec *executionContext) _FFLPlayerSeason(ctx context.Context, sel ast.Select
 			}
 		case "clubSeasonId":
 			out.Values[i] = ec._FFLPlayerSeason_clubSeasonId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var fFLRosterEntryImplementors = []string{"FFLRosterEntry"}
+
+func (ec *executionContext) _FFLRosterEntry(ctx context.Context, sel ast.SelectionSet, obj *FFLRosterEntry) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, fFLRosterEntryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("FFLRosterEntry")
+		case "playerSeasonId":
+			out.Values[i] = ec._FFLRosterEntry_playerSeasonId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "player":
+			out.Values[i] = ec._FFLRosterEntry_player(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -5383,6 +5787,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "calculateFFLFantasyScore":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_calculateFFLFantasyScore(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "setFFLLineup":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_setFFLLineup(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -6036,6 +6447,26 @@ func (ec *executionContext) marshalNFFLClubSeason2ᚖxfflᚋservicesᚋfflᚋint
 	return ec._FFLClubSeason(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNFFLLineupPlayerInput2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInputᚄ(ctx context.Context, v any) ([]*FFLLineupPlayerInput, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*FFLLineupPlayerInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNFFLLineupPlayerInput2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNFFLLineupPlayerInput2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInput(ctx context.Context, v any) (*FFLLineupPlayerInput, error) {
+	res, err := ec.unmarshalInputFFLLineupPlayerInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNFFLMatch2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLMatchᚄ(ctx context.Context, sel ast.SelectionSet, v []*FFLMatch) graphql.Marshaler {
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
@@ -6134,6 +6565,32 @@ func (ec *executionContext) marshalNFFLPlayerSeason2ᚖxfflᚋservicesᚋfflᚋi
 		return graphql.Null
 	}
 	return ec._FFLPlayerSeason(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNFFLRosterEntry2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLRosterEntryᚄ(ctx context.Context, sel ast.SelectionSet, v []*FFLRosterEntry) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNFFLRosterEntry2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLRosterEntry(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNFFLRosterEntry2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLRosterEntry(ctx context.Context, sel ast.SelectionSet, v *FFLRosterEntry) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._FFLRosterEntry(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNFFLRound2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLRound(ctx context.Context, sel ast.SelectionSet, v FFLRound) graphql.Marshaler {
@@ -6242,6 +6699,11 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNSetFFLLineupInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐSetFFLLineupInput(ctx context.Context, v any) (SetFFLLineupInput, error) {
+	res, err := ec.unmarshalInputSetFFLLineupInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -72,8 +72,9 @@ type ComplexityRoot struct {
 	}
 
 	FFLPlayer struct {
-		ID   func(childComplexity int) int
-		Name func(childComplexity int) int
+		AflPlayerID func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
 	}
 
 	FFLPlayerMatch struct {
@@ -304,6 +305,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.FFLMatch.Venue(childComplexity), true
 
+	case "FFLPlayer.aflPlayerId":
+		if e.ComplexityRoot.FFLPlayer.AflPlayerID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLPlayer.AflPlayerID(childComplexity), true
 	case "FFLPlayer.id":
 		if e.ComplexityRoot.FFLPlayer.ID == nil {
 			break
@@ -704,6 +711,7 @@ type FFLClub {
 type FFLPlayer {
   id: ID!
   name: String!
+  aflPlayerId: ID
 }
 
 type FFLSeason {
@@ -1645,6 +1653,35 @@ func (ec *executionContext) fieldContext_FFLPlayer_name(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _FFLPlayer_aflPlayerId(ctx context.Context, field graphql.CollectedField, obj *FFLPlayer) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLPlayer_aflPlayerId,
+		func(ctx context.Context) (any, error) {
+			return obj.AflPlayerID, nil
+		},
+		nil,
+		ec.marshalOID2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLPlayer_aflPlayerId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLPlayer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FFLPlayerMatch_id(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerMatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1731,6 +1768,8 @@ func (ec *executionContext) fieldContext_FFLPlayerMatch_player(_ context.Context
 				return ec.fieldContext_FFLPlayer_id(ctx, field)
 			case "name":
 				return ec.fieldContext_FFLPlayer_name(ctx, field)
+			case "aflPlayerId":
+				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
 		},
@@ -2285,6 +2324,8 @@ func (ec *executionContext) fieldContext_Mutation_createFFLPlayer(ctx context.Co
 				return ec.fieldContext_FFLPlayer_id(ctx, field)
 			case "name":
 				return ec.fieldContext_FFLPlayer_name(ctx, field)
+			case "aflPlayerId":
+				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
 		},
@@ -2332,6 +2373,8 @@ func (ec *executionContext) fieldContext_Mutation_updateFFLPlayer(ctx context.Co
 				return ec.fieldContext_FFLPlayer_id(ctx, field)
 			case "name":
 				return ec.fieldContext_FFLPlayer_name(ctx, field)
+			case "aflPlayerId":
+				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
 		},
@@ -2650,6 +2693,8 @@ func (ec *executionContext) fieldContext_Query_fflPlayers(_ context.Context, fie
 				return ec.fieldContext_FFLPlayer_id(ctx, field)
 			case "name":
 				return ec.fieldContext_FFLPlayer_name(ctx, field)
+			case "aflPlayerId":
+				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
 		},
@@ -2686,6 +2731,8 @@ func (ec *executionContext) fieldContext_Query_fflPlayer(ctx context.Context, fi
 				return ec.fieldContext_FFLPlayer_id(ctx, field)
 			case "name":
 				return ec.fieldContext_FFLPlayer_name(ctx, field)
+			case "aflPlayerId":
+				return ec.fieldContext_FFLPlayer_aflPlayerId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayer", field.Name)
 		},
@@ -4911,6 +4958,8 @@ func (ec *executionContext) _FFLPlayer(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "aflPlayerId":
+			out.Values[i] = ec._FFLPlayer_aflPlayerId(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6392,6 +6441,24 @@ func (ec *executionContext) marshalOFFLClubMatch2ᚖxfflᚋservicesᚋfflᚋinte
 		return graphql.Null
 	}
 	return ec._FFLClubMatch(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v any) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalID(*v)
+	return res
 }
 
 func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v any) (*string, error) {

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -55,8 +55,9 @@ type FFLMatch struct {
 }
 
 type FFLPlayer struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	AflPlayerID *string `json:"aflPlayerId,omitempty"`
 }
 
 type FFLPlayerMatch struct {

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -34,15 +34,23 @@ type FFLClubMatch struct {
 }
 
 type FFLClubSeason struct {
-	ID         string   `json:"id"`
-	Club       *FFLClub `json:"club"`
-	Played     int      `json:"played"`
-	Won        int      `json:"won"`
-	Lost       int      `json:"lost"`
-	Drawn      int      `json:"drawn"`
-	For        int      `json:"for"`
-	Against    int      `json:"against"`
-	Percentage float64  `json:"percentage"`
+	ID         string            `json:"id"`
+	Club       *FFLClub          `json:"club"`
+	Played     int               `json:"played"`
+	Won        int               `json:"won"`
+	Lost       int               `json:"lost"`
+	Drawn      int               `json:"drawn"`
+	For        int               `json:"for"`
+	Against    int               `json:"against"`
+	Percentage float64           `json:"percentage"`
+	Roster     []*FFLRosterEntry `json:"roster"`
+}
+
+type FFLLineupPlayerInput struct {
+	PlayerSeasonID      string  `json:"playerSeasonId"`
+	Position            string  `json:"position"`
+	BackupPositions     *string `json:"backupPositions,omitempty"`
+	InterchangePosition *string `json:"interchangePosition,omitempty"`
 }
 
 type FFLMatch struct {
@@ -77,6 +85,11 @@ type FFLPlayerSeason struct {
 	ClubSeasonID string `json:"clubSeasonId"`
 }
 
+type FFLRosterEntry struct {
+	PlayerSeasonID string     `json:"playerSeasonId"`
+	Player         *FFLPlayer `json:"player"`
+}
+
 type FFLRound struct {
 	ID      string      `json:"id"`
 	Name    string      `json:"name"`
@@ -95,6 +108,11 @@ type Mutation struct {
 }
 
 type Query struct {
+}
+
+type SetFFLLineupInput struct {
+	ClubMatchID string                  `json:"clubMatchId"`
+	Players     []*FFLLineupPlayerInput `json:"players"`
 }
 
 type UpdateFFLPlayerInput struct {

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -86,8 +86,9 @@ type FFLPlayerSeason struct {
 }
 
 type FFLRosterEntry struct {
-	PlayerSeasonID string     `json:"playerSeasonId"`
-	Player         *FFLPlayer `json:"player"`
+	PlayerSeasonID    string     `json:"playerSeasonId"`
+	Player            *FFLPlayer `json:"player"`
+	AflPlayerSeasonID *string    `json:"aflPlayerSeasonId,omitempty"`
 }
 
 type FFLRound struct {

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -7,6 +7,12 @@ type AddFFLPlayerToSeasonInput struct {
 	ClubSeasonID string `json:"clubSeasonId"`
 }
 
+type AddFFLRosterPlayerInput struct {
+	AflPlayerID   string `json:"aflPlayerId"`
+	AflPlayerName string `json:"aflPlayerName"`
+	ClubSeasonID  string `json:"clubSeasonId"`
+}
+
 type CalculateFFLFantasyScoreInput struct {
 	PlayerMatchID string `json:"playerMatchId"`
 	Goals         int    `json:"goals"`

--- a/services/ffl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/ffl/internal/interface/graphql/mutation.resolvers.go
@@ -133,6 +133,23 @@ func (r *mutationResolver) SetFFLLineup(ctx context.Context, input SetFFLLineupI
 	return result, nil
 }
 
+// AddFFLRosterPlayer is the resolver for the addFFLRosterPlayer field.
+func (r *mutationResolver) AddFFLRosterPlayer(ctx context.Context, input AddFFLRosterPlayerInput) (*FFLPlayerSeason, error) {
+	aflPlayerID, err := fromID(input.AflPlayerID)
+	if err != nil {
+		return nil, err
+	}
+	clubSeasonID, err := fromID(input.ClubSeasonID)
+	if err != nil {
+		return nil, err
+	}
+	ps, err := r.Commands.AddAFLPlayerToRoster(ctx, aflPlayerID, input.AflPlayerName, clubSeasonID)
+	if err != nil {
+		return nil, err
+	}
+	return convertPlayerSeason(ps), nil
+}
+
 // Mutation returns MutationResolver implementation.
 func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
 

--- a/services/ffl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/ffl/internal/interface/graphql/mutation.resolvers.go
@@ -7,7 +7,6 @@ package graphql
 
 import (
 	"context"
-
 	"xffl/services/ffl/internal/domain"
 )
 
@@ -81,12 +80,12 @@ func (r *mutationResolver) CalculateFFLFantasyScore(ctx context.Context, input C
 		return nil, err
 	}
 	stats := domain.AFLStats{
-		Goals:    input.Goals,
-		Kicks:    input.Kicks,
+		Goals:     input.Goals,
+		Kicks:     input.Kicks,
 		Handballs: input.Handballs,
-		Marks:    input.Marks,
-		Tackles:  input.Tackles,
-		Hitouts:  input.Hitouts,
+		Marks:     input.Marks,
+		Tackles:   input.Tackles,
+		Hitouts:   input.Hitouts,
 	}
 	pm, err := r.Commands.CalculateFantasyScore(ctx, pmID, stats)
 	if err != nil {

--- a/services/ffl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/ffl/internal/interface/graphql/mutation.resolvers.go
@@ -7,6 +7,8 @@ package graphql
 
 import (
 	"context"
+
+	"xffl/services/ffl/internal/application"
 	"xffl/services/ffl/internal/domain"
 )
 
@@ -96,6 +98,40 @@ func (r *mutationResolver) CalculateFFLFantasyScore(ctx context.Context, input C
 		return nil, err
 	}
 	return convertPlayerMatch(pm, player), nil
+}
+
+// SetFFLLineup is the resolver for the setFFLLineup field.
+func (r *mutationResolver) SetFFLLineup(ctx context.Context, input SetFFLLineupInput) ([]*FFLPlayerMatch, error) {
+	clubMatchID, err := fromID(input.ClubMatchID)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]application.SetLineupEntry, len(input.Players))
+	for i, p := range input.Players {
+		psID, err := fromID(p.PlayerSeasonID)
+		if err != nil {
+			return nil, err
+		}
+		entries[i] = application.SetLineupEntry{
+			PlayerSeasonID:      psID,
+			Position:            p.Position,
+			BackupPositions:     p.BackupPositions,
+			InterchangePosition: p.InterchangePosition,
+		}
+	}
+	pms, err := r.Commands.SetLineup(ctx, clubMatchID, entries)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*FFLPlayerMatch, len(pms))
+	for i, pm := range pms {
+		player, err := r.Queries.GetPlayerForPlayerSeason(ctx, pm.PlayerSeasonID)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = convertPlayerMatch(pm, player)
+	}
+	return result, nil
 }
 
 // Mutation returns MutationResolver implementation.

--- a/services/ffl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/ffl/internal/interface/graphql/mutation.resolvers.go
@@ -7,7 +7,6 @@ package graphql
 
 import (
 	"context"
-
 	"xffl/services/ffl/internal/application"
 	"xffl/services/ffl/internal/domain"
 )

--- a/services/ffl/internal/interface/graphql/query.resolvers.go
+++ b/services/ffl/internal/interface/graphql/query.resolvers.go
@@ -30,6 +30,30 @@ func (r *fFLClubMatchResolver) PlayerMatches(ctx context.Context, obj *FFLClubMa
 	return result, nil
 }
 
+// Roster is the resolver for the roster field.
+func (r *fFLClubSeasonResolver) Roster(ctx context.Context, obj *FFLClubSeason) ([]*FFLRosterEntry, error) {
+	csID, err := fromID(obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	playerSeasons, err := r.Queries.GetPlayerSeasons(ctx, csID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*FFLRosterEntry, len(playerSeasons))
+	for i, ps := range playerSeasons {
+		player, err := r.Queries.GetPlayerForPlayerSeason(ctx, ps.ID)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = &FFLRosterEntry{
+			PlayerSeasonID: toID(ps.ID),
+			Player:         convertPlayer(player),
+		}
+	}
+	return result, nil
+}
+
 // HomeClubMatch is the resolver for the homeClubMatch field.
 func (r *fFLMatchResolver) HomeClubMatch(ctx context.Context, obj *FFLMatch) (*FFLClubMatch, error) {
 	matchID, err := fromID(obj.ID)
@@ -220,6 +244,9 @@ func (r *queryResolver) FflLatestRound(ctx context.Context) (*FFLRound, error) {
 // FFLClubMatch returns FFLClubMatchResolver implementation.
 func (r *Resolver) FFLClubMatch() FFLClubMatchResolver { return &fFLClubMatchResolver{r} }
 
+// FFLClubSeason returns FFLClubSeasonResolver implementation.
+func (r *Resolver) FFLClubSeason() FFLClubSeasonResolver { return &fFLClubSeasonResolver{r} }
+
 // FFLMatch returns FFLMatchResolver implementation.
 func (r *Resolver) FFLMatch() FFLMatchResolver { return &fFLMatchResolver{r} }
 
@@ -233,6 +260,7 @@ func (r *Resolver) FFLSeason() FFLSeasonResolver { return &fFLSeasonResolver{r} 
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
 type fFLClubMatchResolver struct{ *Resolver }
+type fFLClubSeasonResolver struct{ *Resolver }
 type fFLMatchResolver struct{ *Resolver }
 type fFLRoundResolver struct{ *Resolver }
 type fFLSeasonResolver struct{ *Resolver }

--- a/services/ffl/internal/interface/graphql/query.resolvers.go
+++ b/services/ffl/internal/interface/graphql/query.resolvers.go
@@ -46,10 +46,15 @@ func (r *fFLClubSeasonResolver) Roster(ctx context.Context, obj *FFLClubSeason) 
 		if err != nil {
 			return nil, err
 		}
-		result[i] = &FFLRosterEntry{
+		entry := &FFLRosterEntry{
 			PlayerSeasonID: toID(ps.ID),
 			Player:         convertPlayer(player),
 		}
+		if ps.AFLPlayerSeasonID != nil {
+			id := toID(*ps.AFLPlayerSeasonID)
+			entry.AflPlayerSeasonID = &id
+		}
+		result[i] = entry
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary

- **Routing restructure**: FFL Home becomes `/`, AFL views move under `/afl/...`
- **FFL pages**: Home (ladder + matches), Round (scores + top scorers), Match (head-to-head rosters), Team Builder (lineup management with score projections), Roster management (add/remove AFL players)
- **Backend wiring**: `aflPlayerId` on FFL Player, `setFFLLineup` mutation, roster query, AFL player search, Apollo service routing
- **Playwright e2e tests**: 29 new tests across FFL Home, Round, Match, and Team Builder; existing AFL tests updated for new routing
- **Plans & docs**: Sprint plan, page inventory, developer cookbook, revisit backlog

## Details

15 commits, 79 files changed (+4345 / -262). All sprint tasks complete.

Key frontend additions:
- `features/ffl/views/` — HomeView, RoundView, MatchView, TeamBuilderView, RosterView
- `features/ffl/components/` — LadderTable, MatchSummary, RosterTable, RoundNav, StatusBadge
- `features/ffl/api/` — queries and mutations for FFL GraphQL

Key backend additions:
- AFL service: player search query, player season stats aggregation
- FFL service: roster management mutations, lineup mutations, roster queries
- Schema migration: `afl_player_season_id` on FFL player_seasons

## Test plan

- [x] `just dev-up && just dev-seed && just run-all` — verify all pages render
- [x] `just test-e2e` — 29 new FFL tests + existing AFL tests pass
- [x] Navigate FFL Home → Round → Match flow
- [x] Team Builder: assign players to positions, verify score projections
- [x] Roster: search AFL players, add/remove from FFL club roster