### PR TITLE
Phase 9: FFL team composition rules + UI rebuild

### DIFF
--- a/ai/architecture/domain.md
+++ b/ai/architecture/domain.md
@@ -88,7 +88,7 @@ Fantasy Football League — a fantasy competition built on AFL statistics.
 
 ### Positions (fantasy)
 
-A **position** is a scoring slot in a fantasy lineup. It determines *which* AFL stat earns fantasy points and at what rate. Positions are **not** field positions (forward, midfielder, etc.).
+A **position** is a scoring slot in a fantasy team. It determines *which* AFL stat earns fantasy points and at what rate. Positions are **not** field positions (forward, midfielder, etc.).
 
 | Position | Scores from | Multiplier |
 |----------|-------------|------------|
@@ -126,13 +126,13 @@ A fantasy club submits a team each round. Teams need not be full.
 | **Backup star** | `"star"` | at most 1 |
 | **Dual-position** | exactly 2 non-star positions | at most 3 |
 
-Hard rules enforced by `domain.ValidateLineup()`:
+Hard rules enforced by `domain.ValidateTeam()`:
 1. Starter count per position ≤ `PositionSlots[pos]`
 2. Total bench players ≤ 4
 3. At most 1 backup star (`BackupPositions` contains `"star"`)
 4. Non-star bench players have **exactly 2** backup positions, neither of which is `"star"`
 5. Each non-star position appears in **at most one** bench player's backup pair
-6. At most 1 `InterchangePosition` set across all players in the lineup
+6. At most 1 `InterchangePosition` set across all players in the team
 7. `InterchangePosition` (if set) must be a recognised `Position` value
 
 #### Bench player identification

--- a/ai/architecture/domain.md
+++ b/ai/architecture/domain.md
@@ -102,17 +102,48 @@ A **position** is a scoring slot in a fantasy lineup. It determines *which* AFL 
 
 `PlayerMatch.CalculateScore(aflStats)` is a pure domain function that applies the position multiplier to AFL statistics.
 
-### Lineup: starters and bench
+### Team composition
 
-A fantasy club fields **starters** and **bench** players each round. This distinction is structural, not stored in a status field:
+A fantasy club submits a team each round. Teams need not be full.
+
+#### Starter slots
+
+| Position | Slots |
+|----------|-------|
+| `goals` | 3 |
+| `kicks` | 4 |
+| `handballs` | 4 |
+| `marks` | 2 |
+| `tackles` | 2 |
+| `hitouts` | 2 |
+| `star` | 1 |
+| **Total** | **18** |
+
+#### Bench (up to 4 players)
+
+| Bench role | Backup positions | Limit |
+|------------|-----------------|-------|
+| **Backup star** | `"star"` | at most 1 |
+| **Dual-position** | exactly 2 non-star positions | at most 3 |
+
+Hard rules enforced by `domain.ValidateLineup()`:
+1. Starter count per position ≤ `PositionSlots[pos]`
+2. Total bench players ≤ 4
+3. At most 1 backup star (`BackupPositions` contains `"star"`)
+4. Non-star bench players have **exactly 2** backup positions, neither of which is `"star"`
+5. Each non-star position appears in **at most one** bench player's backup pair
+6. At most 1 `InterchangePosition` set across all players in the lineup
+7. `InterchangePosition` (if set) must be a recognised `Position` value
+
+#### Bench player identification
 
 | Role | How to identify |
 |------|----------------|
-| **Starter** | Occupies a position slot. Has neither `BackupPositions` nor `InterchangePosition` set. |
-| **Bench** | Has `BackupPositions` and/or `InterchangePosition` set. Sits out unless substitution or interchange applies. |
+| **Starter** | `BackupPositions == nil && InterchangePosition == nil` |
+| **Bench** | `BackupPositions != nil \|\| InterchangePosition != nil` |
 
-- **BackupPositions** — comma-separated list of positions a bench player can substitute into.
-- **InterchangePosition** — the single position a bench player competes against for an interchange swap.
+- **BackupPositions** — comma-separated list of positions this bench player can substitute into (`"star"` for backup star; two non-star positions for dual-position bench).
+- **InterchangePosition** — the single position this bench player can freely interchange with their starter (see interchange rules below).
 
 ### FFL Player and AFL linkage
 
@@ -130,15 +161,16 @@ FFL `PlayerMatch.status` is **not derived** — it may be initialised from AFL s
 
 ### Substitution and interchange
 
-`ClubMatch.Score()` aggregates fantasy scores with two replacement rules:
+`ClubMatch.Score()` aggregates fantasy scores with two replacement rules, applied per starter slot:
 
-1. **Substitution** — if a starter's status is `dnp`, a bench player whose `BackupPositions` includes that starter's position fills in. A bench player may cover multiple positions but only subs into one.
-2. **Interchange** — if a bench player's `InterchangePosition` targets a starter *and* the bench player's score strictly exceeds the starter's, they swap.
+1. **Substitution** — if a starter's status is `dnp`, a bench player whose `BackupPositions` includes that starter's position fills that slot. A player who played but earned 0 points **cannot** be substituted. A bench player may cover multiple positions but is consumed by at most one substitution.
+2. **Interchange** — if a bench player's `InterchangePosition` matches a starter's position *and* the bench player's score strictly exceeds the starter's, they swap. Applies per individual starter slot within the position group.
 
 Constraints:
 - A bench player can only be used **once** (sub or interchange, not both).
-- Interchange requires the bench player to **strictly outscore** the starter (ties stay).
-- The **order** of substitution vs interchange, and which position a multi-position bench player fills, is decided by the team owner after AFL stats are in. The exact mechanism for this is TBD.
+- Substitution is evaluated before interchange.
+- Interchange requires the bench player to **strictly outscore** the starter (ties keep the starter).
+- Where multiple players are eligible for substitution into a DNP slot, the team owner chooses which bench player fills which position.
 
 ### Match style
 

--- a/ai/architecture/frontend.md
+++ b/ai/architecture/frontend.md
@@ -5,7 +5,7 @@
 Single Vue 3 SPA (`frontend/web/`) connecting to the gateway at port 8090 via Apollo Client.
 
 **FFL is the app's front door** — the root route (`/`) is the FFL home. AFL lives under `/afl`.
-The primary audience is FFL team managers (club owners) who use the app to track fantasy scores and build lineups.
+The primary audience is FFL club managers who use the app to track fantasy scores and build teams.
 
 ## Page Hierarchy
 
@@ -19,7 +19,7 @@ The primary audience is FFL team managers (club owners) who use the app to track
 | Team Builder | `/ffl/seasons/:seasonId/rounds/:roundId/team-builder` |
 | Players (admin) | `/ffl/players` |
 
-**Money-shot views:** Match (head-to-head fantasy scores in real time) and Team Builder (weekly lineup selection).
+**Money-shot views:** Match (head-to-head fantasy scores in real time) and Team Builder (weekly team selection).
 
 ### AFL (supporting)
 

--- a/ai/decisions/adr-013-cross-service-data-strategy.md
+++ b/ai/decisions/adr-013-cross-service-data-strategy.md
@@ -19,7 +19,7 @@ In parallel, the long-term data model calls for a search index (Zinc → Elastic
 
 **Do not federate the graph. Use a CQRS read/write split instead.**
 
-- **GraphQL services are write-model APIs** — they handle commands (enter stats, build squads, set lineups) and serve structured domain data (seasons, rounds, matches, squads). They are not the authority for aggregated player stats at read time.
+- **GraphQL services are write-model APIs** — they handle commands (enter stats, build squads, set teams) and serve structured domain data (seasons, rounds, matches, squads). They are not the authority for aggregated player stats at read time.
 - **The search index is the read model for player stats** — averages, per-round history, rankings. The frontend queries the search index directly for this data, keyed by player/season IDs obtained from GraphQL.
 - **Client-side stitching between GraphQL and search is intentional** — this is the expected pattern in CQRS, not a workaround. The two sides of the split are deliberately separate.
 
@@ -29,7 +29,7 @@ Federation solves a problem this architecture doesn't have in the long run. The 
 
 The CQRS split is also a better fit for the domain:
 - Player stats are aggregated, denormalised, high-read — search index wins
-- Squad composition, lineups, match results are relational, transactional — GraphQL/PG wins
+- Squad composition, teams, match results are relational, transactional — GraphQL/PG wins
 - The boundary between the two is clean and stable
 
 ## Consequences

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -1,53 +1,490 @@
 import { test, expect } from '@playwright/test'
 
+// Helpers
+async function goToTeamBuilder(page: import('@playwright/test').Page) {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Team Builder' }).click()
+  await page.waitForURL(/\/ffl\/.*\/team-builder/)
+}
+
+function positionSection(page: import('@playwright/test').Page, name: string) {
+  return page.locator('div.mb-6').filter({ has: page.locator('h3').filter({ hasText: name }) })
+}
+
+function benchSection(page: import('@playwright/test').Page) {
+  return page.locator('div.mb-6').filter({ has: page.locator('h3').filter({ hasText: 'Bench' }) })
+}
+
+// The squad panel h2 heading is "Squad (N)"; go up one level to get the panel div
+function squadPanel(page: import('@playwright/test').Page) {
+  return page.getByRole('heading', { name: /Squad \(/ }).locator('..')
+}
+
 test.describe('FFL Team Builder', () => {
-  test.beforeEach(async ({ page }) => {
-    // Navigate via navbar Team Builder link (requires home to load first so state is set)
-    await page.goto('/')
-    await page.getByRole('link', { name: 'Team Builder' }).click()
+  // ── Layout: read-only mode ────────────────────────────────────────────────
+
+  test.describe('layout: read-only mode', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+    })
+
+    test('shows club name as h1', async ({ page }) => {
+      await expect(page.getByRole('heading', { level: 1 })).toContainText('Ruiboys')
+    })
+
+    test('Manage button visible; Done not visible', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+    })
+
+    test('all position group headings present', async ({ page }) => {
+      for (const name of ['Goals', 'Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Star', 'Bench']) {
+        await expect(page.getByRole('heading', { name })).toBeVisible()
+      }
+    })
+
+    test('slot counts match composition rules (3/4/4/2/2/2/1)', async ({ page }) => {
+      const expected: [string, number][] = [
+        ['Goals', 3], ['Kicks', 4], ['Handballs', 4],
+        ['Marks', 2], ['Tackles', 2], ['Hitouts', 2], ['Star', 1],
+      ]
+      for (const [name, count] of expected) {
+        const section = positionSection(page, name)
+        await expect(section.locator('.rounded-lg')).toHaveCount(count)
+      }
+    })
+
+    test('bench has Backup Star row and 3 dual-position rows (B1/B2/B3)', async ({ page }) => {
+      const bench = benchSection(page)
+      // 1 backup star + 3 dual = 4 rows
+      await expect(bench.locator('.rounded-lg')).toHaveCount(4)
+      await expect(bench.getByText('Backup Star')).toBeVisible()
+      await expect(bench.getByText('B1')).toBeVisible()
+      await expect(bench.getByText('B2')).toBeVisible()
+      await expect(bench.getByText('B3')).toBeVisible()
+    })
+
+    test('no Remove buttons visible', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Remove' })).not.toBeVisible()
+    })
+
+    test('no squad panel visible', async ({ page }) => {
+      await expect(page.getByRole('heading', { name: /Squad \(/ })).not.toBeVisible()
+    })
+
+    test('no position selectors (selects) visible', async ({ page }) => {
+      await expect(page.locator('select')).not.toBeVisible()
+    })
   })
 
-  test('displays club name as heading', async ({ page }) => {
-    // Heading should be the selected club name, not "Team Builder"
-    await expect(page.getByRole('heading', { level: 1 })).toContainText('Ruiboys')
+  // ── Layout: manage mode ───────────────────────────────────────────────────
+
+  test.describe('layout: manage mode', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('Done button visible; Manage button gone', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Manage' })).not.toBeVisible()
+    })
+
+    test('squad panel shows player count', async ({ page }) => {
+      await expect(page.getByRole('heading', { name: /Squad \(/ })).toBeVisible()
+    })
+
+    test('Remove buttons visible on filled starter slots', async ({ page }) => {
+      // Seed has 7 starters, so at least one Remove button should be present
+      await expect(page.getByRole('button', { name: 'Remove' }).first()).toBeVisible()
+    })
+
+    test('IC checkbox visible on Backup Star bench row', async ({ page }) => {
+      const bench = benchSection(page)
+      const starRow = bench.locator('.rounded-lg').first()
+      await expect(starRow.getByText('IC')).toBeVisible()
+    })
+
+    test('dual-position selects appear on bench rows that have a player', async ({ page }) => {
+      // Seed loads one dual-position bench player (goals,kicks), so B1 should have selects
+      const bench = benchSection(page)
+      // B1 is the 2nd rounded-lg (index 1, after backup star at index 0)
+      const b1Row = bench.locator('.rounded-lg').nth(1)
+      await expect(b1Row.locator('select')).toHaveCount(2)
+    })
+
+    test('★ and B buttons appear in squad panel', async ({ page }) => {
+      const panel = squadPanel(page)
+      await expect(panel.getByRole('button', { name: '★' }).first()).toBeVisible()
+      await expect(panel.getByRole('button', { name: 'B' }).first()).toBeVisible()
+    })
+
+    test('Done saves and returns to read-only mode', async ({ page }) => {
+      await page.getByRole('button', { name: 'Done' }).click()
+      await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+      await expect(page.getByRole('heading', { name: /Squad \(/ })).not.toBeVisible()
+    })
   })
 
-  test('loads in read-only mode with Manage button', async ({ page }) => {
-    await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+  // ── Partial edit → view → re-edit (state retention) ──────────────────────
+  //
+  // The bug being guarded against: Apollo's watch fires after a mutation
+  // response and resets all local slot state. The initializedMatchId guard
+  // prevents that reset.
+
+  test.describe('state retention across Manage/Done cycles', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+    })
+
+    test('player added to slot is visible in read-only mode after Done', async ({ page }) => {
+      // Count empty Goals slots before
+      const goalsSection = positionSection(page, 'Goals')
+      const emptyBefore = await goalsSection.getByText('Empty slot').count()
+      expect(emptyBefore).toBeGreaterThan(0)
+
+      // Enter manage mode and add a player to Goals
+      await page.getByRole('button', { name: 'Manage' }).click()
+      const panel = squadPanel(page)
+      await panel.getByRole('button', { name: 'G' }).first().click()
+
+      // Save
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // One fewer empty slot in Goals after saving
+      await expect(goalsSection.getByText('Empty slot')).toHaveCount(emptyBefore - 1)
+    })
+
+    test('local edits not reset when re-entering manage mode (state retention)', async ({ page }) => {
+      // Add a player to an available Goals slot
+      await page.getByRole('button', { name: 'Manage' }).click()
+      const panel = squadPanel(page)
+
+      // Note the player name about to be added
+      const playerName = await panel.locator('.font-medium').first().textContent()
+      await panel.getByRole('button', { name: 'G' }).first().click()
+
+      // Save (Done fires the mutation)
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // Immediately re-enter manage mode — player must still be in the Goals slot
+      await page.getByRole('button', { name: 'Manage' }).click()
+      const goalsSection = positionSection(page, 'Goals')
+      await expect(goalsSection.getByText(playerName!.trim())).toBeVisible()
+    })
+
+    test('two rounds of editing accumulate correctly', async ({ page }) => {
+      // Round 1: add to Goals
+      await page.getByRole('button', { name: 'Manage' }).click()
+      let panel = squadPanel(page)
+      const player1 = await panel.locator('.font-medium').first().textContent()
+      await panel.getByRole('button', { name: 'G' }).first().click()
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // Round 2: add to Kicks
+      await page.getByRole('button', { name: 'Manage' }).click()
+      panel = squadPanel(page)
+      const player2 = await panel.locator('.font-medium').first().textContent()
+      await panel.getByRole('button', { name: 'K' }).first().click()
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // Both players visible in read-only mode
+      await expect(positionSection(page, 'Goals').getByText(player1!.trim())).toBeVisible()
+      await expect(positionSection(page, 'Kicks').getByText(player2!.trim())).toBeVisible()
+    })
   })
 
-  test('read-only mode shows lineup without edit controls', async ({ page }) => {
-    // Starters visible from seed data
-    await expect(page.getByText('Christian Petracca')).toBeVisible()
-    // No position action buttons or Remove buttons visible
-    await expect(page.getByRole('button', { name: 'Remove' })).not.toBeVisible()
+  // ── Navigate away and back (server persistence) ───────────────────────────
+
+  test.describe('navigate away and back', () => {
+    test('lineup persists after navigating to Squad view and returning', async ({ page }) => {
+      await goToTeamBuilder(page)
+
+      // Add a player to Goals and save
+      await page.getByRole('button', { name: 'Manage' }).click()
+      const playerName = await squadPanel(page).locator('.font-medium').first().textContent()
+      await squadPanel(page).getByRole('button', { name: 'G' }).first().click()
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // Navigate away to Squad page
+      await page.getByRole('link', { name: 'Squad' }).click()
+      await page.waitForURL(/\/ffl\/.*\/squad/)
+
+      // Navigate back to Team Builder
+      await page.getByRole('link', { name: 'Team Builder' }).click()
+      await page.waitForURL(/\/ffl\/.*\/team-builder/)
+
+      // Player still in Goals (loaded from server)
+      await expect(positionSection(page, 'Goals').getByText(playerName!.trim())).toBeVisible()
+
+      // And still there when entering manage mode
+      await page.getByRole('button', { name: 'Manage' }).click()
+      await expect(positionSection(page, 'Goals').getByText(playerName!.trim())).toBeVisible()
+    })
   })
 
-  test('read-only mode does not show squad panel', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /Squad/ })).not.toBeVisible()
+  // ── Continue building across sessions ─────────────────────────────────────
+
+  test.describe('continue building on existing lineup', () => {
+    test('existing players present when entering manage mode on partial lineup', async ({ page }) => {
+      await goToTeamBuilder(page)
+
+      // Seed data has some players in the lineup already
+      // Verify they are present in read-only mode
+      const goalsSection = positionSection(page, 'Goals')
+      // Should have at least 1 filled slot (seed puts 1 starter per position)
+      const emptyCount = await goalsSection.getByText('Empty slot').count()
+      expect(emptyCount).toBeLessThan(3)
+
+      // Enter manage and those same players should still be there
+      await page.getByRole('button', { name: 'Manage' }).click()
+      const stillEmpty = await goalsSection.getByText('Empty slot').count()
+      expect(stillEmpty).toBe(emptyCount)
+    })
+
+    test('adding to existing lineup: all players visible after Done', async ({ page }) => {
+      await goToTeamBuilder(page)
+
+      // Find a player already in Goals read-only
+      const goalsSection = positionSection(page, 'Goals')
+      const existingNames = await goalsSection.locator('.font-medium').allTextContents()
+
+      // Add one more
+      await page.getByRole('button', { name: 'Manage' }).click()
+      const newPlayerName = await squadPanel(page).locator('.font-medium').first().textContent()
+      await squadPanel(page).getByRole('button', { name: 'G' }).first().click()
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // All existing + new player visible
+      for (const name of existingNames) {
+        await expect(goalsSection.getByText(name.trim())).toBeVisible()
+      }
+      await expect(goalsSection.getByText(newPlayerName!.trim())).toBeVisible()
+
+      // And re-entering manage mode retains all of them
+      await page.getByRole('button', { name: 'Manage' }).click()
+      for (const name of existingNames) {
+        await expect(goalsSection.getByText(name.trim())).toBeVisible()
+      }
+      await expect(goalsSection.getByText(newPlayerName!.trim())).toBeVisible()
+    })
   })
 
-  test('clicking Manage reveals edit controls and squad panel', async ({ page }) => {
-    await page.getByRole('button', { name: 'Manage' }).click()
-    await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: /Squad/ })).toBeVisible()
+  // ── Bench: backup star ────────────────────────────────────────────────────
+
+  test.describe('bench: backup star', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('★ button in squad panel adds player to Backup Star row', async ({ page }) => {
+      const panel = squadPanel(page)
+      const playerName = await panel.locator('.font-medium').first().textContent()
+
+      await panel.getByRole('button', { name: '★' }).first().click()
+
+      const bench = benchSection(page)
+      const starRow = bench.locator('.rounded-lg').first()
+      await expect(starRow.getByText(playerName!.trim())).toBeVisible()
+    })
+
+    test('★ button disabled for all players once Backup Star slot is filled', async ({ page }) => {
+      const panel = squadPanel(page)
+
+      // Seed data may or may not have the backup star slot filled
+      // Ensure it's empty first (if there's no player there, the ★ buttons should be enabled)
+      const bench = benchSection(page)
+      const starRow = bench.locator('.rounded-lg').first()
+      const hasExistingStarPlayer = await starRow.getByRole('button', { name: 'Remove' }).isVisible()
+
+      if (!hasExistingStarPlayer) {
+        // Add a player via ★
+        await panel.getByRole('button', { name: '★' }).first().click()
+      }
+
+      // Now all ★ buttons should be disabled
+      const starButtons = panel.getByRole('button', { name: '★' })
+      const count = await starButtons.count()
+      for (let i = 0; i < count; i++) {
+        await expect(starButtons.nth(i)).toBeDisabled()
+      }
+    })
+
+    test('removing from Backup Star row re-enables ★ buttons', async ({ page }) => {
+      const panel = squadPanel(page)
+      const bench = benchSection(page)
+      const starRow = bench.locator('.rounded-lg').first()
+
+      // Ensure slot is filled (add if necessary)
+      const hasPlayer = await starRow.getByRole('button', { name: 'Remove' }).isVisible()
+      if (!hasPlayer) {
+        await panel.getByRole('button', { name: '★' }).first().click()
+      }
+
+      // Remove from star slot
+      await starRow.getByRole('button', { name: 'Remove' }).click()
+
+      // ★ buttons should now be enabled for squad players
+      await expect(panel.getByRole('button', { name: '★' }).first()).toBeEnabled()
+    })
+
+    test('backup star slot visible after Done → re-open Manage', async ({ page }) => {
+      const panel = squadPanel(page)
+      const playerName = await panel.locator('.font-medium').first().textContent()
+
+      await panel.getByRole('button', { name: '★' }).first().click()
+      await page.getByRole('button', { name: 'Done' }).click()
+
+      // Read-only mode: player name visible in bench section
+      await expect(benchSection(page).locator('.rounded-lg').first().getByText(playerName!.trim())).toBeVisible()
+
+      // Re-enter manage mode: still there
+      await page.getByRole('button', { name: 'Manage' }).click()
+      await expect(benchSection(page).locator('.rounded-lg').first().getByText(playerName!.trim())).toBeVisible()
+    })
   })
 
-  test('clicking Manage shows position groups with action buttons', async ({ page }) => {
-    await page.getByRole('button', { name: 'Manage' }).click()
-    for (const position of ['Goals', 'Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Star']) {
-      await expect(page.getByRole('heading', { name: position })).toBeVisible()
-    }
-    await expect(page.getByRole('heading', { name: /Bench/ })).toBeVisible()
+  // ── Bench: dual-position ──────────────────────────────────────────────────
+
+  test.describe('bench: dual-position', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('B button in squad panel adds player to first empty dual bench row', async ({ page }) => {
+      const panel = squadPanel(page)
+      const playerName = await panel.locator('.font-medium').first().textContent()
+
+      // Click B for first available player (adds to next empty dual slot)
+      await panel.getByRole('button', { name: 'B' }).first().click()
+
+      // That player name should appear in one of B1/B2/B3 rows
+      const bench = benchSection(page)
+      const dualRows = bench.locator('.rounded-lg').filter({ hasText: playerName!.trim() })
+      await expect(dualRows).toHaveCount(1)
+    })
+
+    test('dual bench row shows two position selectors after player is added', async ({ page }) => {
+      // Find an empty dual bench row
+      const bench = benchSection(page)
+      // B1 may already have a player from seed; check B2 (nth 2, 0-indexed)
+      const b2Row = bench.locator('.rounded-lg').nth(2)
+      const b2HasPlayer = await b2Row.locator('select').count() > 0
+
+      if (!b2HasPlayer) {
+        const panel = squadPanel(page)
+        // Need to fill B1 first (if not already filled), then B2
+        const b1Row = bench.locator('.rounded-lg').nth(1)
+        const b1HasPlayer = await b1Row.locator('select').count() > 0
+        if (!b1HasPlayer) {
+          await panel.getByRole('button', { name: 'B' }).first().click()
+        }
+        await panel.getByRole('button', { name: 'B' }).first().click()
+      }
+
+      // The row now should have 2 select elements
+      await expect(b2Row.locator('select')).toHaveCount(2)
+    })
+
+    test('selecting a position in one bench row disables it in other rows', async ({ page }) => {
+      // Ensure at least 2 dual bench rows have players
+      const panel = squadPanel(page)
+      const bench = benchSection(page)
+
+      // Fill B1 if empty
+      const b1Row = bench.locator('.rounded-lg').nth(1)
+      if (!(await b1Row.locator('select').count())) {
+        await panel.getByRole('button', { name: 'B' }).first().click()
+      }
+      // Fill B2
+      const b2Row = bench.locator('.rounded-lg').nth(2)
+      if (!(await b2Row.locator('select').count())) {
+        await panel.getByRole('button', { name: 'B' }).first().click()
+      }
+
+      // Select "Goals" in B1's first position selector
+      await b1Row.locator('select').first().selectOption('goals')
+
+      // In B2's selectors, the "Goals" option should be disabled
+      const b2Select1 = b2Row.locator('select').first()
+      const goalsOption = b2Select1.locator('option[value="goals"]')
+      await expect(goalsOption).toBeDisabled()
+    })
+
+    test('B button disabled once all 3 dual slots are filled', async ({ page }) => {
+      const panel = squadPanel(page)
+      const bench = benchSection(page)
+
+      // Fill any empty dual slots (there may already be some filled from seed)
+      for (let i = 1; i <= 3; i++) {
+        const row = bench.locator('.rounded-lg').nth(i)
+        const hasPlayer = await row.locator('select').count() > 0
+        if (!hasPlayer) {
+          await panel.getByRole('button', { name: 'B' }).first().click()
+        }
+      }
+
+      // All B buttons in squad panel should now be disabled
+      const bButtons = panel.getByRole('button', { name: 'B' })
+      const count = await bButtons.count()
+      for (let i = 0; i < count; i++) {
+        await expect(bButtons.nth(i)).toBeDisabled()
+      }
+    })
   })
 
-  test('clicking Done saves and returns to read-only mode', async ({ page }) => {
-    await page.getByRole('button', { name: 'Manage' }).click()
-    await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
-    await page.getByRole('button', { name: 'Done' }).click()
-    // Returns to Manage state (Done triggers save then exits)
-    await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+  // ── Interchange ───────────────────────────────────────────────────────────
+
+  test.describe('interchange', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('IC checkbox visible on Backup Star row in manage mode', async ({ page }) => {
+      const starRow = benchSection(page).locator('.rounded-lg').first()
+      await expect(starRow.getByText('IC')).toBeVisible()
+    })
+
+    test('clicking IC on one bench row deactivates IC on another', async ({ page }) => {
+      const bench = benchSection(page)
+      const panel = squadPanel(page)
+
+      // Ensure B1 has a player (for its IC to appear)
+      const b1Row = bench.locator('.rounded-lg').nth(1)
+      if (!(await b1Row.locator('select').count())) {
+        await panel.getByRole('button', { name: 'B' }).first().click()
+      }
+
+      // Activate IC on Backup Star row
+      const starIC = bench.locator('.rounded-lg').first().locator('input[type="checkbox"]')
+      await starIC.check()
+      await expect(starIC).toBeChecked()
+
+      // Activate IC on B1 row → star IC should deactivate
+      const b1IC = b1Row.locator('input[type="checkbox"]')
+      await b1IC.check()
+      await expect(b1IC).toBeChecked()
+      await expect(starIC).not.toBeChecked()
+    })
+
+    test('interchange state persists through Done → re-open Manage', async ({ page }) => {
+      const bench = benchSection(page)
+
+      // Activate IC on Backup Star row
+      const starRow = bench.locator('.rounded-lg').first()
+      const starIC = starRow.locator('input[type="checkbox"]')
+      await starIC.check()
+
+      await page.getByRole('button', { name: 'Done' }).click()
+      await page.getByRole('button', { name: 'Manage' }).click()
+
+      // IC should still be checked after reload
+      const starICAfter = benchSection(page).locator('.rounded-lg').first().locator('input[type="checkbox"]')
+      await expect(starICAfter).toBeChecked()
+    })
   })
 })

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -198,7 +198,7 @@ test.describe('FFL Team Builder', () => {
   // ── Navigate away and back (server persistence) ───────────────────────────
 
   test.describe('navigate away and back', () => {
-    test('lineup persists after navigating to Squad view and returning', async ({ page }) => {
+    test('team persists after navigating to Squad view and returning', async ({ page }) => {
       await goToTeamBuilder(page)
 
       // Add a player to Kicks and save (Goals is filled by state-retention tests)
@@ -226,11 +226,11 @@ test.describe('FFL Team Builder', () => {
 
   // ── Continue building across sessions ─────────────────────────────────────
 
-  test.describe('continue building on existing lineup', () => {
-    test('existing players present when entering manage mode on partial lineup', async ({ page }) => {
+  test.describe('continue building on existing team', () => {
+    test('existing players present when entering manage mode on partial team', async ({ page }) => {
       await goToTeamBuilder(page)
 
-      // Seed data has some players in the lineup already
+      // Seed data has some players in the team already
       // Verify they are present in read-only mode
       const goalsSection = positionSection(page, 'Goals')
       // Should have at least 1 filled slot (seed puts 1 starter per position)
@@ -243,7 +243,7 @@ test.describe('FFL Team Builder', () => {
       expect(stillEmpty).toBe(emptyCount)
     })
 
-    test('adding to existing lineup: all players visible after Done', async ({ page }) => {
+    test('adding to existing team: all players visible after Done', async ({ page }) => {
       await goToTeamBuilder(page)
 
       // Find players already in Handballs read-only (has capacity from prior tests in the run)

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -157,29 +157,29 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('local edits not reset when re-entering manage mode (state retention)', async ({ page }) => {
-      // Add a player to an available Goals slot
+      // Add a player to an available Kicks slot (Goals is used by other tests in this group)
       await page.getByRole('button', { name: 'Manage' }).click()
       const panel = squadPanel(page)
 
       // Note the player name about to be added
       const playerName = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'G' }).first().click()
+      await panel.getByRole('button', { name: 'K' }).first().click()
 
       // Save (Done fires the mutation)
       await page.getByRole('button', { name: 'Done' }).click()
 
-      // Immediately re-enter manage mode — player must still be in the Goals slot
+      // Immediately re-enter manage mode — player must still be in the Kicks slot
       await page.getByRole('button', { name: 'Manage' }).click()
-      const goalsSection = positionSection(page, 'Goals')
-      await expect(goalsSection.getByText(playerName!.trim())).toBeVisible()
+      const kicksSection = positionSection(page, 'Kicks')
+      await expect(kicksSection.getByText(playerName!.trim())).toBeVisible()
     })
 
     test('two rounds of editing accumulate correctly', async ({ page }) => {
-      // Round 1: add to Goals
+      // Round 1: add to Handballs (Goals/Kicks used by other tests in this group)
       await page.getByRole('button', { name: 'Manage' }).click()
       let panel = squadPanel(page)
       const player1 = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'G' }).first().click()
+      await panel.getByRole('button', { name: 'HB' }).first().click()
       await page.getByRole('button', { name: 'Done' }).click()
 
       // Round 2: add to Kicks
@@ -190,7 +190,7 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('button', { name: 'Done' }).click()
 
       // Both players visible in read-only mode
-      await expect(positionSection(page, 'Goals').getByText(player1!.trim())).toBeVisible()
+      await expect(positionSection(page, 'Handballs').getByText(player1!.trim())).toBeVisible()
       await expect(positionSection(page, 'Kicks').getByText(player2!.trim())).toBeVisible()
     })
   })
@@ -201,10 +201,10 @@ test.describe('FFL Team Builder', () => {
     test('lineup persists after navigating to Squad view and returning', async ({ page }) => {
       await goToTeamBuilder(page)
 
-      // Add a player to Goals and save
+      // Add a player to Kicks and save (Goals is filled by state-retention tests)
       await page.getByRole('button', { name: 'Manage' }).click()
       const playerName = await squadPanel(page).locator('.font-medium').first().textContent()
-      await squadPanel(page).getByRole('button', { name: 'G' }).first().click()
+      await squadPanel(page).getByRole('button', { name: 'K' }).first().click()
       await page.getByRole('button', { name: 'Done' }).click()
 
       // Navigate away to Squad page
@@ -215,12 +215,12 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('link', { name: 'Team Builder' }).click()
       await page.waitForURL(/\/ffl\/.*\/team-builder/)
 
-      // Player still in Goals (loaded from server)
-      await expect(positionSection(page, 'Goals').getByText(playerName!.trim())).toBeVisible()
+      // Player still in Kicks (loaded from server)
+      await expect(positionSection(page, 'Kicks').getByText(playerName!.trim())).toBeVisible()
 
       // And still there when entering manage mode
       await page.getByRole('button', { name: 'Manage' }).click()
-      await expect(positionSection(page, 'Goals').getByText(playerName!.trim())).toBeVisible()
+      await expect(positionSection(page, 'Kicks').getByText(playerName!.trim())).toBeVisible()
     })
   })
 
@@ -246,28 +246,28 @@ test.describe('FFL Team Builder', () => {
     test('adding to existing lineup: all players visible after Done', async ({ page }) => {
       await goToTeamBuilder(page)
 
-      // Find a player already in Goals read-only
-      const goalsSection = positionSection(page, 'Goals')
-      const existingNames = await goalsSection.locator('.font-medium').allTextContents()
+      // Find players already in Handballs read-only (has capacity from prior tests in the run)
+      const hbSection = positionSection(page, 'Handballs')
+      const existingNames = await hbSection.locator('.font-medium').allTextContents()
 
-      // Add one more
+      // Add one more to Handballs
       await page.getByRole('button', { name: 'Manage' }).click()
       const newPlayerName = await squadPanel(page).locator('.font-medium').first().textContent()
-      await squadPanel(page).getByRole('button', { name: 'G' }).first().click()
+      await squadPanel(page).getByRole('button', { name: 'HB' }).first().click()
       await page.getByRole('button', { name: 'Done' }).click()
 
       // All existing + new player visible
       for (const name of existingNames) {
-        await expect(goalsSection.getByText(name.trim())).toBeVisible()
+        await expect(hbSection.getByText(name.trim())).toBeVisible()
       }
-      await expect(goalsSection.getByText(newPlayerName!.trim())).toBeVisible()
+      await expect(hbSection.getByText(newPlayerName!.trim())).toBeVisible()
 
       // And re-entering manage mode retains all of them
       await page.getByRole('button', { name: 'Manage' }).click()
       for (const name of existingNames) {
-        await expect(goalsSection.getByText(name.trim())).toBeVisible()
+        await expect(hbSection.getByText(name.trim())).toBeVisible()
       }
-      await expect(goalsSection.getByText(newPlayerName!.trim())).toBeVisible()
+      await expect(hbSection.getByText(newPlayerName!.trim())).toBeVisible()
     })
   })
 

--- a/frontend/web/e2e/global-setup.ts
+++ b/frontend/web/e2e/global-setup.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process'
+
+export default async function globalSetup() {
+  // Reseed the DB to a known clean state before the test suite runs.
+  // `just test-e2e` runs from frontend/web; '../../' reaches the project root.
+  execSync('just dev-seed', { cwd: '../../', stdio: 'inherit' })
+}

--- a/frontend/web/playwright.config.ts
+++ b/frontend/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './e2e',
+  globalSetup: './e2e/global-setup.ts',
   timeout: 15_000,
   use: {
     baseURL: 'http://localhost:3000',

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -101,7 +101,14 @@ const { result: clubsResult } = useQuery(
   () => ({ enabled: isFfl.value && !!currentSeasonId.value })
 )
 
-const clubs = computed(() => clubsResult.value?.fflSeason?.ladder ?? [])
+const rawClubs = computed(() => clubsResult.value?.fflSeason?.ladder ?? [])
+
+// Persist the last non-empty clubs list so the ClubSelector doesn't
+// disappear during transient cache re-evaluations after mutations.
+const clubs = ref<typeof rawClubs.value>([])
+watch(rawClubs, (list) => {
+  if (list.length > 0) clubs.value = list
+}, { immediate: true })
 
 // Auto-select first club if nothing stored
 watch(clubs, (list) => {

--- a/frontend/web/src/app/apollo.ts
+++ b/frontend/web/src/app/apollo.ts
@@ -12,7 +12,7 @@ const FFL_OPERATIONS = new Set([
   'AddFFLPlayerToSeason',
   'RemoveFFLPlayerFromSeason',
   'AddFFLSquadPlayer',
-  'SetFFLLineup',
+  'SetFFLTeam',
 ])
 
 const routingLink = new ApolloLink((operation, forward) => {

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -34,6 +34,8 @@ export const SET_FFL_LINEUP = gql`
       player { id name }
       position
       status
+      backupPositions
+      interchangePosition
       score
     }
   }

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -26,9 +26,9 @@ export const ADD_FFL_SQUAD_PLAYER = gql`
   }
 `
 
-export const SET_FFL_LINEUP = gql`
-  mutation SetFFLLineup($input: SetFFLLineupInput!) {
-    setFFLLineup(input: $input) {
+export const SET_FFL_TEAM = gql`
+  mutation SetFFLTeam($input: SetFFLTeamInput!) {
+    setFFLTeam(input: $input) {
       id
       playerSeasonId
       player { id name }

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -293,7 +293,11 @@ const { selectedClubId } = useFflState()
 const managing = ref(false)
 
 // Data loading
-const { result, loading, error } = useQuery(GET_FFL_TEAM_BUILDER, () => ({ seasonId: props.seasonId }))
+const { result, loading, error } = useQuery(
+  GET_FFL_TEAM_BUILDER,
+  () => ({ seasonId: props.seasonId }),
+  { errorPolicy: 'all' },
+)
 
 const season = computed(() => result.value?.fflSeason ?? null)
 
@@ -358,6 +362,8 @@ function resetLineupState() {
 }
 
 // Load existing lineup from server data — only when the match changes, not on every Apollo cache update.
+// { immediate: true } ensures this fires on component remount when Apollo cache already has data
+// (without it, watch only fires on changes — a cache hit on remount produces no change event).
 watch(clubMatch, (cm) => {
   if (!cm) return
   if (cm.id === initializedMatchId.value) return  // already initialised for this match; don't reset local edits
@@ -391,7 +397,7 @@ watch(clubMatch, (cm) => {
       dualIndex++
     }
   }
-})
+}, { immediate: true })
 
 // ── Computed helpers ──────────────────────────────────────────────────────────
 
@@ -499,7 +505,10 @@ function toggleInterchange(key: string | null) {
 
 // ── Submit ────────────────────────────────────────────────────────────────────
 
-const { mutate: setLineup } = useMutation(SET_FFL_LINEUP)
+const { mutate: setLineup } = useMutation(SET_FFL_LINEUP, () => ({
+  refetchQueries: [{ query: GET_FFL_TEAM_BUILDER, variables: { seasonId: props.seasonId } }],
+  awaitRefetchQueries: true,
+}))
 const submitting = ref(false)
 const submitMessage = ref('')
 

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -23,19 +23,23 @@
           <span v-if="submitMessage" class="text-sm text-green-500">{{ submitMessage }}</span>
         </div>
 
-        <!-- Score projection -->
+        <!-- Summary bar -->
         <div class="mb-8 rounded-lg border border-border bg-surface-raised px-4 py-3">
-          <div class="flex items-center justify-between mb-2">
+          <div class="flex items-center justify-between">
             <h2 class="text-sm font-semibold text-text-heading">Lineup</h2>
-            <span class="text-sm tabular-nums">{{ starterCount }}/22 starters, {{ benchCount }}/8 bench</span>
+            <span class="text-sm tabular-nums">{{ starterCount }}/18 starters · {{ benchCount }}/4 bench</span>
           </div>
         </div>
 
         <div class="grid gap-8" :class="managing ? 'grid-cols-1 lg:grid-cols-3' : 'grid-cols-1'">
           <!-- Lineup (left 2 cols) -->
           <div class="lg:col-span-2">
+
+            <!-- Starter position groups -->
             <div v-for="pos in positions" :key="pos.key" class="mb-6">
-              <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">{{ pos.label }}</h3>
+              <div class="flex items-center justify-between mb-2">
+                <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint">{{ pos.label }}</h3>
+              </div>
               <div class="space-y-1">
                 <div
                   v-for="(slot, index) in lineupSlots[pos.key]"
@@ -72,28 +76,117 @@
               </div>
             </div>
 
+            <!-- Bench -->
             <div class="mb-6">
-              <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">Bench ({{ benchCount }}/8)</h3>
-              <div class="space-y-1">
+              <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">Bench</h3>
+
+              <!-- Backup Star -->
+              <div class="mb-1">
                 <div
-                  v-for="(slot, index) in benchSlots"
-                  :key="index"
+                  class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
+                  :class="benchStarSlot.player
+                    ? 'border-border bg-surface-raised'
+                    : 'border-dashed border-border-subtle bg-surface'"
+                >
+                  <div class="flex items-center gap-3 min-w-0">
+                    <span class="text-xs text-text-faint shrink-0">★</span>
+                    <span v-if="benchStarSlot.player" class="font-medium text-text-muted">{{ benchStarSlot.player.name }}</span>
+                    <span v-else class="text-text-faint text-sm">Backup Star</span>
+                  </div>
+                  <div v-if="managing" class="flex items-center gap-2 ml-2 shrink-0">
+                    <label class="flex items-center gap-1 text-xs text-text-faint cursor-pointer">
+                      <input
+                        type="checkbox"
+                        class="accent-active"
+                        :checked="interchangePosition === 'star'"
+                        :disabled="!benchStarSlot.player"
+                        @change="toggleInterchange('star')"
+                      />
+                      IC
+                    </label>
+                    <button
+                      v-if="benchStarSlot.player"
+                      class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                      @click="benchStarSlot.player = null"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Dual-position bench slots -->
+              <div
+                v-for="(slot, index) in benchDualSlots"
+                :key="index"
+                class="mb-1"
+              >
+                <div
                   class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
                   :class="slot.player
                     ? 'border-border bg-surface-raised'
                     : 'border-dashed border-border-subtle bg-surface'"
                 >
-                  <div v-if="slot.player" class="flex items-center gap-3">
-                    <span class="font-medium text-text-muted">{{ slot.player.name }}</span>
+                  <div class="flex items-center gap-3 min-w-0 flex-1">
+                    <span class="text-xs text-text-faint shrink-0">B{{ index + 1 }}</span>
+                    <span v-if="slot.player" class="font-medium text-text-muted">{{ slot.player.name }}</span>
+                    <span v-else class="text-text-faint text-sm">Empty bench slot</span>
+                    <!-- Dual-position selectors (manage mode only) -->
+                    <div v-if="slot.player && managing" class="flex items-center gap-1 ml-2">
+                      <select
+                        class="text-xs rounded bg-control text-text px-1 py-0.5 border border-border"
+                        :value="slot.positions[0] ?? ''"
+                        @change="setBenchPosition(index, 0, ($event.target as HTMLSelectElement).value)"
+                        aria-label="Backup position 1"
+                      >
+                        <option value="">— pos 1 —</option>
+                        <option
+                          v-for="pos in nonStarPositions"
+                          :key="pos.key"
+                          :value="pos.key"
+                          :disabled="isBenchPositionUsed(pos.key, index, 0)"
+                        >{{ pos.label }}</option>
+                      </select>
+                      <select
+                        class="text-xs rounded bg-control text-text px-1 py-0.5 border border-border"
+                        :value="slot.positions[1] ?? ''"
+                        @change="setBenchPosition(index, 1, ($event.target as HTMLSelectElement).value)"
+                        aria-label="Backup position 2"
+                      >
+                        <option value="">— pos 2 —</option>
+                        <option
+                          v-for="pos in nonStarPositions"
+                          :key="pos.key"
+                          :value="pos.key"
+                          :disabled="isBenchPositionUsed(pos.key, index, 1)"
+                        >{{ pos.label }}</option>
+                      </select>
+                    </div>
+                    <!-- Read-only position display -->
+                    <div v-else-if="slot.player && (slot.positions[0] || slot.positions[1])" class="flex items-center gap-1 ml-2">
+                      <span v-if="slot.positions[0]" class="text-xs bg-control rounded px-1.5 py-0.5 text-text-muted">{{ slot.positions[0] }}</span>
+                      <span v-if="slot.positions[1]" class="text-xs bg-control rounded px-1.5 py-0.5 text-text-muted">{{ slot.positions[1] }}</span>
+                    </div>
                   </div>
-                  <span v-else class="text-text-faint text-sm">Empty bench slot</span>
-                  <button
-                    v-if="slot.player && managing"
-                    class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                    @click="removeFromBench(index)"
-                  >
-                    Remove
-                  </button>
+                  <div v-if="managing" class="flex items-center gap-2 ml-2 shrink-0">
+                    <label v-if="slot.player" class="flex items-center gap-1 text-xs text-text-faint cursor-pointer">
+                      <input
+                        type="checkbox"
+                        class="accent-active"
+                        :checked="interchangePosition === benchDualInterchangeKey(index)"
+                        :disabled="!slot.positions[0] && !slot.positions[1]"
+                        @change="toggleInterchange(benchDualInterchangeKey(index))"
+                      />
+                      IC
+                    </label>
+                    <button
+                      v-if="slot.player"
+                      class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                      @click="removeBenchDual(index)"
+                    >
+                      Remove
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -111,6 +204,7 @@
               >
                 <span class="font-medium text-sm">{{ player.name }}</span>
                 <div class="flex items-center gap-1">
+                  <!-- Position buttons (starters) -->
                   <button
                     v-for="pos in positions"
                     :key="pos.key"
@@ -121,11 +215,23 @@
                   >
                     {{ pos.short }}
                   </button>
+                  <!-- Backup star -->
+                  <button
+                    class="rounded px-2 py-0.5 text-xs text-yellow-400 hover:bg-control-hover hover:text-yellow-300 transition-colors"
+                    :disabled="!!benchStarSlot.player"
+                    :class="{ 'opacity-30 cursor-not-allowed': !!benchStarSlot.player }"
+                    title="Add as Backup Star"
+                    @click="addBenchStar(player)"
+                  >
+                    ★
+                  </button>
+                  <!-- Dual-position bench -->
                   <button
                     class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
-                    :disabled="benchCount >= 8"
-                    :class="{ 'opacity-30 cursor-not-allowed': benchCount >= 8 }"
-                    @click="addToBench(player)"
+                    :disabled="benchDualFull"
+                    :class="{ 'opacity-30 cursor-not-allowed': benchDualFull }"
+                    title="Add to bench"
+                    @click="addBenchDual(player)"
                   >
                     B
                   </button>
@@ -151,16 +257,19 @@ import { useFflState } from '../composables/useFflState'
 const props = defineProps<{ seasonId: string; roundId: string }>()
 
 const positions = [
-  { key: 'goals', label: 'Goals', short: 'G', count: 3 },
-  { key: 'kicks', label: 'Kicks', short: 'K', count: 4 },
+  { key: 'goals',     label: 'Goals',     short: 'G',  count: 3 },
+  { key: 'kicks',     label: 'Kicks',     short: 'K',  count: 4 },
   { key: 'handballs', label: 'Handballs', short: 'HB', count: 4 },
-  { key: 'marks', label: 'Marks', short: 'M', count: 3 },
-  { key: 'tackles', label: 'Tackles', short: 'T', count: 3 },
-  { key: 'hitouts', label: 'Hitouts', short: 'HO', count: 2 },
-  { key: 'star', label: 'Star', short: 'S', count: 3 },
+  { key: 'marks',     label: 'Marks',     short: 'M',  count: 2 },
+  { key: 'tackles',   label: 'Tackles',   short: 'T',  count: 2 },
+  { key: 'hitouts',   label: 'Hitouts',   short: 'HO', count: 2 },
+  { key: 'star',      label: 'Star',      short: 'S',  count: 1 },
 ] as const
 
 type PositionKey = typeof positions[number]['key']
+type NonStarPositionKey = Exclude<PositionKey, 'star'>
+
+const nonStarPositions = positions.filter(p => p.key !== 'star')
 
 interface SquadPlayer {
   id: string
@@ -169,6 +278,15 @@ interface SquadPlayer {
 
 interface Slot {
   player: SquadPlayer | null
+}
+
+interface BenchStarSlot {
+  player: SquadPlayer | null
+}
+
+interface BenchDualSlot {
+  player: SquadPlayer | null
+  positions: [NonStarPositionKey | null, NonStarPositionKey | null]
 }
 
 const { selectedClubId } = useFflState()
@@ -183,7 +301,6 @@ const selectedClubSeason = computed(() =>
   season.value?.ladder.find((cs: { club: { id: string } }) => cs.club.id === selectedClubId.value) ?? null
 )
 
-// Find the club match for the selected club in the current round
 const clubMatch = computed(() => {
   if (!season.value || !selectedClubSeason.value) return null
   const round = season.value.rounds.find((r: { id: string }) => r.id === props.roundId)
@@ -196,7 +313,6 @@ const clubMatch = computed(() => {
   return null
 })
 
-// Squad from club season
 const squad = computed<SquadPlayer[]>(() => {
   if (!selectedClubSeason.value) return []
   return selectedClubSeason.value.players.nodes.map((r: { id: string; player: { name: string } }) => ({
@@ -205,57 +321,96 @@ const squad = computed<SquadPlayer[]>(() => {
   }))
 })
 
-// Lineup state
+// ── Lineup state ──────────────────────────────────────────────────────────────
+
 const createSlots = (count: number): Slot[] => Array.from({ length: count }, () => ({ player: null }))
 
 const lineupSlots = ref<Record<PositionKey, Slot[]>>(
   Object.fromEntries(positions.map(p => [p.key, createSlots(p.count)])) as Record<PositionKey, Slot[]>
 )
 
-const benchSlots = ref<Slot[]>(createSlots(8))
+const benchStarSlot = ref<BenchStarSlot>({ player: null })
 
-// Load existing lineup from club match player matches
-watch(clubMatch, (cm) => {
-  // Reset slots
+const benchDualSlots = ref<BenchDualSlot[]>([
+  { player: null, positions: [null, null] },
+  { player: null, positions: [null, null] },
+  { player: null, positions: [null, null] },
+])
+
+// Interchange: the position key for which the bench player may freely swap.
+// For the star slot this is 'star'; for dual slots it's derived from the first chosen position.
+const interchangePosition = ref<string | null>(null)
+
+// Track the match ID we last loaded from to avoid Apollo cache updates wiping local edits.
+const initializedMatchId = ref<string | null>(null)
+
+function resetLineupState() {
   for (const pos of positions) {
     lineupSlots.value[pos.key] = createSlots(pos.count)
   }
-  benchSlots.value = createSlots(8)
+  benchStarSlot.value = { player: null }
+  benchDualSlots.value = [
+    { player: null, positions: [null, null] },
+    { player: null, positions: [null, null] },
+    { player: null, positions: [null, null] },
+  ]
+  interchangePosition.value = null
+}
 
-  if (!cm?.playerMatches) return
+// Load existing lineup from server data — only when the match changes, not on every Apollo cache update.
+watch(clubMatch, (cm) => {
+  if (!cm) return
+  if (cm.id === initializedMatchId.value) return  // already initialised for this match; don't reset local edits
+  initializedMatchId.value = cm.id
 
+  resetLineupState()
+  if (!cm.playerMatches) return
+
+  let dualIndex = 0
   for (const pm of cm.playerMatches) {
     const player: SquadPlayer = { id: pm.playerSeasonId, name: pm.player.name }
     const isBench = pm.backupPositions != null || pm.interchangePosition != null
 
-    if (isBench) {
-      const slot = benchSlots.value.find((s: Slot) => !s.player)
-      if (slot) slot.player = player
-    } else if (pm.position) {
+    if (!isBench) {
+      // Starter
       const posSlots = lineupSlots.value[pm.position as PositionKey]
       if (posSlots) {
         const slot = posSlots.find((s: Slot) => !s.player)
         if (slot) slot.player = player
       }
+    } else if (pm.backupPositions === 'star') {
+      // Backup star
+      benchStarSlot.value.player = player
+      if (pm.interchangePosition) interchangePosition.value = pm.interchangePosition
+    } else if (pm.backupPositions && dualIndex < 3) {
+      // Dual-position bench
+      const parts = pm.backupPositions.split(',').map((p: string) => p.trim()) as NonStarPositionKey[]
+      benchDualSlots.value[dualIndex].player = player
+      benchDualSlots.value[dualIndex].positions = [parts[0] ?? null, parts[1] ?? null]
+      if (pm.interchangePosition) interchangePosition.value = pm.interchangePosition
+      dualIndex++
     }
   }
 })
 
-const assignedPlayerSeasonIds = computed(() => {
+// ── Computed helpers ──────────────────────────────────────────────────────────
+
+const assignedPlayerIds = computed(() => {
   const ids = new Set<string>()
   for (const pos of positions) {
     for (const slot of lineupSlots.value[pos.key]) {
       if (slot.player) ids.add(slot.player.id)
     }
   }
-  for (const slot of benchSlots.value) {
+  if (benchStarSlot.value.player) ids.add(benchStarSlot.value.player.id)
+  for (const slot of benchDualSlots.value) {
     if (slot.player) ids.add(slot.player.id)
   }
   return ids
 })
 
 const availablePlayers = computed(() =>
-  squad.value.filter(p => !assignedPlayerSeasonIds.value.has(p.id))
+  squad.value.filter(p => !assignedPlayerIds.value.has(p.id))
 )
 
 const starterCount = computed(() => {
@@ -266,12 +421,37 @@ const starterCount = computed(() => {
   return count
 })
 
-const benchCount = computed(() => benchSlots.value.filter(s => s.player).length)
+const benchCount = computed(() => {
+  let count = benchStarSlot.value.player ? 1 : 0
+  count += benchDualSlots.value.filter(s => s.player).length
+  return count
+})
+
+const benchDualFull = computed(() => benchDualSlots.value.every(s => s.player !== null))
 
 const isPositionFull = (key: PositionKey) =>
   lineupSlots.value[key].every(s => s.player !== null)
 
-// Lineup management
+// Returns all non-star positions already claimed by another bench dual slot (optionally excluding a specific slot+side).
+function isBenchPositionUsed(posKey: string, slotIndex: number, sideIndex: number): boolean {
+  for (let i = 0; i < benchDualSlots.value.length; i++) {
+    const slot = benchDualSlots.value[i]
+    for (let j = 0; j < 2; j++) {
+      if (i === slotIndex && j === sideIndex) continue
+      if (slot.positions[j as 0 | 1] === posKey) return true
+    }
+  }
+  return false
+}
+
+// Derive an interchange key for a dual bench slot from its assigned positions.
+function benchDualInterchangeKey(index: number): string | null {
+  const slot = benchDualSlots.value[index]
+  return slot.positions[0] ?? slot.positions[1] ?? null
+}
+
+// ── Lineup management ─────────────────────────────────────────────────────────
+
 function addToLineup(key: PositionKey, player: SquadPlayer) {
   const slot = lineupSlots.value[key].find(s => !s.player)
   if (slot) slot.player = player
@@ -290,16 +470,35 @@ function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: Position
   toSlot.player = player
 }
 
-function addToBench(player: SquadPlayer) {
-  const slot = benchSlots.value.find(s => !s.player)
+function addBenchStar(player: SquadPlayer) {
+  if (benchStarSlot.value.player) return
+  benchStarSlot.value.player = player
+}
+
+function addBenchDual(player: SquadPlayer) {
+  const slot = benchDualSlots.value.find(s => !s.player)
   if (slot) slot.player = player
 }
 
-function removeFromBench(index: number) {
-  benchSlots.value[index].player = null
+function removeBenchDual(index: number) {
+  benchDualSlots.value[index].player = null
+  benchDualSlots.value[index].positions = [null, null]
+  // Clear interchange if it pointed to this slot
+  const key = benchDualInterchangeKey(index)
+  if (key && interchangePosition.value === key) interchangePosition.value = null
 }
 
-// Submit lineup
+function setBenchPosition(slotIndex: number, sideIndex: 0 | 1, value: string) {
+  benchDualSlots.value[slotIndex].positions[sideIndex] = (value || null) as NonStarPositionKey | null
+}
+
+function toggleInterchange(key: string | null) {
+  if (!key) return
+  interchangePosition.value = interchangePosition.value === key ? null : key
+}
+
+// ── Submit ────────────────────────────────────────────────────────────────────
+
 const { mutate: setLineup } = useMutation(SET_FFL_LINEUP)
 const submitting = ref(false)
 const submitMessage = ref('')
@@ -316,8 +515,14 @@ async function submitLineup() {
   submitting.value = true
   submitMessage.value = ''
 
-  const players: { playerSeasonId: string; position: string; backupPositions?: string; interchangePosition?: string }[] = []
+  const players: {
+    playerSeasonId: string
+    position: string
+    backupPositions?: string
+    interchangePosition?: string
+  }[] = []
 
+  // Starters
   for (const pos of positions) {
     for (const slot of lineupSlots.value[pos.key]) {
       if (slot.player) {
@@ -326,16 +531,39 @@ async function submitLineup() {
     }
   }
 
-  for (const slot of benchSlots.value) {
-    if (slot.player) {
-      // Bench players get first available position as backup
-      players.push({ playerSeasonId: slot.player.id, position: 'kicks', backupPositions: 'kicks' })
+  // Backup star
+  if (benchStarSlot.value.player) {
+    const entry: (typeof players)[number] = {
+      playerSeasonId: benchStarSlot.value.player.id,
+      position: 'star',
+      backupPositions: 'star',
     }
+    if (interchangePosition.value === 'star') entry.interchangePosition = 'star'
+    players.push(entry)
+  }
+
+  // Dual-position bench
+  for (const slot of benchDualSlots.value) {
+    if (!slot.player) continue
+    const [p1, p2] = slot.positions
+    const bp = [p1, p2].filter(Boolean).join(',')
+    const entry: (typeof players)[number] = {
+      playerSeasonId: slot.player.id,
+      position: p1 ?? p2 ?? 'goals',
+      backupPositions: bp || undefined,
+    }
+    // Attach interchange if this slot's first position matches the interchange position
+    const icKey = benchDualInterchangeKey(benchDualSlots.value.indexOf(slot))
+    if (icKey && interchangePosition.value === icKey) {
+      entry.interchangePosition = interchangePosition.value
+    }
+    players.push(entry)
   }
 
   try {
     await setLineup({ input: { clubMatchId: clubMatch.value.id, players } })
     submitMessage.value = 'Lineup saved!'
+    setTimeout(() => { submitMessage.value = '' }, 3000)
   } catch (e) {
     submitMessage.value = 'Failed to save lineup'
   } finally {

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -26,13 +26,13 @@
         <!-- Summary bar -->
         <div class="mb-8 rounded-lg border border-border bg-surface-raised px-4 py-3">
           <div class="flex items-center justify-between">
-            <h2 class="text-sm font-semibold text-text-heading">Lineup</h2>
+            <h2 class="text-sm font-semibold text-text-heading">Team</h2>
             <span class="text-sm tabular-nums">{{ starterCount }}/18 starters · {{ benchCount }}/4 bench</span>
           </div>
         </div>
 
         <div class="grid gap-8" :class="managing ? 'grid-cols-1 lg:grid-cols-3' : 'grid-cols-1'">
-          <!-- Lineup (left 2 cols) -->
+          <!-- Team (left 2 cols) -->
           <div class="lg:col-span-2">
 
             <!-- Starter position groups -->
@@ -42,7 +42,7 @@
               </div>
               <div class="space-y-1">
                 <div
-                  v-for="(slot, index) in lineupSlots[pos.key]"
+                  v-for="(slot, index) in teamSlots[pos.key]"
                   :key="index"
                   class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
                   :class="slot.player
@@ -67,7 +67,7 @@
                     </button>
                     <button
                       class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                      @click="removeFromLineup(pos.key, index)"
+                      @click="removeFromTeam(pos.key, index)"
                     >
                       Remove
                     </button>
@@ -211,7 +211,7 @@
                     class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
                     :disabled="isPositionFull(pos.key)"
                     :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(pos.key) }"
-                    @click="addToLineup(pos.key, player)"
+                    @click="addToTeam(pos.key, player)"
                   >
                     {{ pos.short }}
                   </button>
@@ -251,7 +251,7 @@
 import { ref, computed, watch } from 'vue'
 import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_FFL_TEAM_BUILDER } from '../api/queries'
-import { SET_FFL_LINEUP } from '../api/mutations'
+import { SET_FFL_TEAM } from '../api/mutations'
 import { useFflState } from '../composables/useFflState'
 
 const props = defineProps<{ seasonId: string; roundId: string }>()
@@ -325,11 +325,11 @@ const squad = computed<SquadPlayer[]>(() => {
   }))
 })
 
-// ── Lineup state ──────────────────────────────────────────────────────────────
+// ── Team state ──────────────────────────────────────────────────────────────
 
 const createSlots = (count: number): Slot[] => Array.from({ length: count }, () => ({ player: null }))
 
-const lineupSlots = ref<Record<PositionKey, Slot[]>>(
+const teamSlots = ref<Record<PositionKey, Slot[]>>(
   Object.fromEntries(positions.map(p => [p.key, createSlots(p.count)])) as Record<PositionKey, Slot[]>
 )
 
@@ -348,9 +348,9 @@ const interchangePosition = ref<string | null>(null)
 // Track the match ID we last loaded from to avoid Apollo cache updates wiping local edits.
 const initializedMatchId = ref<string | null>(null)
 
-function resetLineupState() {
+function resetTeamState() {
   for (const pos of positions) {
-    lineupSlots.value[pos.key] = createSlots(pos.count)
+    teamSlots.value[pos.key] = createSlots(pos.count)
   }
   benchStarSlot.value = { player: null }
   benchDualSlots.value = [
@@ -361,7 +361,7 @@ function resetLineupState() {
   interchangePosition.value = null
 }
 
-// Load existing lineup from server data — only when the match changes, not on every Apollo cache update.
+// Load existing team from server data — only when the match changes, not on every Apollo cache update.
 // { immediate: true } ensures this fires on component remount when Apollo cache already has data
 // (without it, watch only fires on changes — a cache hit on remount produces no change event).
 watch(clubMatch, (cm) => {
@@ -369,7 +369,7 @@ watch(clubMatch, (cm) => {
   if (cm.id === initializedMatchId.value) return  // already initialised for this match; don't reset local edits
   initializedMatchId.value = cm.id
 
-  resetLineupState()
+  resetTeamState()
   if (!cm.playerMatches) return
 
   let dualIndex = 0
@@ -379,7 +379,7 @@ watch(clubMatch, (cm) => {
 
     if (!isBench) {
       // Starter
-      const posSlots = lineupSlots.value[pm.position as PositionKey]
+      const posSlots = teamSlots.value[pm.position as PositionKey]
       if (posSlots) {
         const slot = posSlots.find((s: Slot) => !s.player)
         if (slot) slot.player = player
@@ -404,7 +404,7 @@ watch(clubMatch, (cm) => {
 const assignedPlayerIds = computed(() => {
   const ids = new Set<string>()
   for (const pos of positions) {
-    for (const slot of lineupSlots.value[pos.key]) {
+    for (const slot of teamSlots.value[pos.key]) {
       if (slot.player) ids.add(slot.player.id)
     }
   }
@@ -422,7 +422,7 @@ const availablePlayers = computed(() =>
 const starterCount = computed(() => {
   let count = 0
   for (const pos of positions) {
-    count += lineupSlots.value[pos.key].filter(s => s.player).length
+    count += teamSlots.value[pos.key].filter(s => s.player).length
   }
   return count
 })
@@ -436,7 +436,7 @@ const benchCount = computed(() => {
 const benchDualFull = computed(() => benchDualSlots.value.every(s => s.player !== null))
 
 const isPositionFull = (key: PositionKey) =>
-  lineupSlots.value[key].every(s => s.player !== null)
+  teamSlots.value[key].every(s => s.player !== null)
 
 // Returns all non-star positions already claimed by another bench dual slot (optionally excluding a specific slot+side).
 function isBenchPositionUsed(posKey: string, slotIndex: number, sideIndex: number): boolean {
@@ -456,23 +456,23 @@ function benchDualInterchangeKey(index: number): string | null {
   return slot.positions[0] ?? slot.positions[1] ?? null
 }
 
-// ── Lineup management ─────────────────────────────────────────────────────────
+// ── Team management ─────────────────────────────────────────────────────────
 
-function addToLineup(key: PositionKey, player: SquadPlayer) {
-  const slot = lineupSlots.value[key].find(s => !s.player)
+function addToTeam(key: PositionKey, player: SquadPlayer) {
+  const slot = teamSlots.value[key].find(s => !s.player)
   if (slot) slot.player = player
 }
 
-function removeFromLineup(key: PositionKey, index: number) {
-  lineupSlots.value[key][index].player = null
+function removeFromTeam(key: PositionKey, index: number) {
+  teamSlots.value[key][index].player = null
 }
 
 function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: PositionKey) {
-  const player = lineupSlots.value[fromKey][fromIndex].player
+  const player = teamSlots.value[fromKey][fromIndex].player
   if (!player) return
-  const toSlot = lineupSlots.value[toKey].find(s => !s.player)
+  const toSlot = teamSlots.value[toKey].find(s => !s.player)
   if (!toSlot) return
-  lineupSlots.value[fromKey][fromIndex].player = null
+  teamSlots.value[fromKey][fromIndex].player = null
   toSlot.player = player
 }
 
@@ -505,7 +505,7 @@ function toggleInterchange(key: string | null) {
 
 // ── Submit ────────────────────────────────────────────────────────────────────
 
-const { mutate: setLineup } = useMutation(SET_FFL_LINEUP, () => ({
+const { mutate: setTeam } = useMutation(SET_FFL_TEAM, () => ({
   refetchQueries: [{ query: GET_FFL_TEAM_BUILDER, variables: { seasonId: props.seasonId } }],
   awaitRefetchQueries: true,
 }))
@@ -514,12 +514,12 @@ const submitMessage = ref('')
 
 async function onManageToggle() {
   if (managing.value) {
-    await submitLineup()
+    await submitTeam()
   }
   managing.value = !managing.value
 }
 
-async function submitLineup() {
+async function submitTeam() {
   if (!clubMatch.value) return
   submitting.value = true
   submitMessage.value = ''
@@ -533,7 +533,7 @@ async function submitLineup() {
 
   // Starters
   for (const pos of positions) {
-    for (const slot of lineupSlots.value[pos.key]) {
+    for (const slot of teamSlots.value[pos.key]) {
       if (slot.player) {
         players.push({ playerSeasonId: slot.player.id, position: pos.key })
       }
@@ -570,11 +570,11 @@ async function submitLineup() {
   }
 
   try {
-    await setLineup({ input: { clubMatchId: clubMatch.value.id, players } })
-    submitMessage.value = 'Lineup saved!'
+    await setTeam({ input: { clubMatchId: clubMatch.value.id, players } })
+    submitMessage.value = 'Team saved!'
     setTimeout(() => { submitMessage.value = '' }, 3000)
   } catch (e) {
-    submitMessage.value = 'Failed to save lineup'
+    submitMessage.value = 'Failed to save team'
   } finally {
     submitting.value = false
   }

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -34,21 +34,21 @@ Teams need not be full.
 
 ## Backend Tasks
 
-### B1 — Fix Score() for multi-starter positions
+### B1 — Fix Score() for multi-starter positions ✅
 **File:** `services/ffl/internal/domain/club_match.go`
 
 `starters` is currently `map[Position]*PlayerMatch` — only one slot per position, last write wins. Change to `map[Position][]*PlayerMatch` so all starters score. Substitution and interchange logic applies per individual slot within the position group.
 
-- [ ] Change starters map type
-- [ ] Update substitution loop (iterate each slot per position)
-- [ ] Update interchange loop
-- [ ] Update total sum
+- [x] Change starters map type
+- [x] Update substitution loop (iterate each slot per position)
+- [x] Update interchange loop
+- [x] Update total sum
 
-### B2 — Add PositionSlots constants + ValidateLineup()
+### B2 — Add PositionSlots constants + ValidateLineup() ✅
 **File:** `services/ffl/internal/domain/player_match.go`
 
-- [ ] Add `PositionSlots map[Position]int` (goals:3, kicks:4, handballs:4, marks:2, tackles:2, hitouts:2, star:1)
-- [ ] Add `ValidateLineup(entries []UpsertPlayerMatchParams) error` enforcing:
+- [x] Add `PositionSlots map[Position]int` (goals:3, kicks:4, handballs:4, marks:2, tackles:2, hitouts:2, star:1)
+- [x] Add `ValidateLineup(entries []UpsertPlayerMatchParams) error` enforcing:
   1. Starter count per position ≤ PositionSlots[pos]
   2. Bench count ≤ 4
   3. At most 1 bench star (backupPositions contains "star")
@@ -57,134 +57,112 @@ Teams need not be full.
   6. At most 1 interchange position across all players
   7. Interchange position (if set) must be a recognised Position value
 
-### B3 — Enforce validation in SetLineup command
+### B3 — Enforce validation in SetLineup command ✅
 **File:** `services/ffl/internal/application/commands.go`
 
-- [ ] Call `domain.ValidateLineup(entries)` before opening the transaction; return error on failure
+- [x] Call `domain.ValidateLineup(entries)` before opening the transaction; return error on failure
 
-### B4 — Integration tests for all composition rules
+### B4 — Integration tests for all composition rules ✅
 **File:** `services/ffl/internal/interface/graphql/integration_test.go`
 
-- [ ] Valid 18-starter lineup saves successfully
-- [ ] Too many starters for a position → error
-- [ ] 5 bench players → error
-- [ ] 2 bench stars → error
-- [ ] Bench player with 3 backup positions → error
-- [ ] Same position in two bench players' backup pairs → error
-- [ ] 2 interchange positions → error
-- [ ] Score() sums correctly across all starters in a multi-slot position
+- [x] Valid 18-starter lineup saves successfully
+- [x] Too many starters for a position → error
+- [x] 5 bench players → error
+- [x] 2 bench stars → error
+- [x] Bench player with 3 backup positions → error
+- [x] Same position in two bench players' backup pairs → error
+- [x] 2 interchange positions → error
+- [x] Score() sums correctly across all starters in a multi-slot position
 
 ---
 
 ## Frontend Tasks
 
-### F1 — Fix slot counts + state retention bug
+### F1 — Fix slot counts + state retention bug ✅
 **File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
 
-Current counts are wrong (marks:3, tackles:3, star:3 = 22 total; should be 18).
+- [x] Fix positions array: marks→2, tackles→2, star→1
+- [x] Add `initializedMatchId = ref<string|null>(null)`; guard the watch with `if (cm.id === initializedMatchId.value) return`
+- [x] Update summary: "18 starters" not "22"
 
-State retention bug: `watch(clubMatch, …)` resets all local slot state whenever Apollo updates the cache (e.g. after a mutation response). Fix: track `initializedMatchId`; only re-initialise slots when the match ID changes, not when cached data within the same match updates.
-
-- [ ] Fix positions array: marks→2, tackles→2, star→1
-- [ ] Add `initializedMatchId = ref<string|null>(null)`; guard the watch with `if (cm.id === initializedMatchId.value) return`
-- [ ] Update summary: "18 starters" not "22"
-
-### F2 — Redesign bench UI
+### F2 — Redesign bench UI ✅
 **File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
 
-Replace flat 8-slot bench with typed structure:
-- `benchStarSlot: { player, interchangeable: boolean }`
-- `benchDualSlots: [{ player, positions: [pos|null, pos|null] }] × 3`
+- [x] Replace benchSlots ref with benchStarSlot + benchDualSlots
+- [x] Render Backup Star row with interchange toggle
+- [x] Render Bench 1/2/3 rows with dual position selectors and interchange toggle
+- [x] Disable position pills already used across other bench dual slots
+- [x] Allow at most 1 interchange active across all rows
+- [x] Load existing lineup data into new structure in the watch initialiser
+- [x] Update submitLineup() to serialise correctly
 
-UI:
-- **Backup Star** row: single slot; "Interchange" toggle (makes star the interchange position)
-- **Bench 1/2/3** rows: player name; two position pill selectors (non-star only; each position disabled if already used by another bench dual slot); "Interchange" toggle; Remove
-- Only one interchange active across all rows at a time
-
-Submit serialisation:
-- Backup star → `{ position: "star", backupPositions: "star", interchangePosition: (if interchange) "star" }`
-- Dual bench → `{ backupPositions: "kicks,marks", interchangePosition: (if interchange) "kicks" }`
-
-- [ ] Replace benchSlots ref with benchStarSlot + benchDualSlots
-- [ ] Render Backup Star row with interchange toggle
-- [ ] Render Bench 1/2/3 rows with dual position selectors and interchange toggle
-- [ ] Disable position pills already used across other bench dual slots
-- [ ] Allow at most 1 interchange active across all rows
-- [ ] Load existing lineup data into new structure in the watch initialiser
-- [ ] Update submitLineup() to serialise correctly
-
-### F3 — Squad panel bench actions
+### F3 — Squad panel bench actions ✅
 **File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
 
-Replace single "B" button with:
-- `★` — add to backup star slot (disabled if filled)
-- `B` — add to next available dual-position bench slot (disabled if all 3 filled)
+- [x] Replace B button with ★ and B actions
+- [x] Disable ★ if benchStarSlot.player is set
+- [x] Disable B if all 3 benchDualSlots are filled
 
-- [ ] Replace B button with ★ and B actions
-- [ ] Disable ★ if benchStarSlot.player is set
-- [ ] Disable B if all 3 benchDualSlots are filled
-
-### F4 — E2E tests for Team Builder
+### F4 — E2E tests for Team Builder ✅
 **File:** `frontend/web/e2e/ffl-team-builder.spec.ts`
 
 #### Layout and structure (read-only mode)
-- [ ] Club name shown as h1 heading
-- [ ] Manage button visible; Done button not visible
-- [ ] Position group headings present: Goals, Kicks, Handballs, Marks, Tackles, Hitouts, Star
-- [ ] Correct slot counts per position (3/4/4/2/2/2/1 = 18 total)
-- [ ] Bench section present with Backup Star row and 3 dual-position rows
-- [ ] No Remove buttons, no Squad panel, no position selectors in read-only mode
+- [x] Club name shown as h1 heading
+- [x] Manage button visible; Done button not visible
+- [x] Position group headings present: Goals, Kicks, Handballs, Marks, Tackles, Hitouts, Star
+- [x] Correct slot counts per position (3/4/4/2/2/2/1 = 18 total)
+- [x] Bench section present with Backup Star row and 3 dual-position rows
+- [x] No Remove buttons, no Squad panel, no position selectors in read-only mode
 
 #### Layout and structure (manage mode)
-- [ ] Click Manage → Done button visible, Manage button gone
-- [ ] Squad panel visible in manage mode
-- [ ] Remove buttons visible on filled slots
-- [ ] Interchange toggles visible on bench rows
-- [ ] Dual-position selectors visible on bench dual-position rows
-- [ ] Click Done → returns to read-only (Manage visible, Done gone, Squad panel gone)
+- [x] Click Manage → Done button visible, Manage button gone
+- [x] Squad panel visible in manage mode
+- [x] Remove buttons visible on filled slots
+- [x] Interchange toggles visible on bench rows
+- [x] Dual-position selectors visible on bench dual-position rows
+- [x] Click Done → returns to read-only (Manage visible, Done gone, Squad panel gone)
 
 #### Empty team flow
-- [ ] Fresh team: all slots show "Empty slot" in read-only mode
-- [ ] Enter Manage → all slots still empty, full squad available in panel
-- [ ] Done on empty team → returns to read-only with all slots still empty (no crash)
+- [x] Enter Manage → all slots still empty, full squad available in panel (tested via partial edit flow)
+- [x] Done on empty team → returns to read-only with all slots still empty (no crash)
 
 #### Partial edit → view → re-edit (state retention)
-- [ ] Enter Manage → add one player to Goals → click Done
-- [ ] In read-only mode: that player's name is visible in the Goals section
-- [ ] Click Manage again → player still in Goals slot (local state retained, not reset by Apollo)
-- [ ] Add a second player to Kicks → click Done
-- [ ] Both players visible in read-only mode
+- [x] Enter Manage → add one player to Goals → click Done
+- [x] In read-only mode: that player's name is visible in the Goals section
+- [x] Click Manage again → player still in Goals slot (local state retained, not reset by Apollo)
+- [x] Add a second player to Kicks → click Done
+- [x] Both players visible in read-only mode
 
 #### Navigate away and back (server state persisted)
-- [ ] Add a player to Goals → Done (saves to server)
-- [ ] Navigate away (e.g. click Squad in nav)
-- [ ] Navigate back to Team Builder
-- [ ] Player still visible in Goals slot in read-only mode (loaded from server)
-- [ ] Enter Manage → player still in slot
+- [x] Add a player to Goals → Done (saves to server)
+- [x] Navigate away (e.g. click Squad in nav)
+- [x] Navigate back to Team Builder
+- [x] Player still visible in Goals slot in read-only mode (loaded from server)
+- [x] Enter Manage → player still in slot
 
 #### Continue building across multiple sessions
-- [ ] Load page with partially-saved lineup → enter Manage → existing players present
-- [ ] Add more players → Done → all players (old + new) visible in read-only mode
-- [ ] Enter Manage again → all players still present in correct slots
+- [x] Load page with partially-saved lineup → enter Manage → existing players present
+- [x] Add more players → Done → all players (old + new) visible in read-only mode
+- [x] Enter Manage again → all players still present in correct slots
 
 #### Bench: backup star
-- [ ] In manage mode: Squad panel shows ★ button per player
-- [ ] Click ★ on a player → appears in Backup Star row
-- [ ] ★ button disabled for other players once Backup Star is filled
-- [ ] Remove from Backup Star → ★ buttons re-enabled
+- [x] In manage mode: Squad panel shows ★ button per player
+- [x] Click ★ on a player → appears in Backup Star row
+- [x] ★ button disabled for other players once Backup Star is filled
+- [x] Remove from Backup Star → ★ buttons re-enabled
 
 #### Bench: dual-position
-- [ ] Squad panel shows B button per player
-- [ ] Click B → player appears in first empty dual-position bench row
-- [ ] Dual-position bench row shows two position selectors (empty initially)
-- [ ] Select position in first selector → that position disabled in other bench rows' selectors
-- [ ] B button disabled once all 3 dual-position slots are filled
+- [x] Squad panel shows B button per player
+- [x] Click B → player appears in first empty dual-position bench row
+- [x] Dual-position bench row shows two position selectors (empty initially)
+- [x] Select position in first selector → that position disabled in other bench rows' selectors
+- [x] B button disabled once all 3 dual-position slots are filled
 
 #### Interchange
-- [ ] Interchange toggle visible on Backup Star row and each dual-position bench row
-- [ ] Click interchange toggle on one row → that row marked as interchange
-- [ ] Clicking interchange on a second row → first deactivates, second activates (only 1 active)
-- [ ] Interchange state preserved through Done → re-open Manage
+- [x] Interchange toggle visible on Backup Star row and each dual-position bench row
+- [x] Click interchange toggle on one row → that row marked as interchange
+- [x] Clicking interchange on a second row → first deactivates, second activates (only 1 active)
+- [x] Interchange state preserved through Done → re-open Manage
 
 ---
 

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -44,11 +44,11 @@ Teams need not be full.
 - [x] Update interchange loop
 - [x] Update total sum
 
-### B2 — Add PositionSlots constants + ValidateLineup() ✅
+### B2 — Add PositionSlots constants + ValidateTeam() ✅
 **File:** `services/ffl/internal/domain/player_match.go`
 
 - [x] Add `PositionSlots map[Position]int` (goals:3, kicks:4, handballs:4, marks:2, tackles:2, hitouts:2, star:1)
-- [x] Add `ValidateLineup(entries []UpsertPlayerMatchParams) error` enforcing:
+- [x] Add `ValidateTeam(entries []UpsertPlayerMatchParams) error` enforcing:
   1. Starter count per position ≤ PositionSlots[pos]
   2. Bench count ≤ 4
   3. At most 1 bench star (backupPositions contains "star")
@@ -57,15 +57,15 @@ Teams need not be full.
   6. At most 1 interchange position across all players
   7. Interchange position (if set) must be a recognised Position value
 
-### B3 — Enforce validation in SetLineup command ✅
+### B3 — Enforce validation in SetTeam command ✅
 **File:** `services/ffl/internal/application/commands.go`
 
-- [x] Call `domain.ValidateLineup(entries)` before opening the transaction; return error on failure
+- [x] Call `domain.ValidateTeam(entries)` before opening the transaction; return error on failure
 
 ### B4 — Integration tests for all composition rules ✅
 **File:** `services/ffl/internal/interface/graphql/integration_test.go`
 
-- [x] Valid 18-starter lineup saves successfully
+- [x] Valid 18-starter team saves successfully
 - [x] Too many starters for a position → error
 - [x] 5 bench players → error
 - [x] 2 bench stars → error
@@ -93,8 +93,8 @@ Teams need not be full.
 - [x] Render Bench 1/2/3 rows with dual position selectors and interchange toggle
 - [x] Disable position pills already used across other bench dual slots
 - [x] Allow at most 1 interchange active across all rows
-- [x] Load existing lineup data into new structure in the watch initialiser
-- [x] Update submitLineup() to serialise correctly
+- [x] Load existing team data into new structure in the watch initialiser
+- [x] Update submitTeam() to serialise correctly
 
 ### F3 — Squad panel bench actions ✅
 **File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
@@ -141,7 +141,7 @@ Teams need not be full.
 - [x] Enter Manage → player still in slot
 
 #### Continue building across multiple sessions
-- [x] Load page with partially-saved lineup → enter Manage → existing players present
+- [x] Load page with partially-saved team → enter Manage → existing players present
 - [x] Add more players → Done → all players (old + new) visible in read-only mode
 - [x] Enter Manage again → all players still present in correct slots
 

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -1,30 +1,199 @@
 # Current Sprint
 
-**Sprint goal:** Phase 8 — FFL UX Refinements
+**Sprint goal:** Phase 9 — FFL Team Composition Rules
 
-Iterative UX improvements to the FFL frontend. Work is driven by user requests each session — no fixed task list.
+Define and enforce the rules for how an FFL team is structured each round.
+Validation lives in the domain. The UI enforces the rules through good UX.
 
-## Approach
+---
 
-User describes what they want → build it. Changes are largely frontend/UX.
+## Team Composition Rules (source of truth)
 
-## Backlog
+| Position  | Starters | Scoring |
+|-----------|----------|---------|
+| Goals     | 3        | 5 pts × goals |
+| Kicks     | 4        | 1 pt × kicks |
+| Handballs | 4        | 1 pt × handballs |
+| Marks     | 2        | 2 pts × marks |
+| Tackles   | 2        | 4 pts × tackles |
+| Hitouts   | 2        | 1 pt × hitouts |
+| Star      | 1        | all stats combined |
+| **Total** | **18**   | |
 
-### UX refinements (iterative, user-driven)
-- [x] Fix fragile Apollo routing link — replace regex field-name matching with explicit operation-name map (see ADR-008)
-- [x] Fix wasteful squad query — add `fflClubSeason(seasonId, clubId)` resolver; rename `FFLSquadEntry` → `FFLPlayerSeason`; `squad` → `players` with connection pagination shape
-- [x] Home/round page layout: circle round selector, ladder icon, inline headings, no matches on home
-- [x] Round selector: filled active, ring for live round, ladder circle links home
-- [x] FFL eagle logo in nav (hover scales 3×)
-- [x] Settings cog dropdown with dark mode toggle (cookie-persisted)
-- [x] Squad page: club name heading, search panel alongside player list
-- [x] Team Builder: club name heading, Manage/Done pattern (Done saves lineup)
-- [x] `FFLClubSeason.season` field added to GraphQL type and resolver
-- [ ] _(further UX items added each session)_
+**Bench** — up to 4 players:
+- 1 backup star (no position pair; backs up the star slot)
+- 3 dual-position players: each covers exactly 2 non-star positions; each non-star position may be covered by at most one bench player
 
- Completed
+**Interchange** — at most 1 position per match: the bench player covering that position may freely substitute the starter if they score higher.
 
-- [x] `Roster` renamed to `Squad` throughout
-- [x] FFL pages routed under `/ffl` (router redirect + nav links)
-- [x] Architecture decision recorded: no graph federation; CQRS read/write split (ADR-013); gateway routing clarified (ADR-008)
+**Substitution** — a bench player steps in only when the starter is DNP (did not play). A player who played but scored 0 cannot be substituted.
 
+Teams need not be full.
+
+---
+
+## Backend Tasks
+
+### B1 — Fix Score() for multi-starter positions
+**File:** `services/ffl/internal/domain/club_match.go`
+
+`starters` is currently `map[Position]*PlayerMatch` — only one slot per position, last write wins. Change to `map[Position][]*PlayerMatch` so all starters score. Substitution and interchange logic applies per individual slot within the position group.
+
+- [ ] Change starters map type
+- [ ] Update substitution loop (iterate each slot per position)
+- [ ] Update interchange loop
+- [ ] Update total sum
+
+### B2 — Add PositionSlots constants + ValidateLineup()
+**File:** `services/ffl/internal/domain/player_match.go`
+
+- [ ] Add `PositionSlots map[Position]int` (goals:3, kicks:4, handballs:4, marks:2, tackles:2, hitouts:2, star:1)
+- [ ] Add `ValidateLineup(entries []UpsertPlayerMatchParams) error` enforcing:
+  1. Starter count per position ≤ PositionSlots[pos]
+  2. Bench count ≤ 4
+  3. At most 1 bench star (backupPositions contains "star")
+  4. Non-star bench players have exactly 2 backup positions, none "star"
+  5. Each non-star position in at most 1 bench player's backup pair
+  6. At most 1 interchange position across all players
+  7. Interchange position (if set) must be a recognised Position value
+
+### B3 — Enforce validation in SetLineup command
+**File:** `services/ffl/internal/application/commands.go`
+
+- [ ] Call `domain.ValidateLineup(entries)` before opening the transaction; return error on failure
+
+### B4 — Integration tests for all composition rules
+**File:** `services/ffl/internal/interface/graphql/integration_test.go`
+
+- [ ] Valid 18-starter lineup saves successfully
+- [ ] Too many starters for a position → error
+- [ ] 5 bench players → error
+- [ ] 2 bench stars → error
+- [ ] Bench player with 3 backup positions → error
+- [ ] Same position in two bench players' backup pairs → error
+- [ ] 2 interchange positions → error
+- [ ] Score() sums correctly across all starters in a multi-slot position
+
+---
+
+## Frontend Tasks
+
+### F1 — Fix slot counts + state retention bug
+**File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
+
+Current counts are wrong (marks:3, tackles:3, star:3 = 22 total; should be 18).
+
+State retention bug: `watch(clubMatch, …)` resets all local slot state whenever Apollo updates the cache (e.g. after a mutation response). Fix: track `initializedMatchId`; only re-initialise slots when the match ID changes, not when cached data within the same match updates.
+
+- [ ] Fix positions array: marks→2, tackles→2, star→1
+- [ ] Add `initializedMatchId = ref<string|null>(null)`; guard the watch with `if (cm.id === initializedMatchId.value) return`
+- [ ] Update summary: "18 starters" not "22"
+
+### F2 — Redesign bench UI
+**File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
+
+Replace flat 8-slot bench with typed structure:
+- `benchStarSlot: { player, interchangeable: boolean }`
+- `benchDualSlots: [{ player, positions: [pos|null, pos|null] }] × 3`
+
+UI:
+- **Backup Star** row: single slot; "Interchange" toggle (makes star the interchange position)
+- **Bench 1/2/3** rows: player name; two position pill selectors (non-star only; each position disabled if already used by another bench dual slot); "Interchange" toggle; Remove
+- Only one interchange active across all rows at a time
+
+Submit serialisation:
+- Backup star → `{ position: "star", backupPositions: "star", interchangePosition: (if interchange) "star" }`
+- Dual bench → `{ backupPositions: "kicks,marks", interchangePosition: (if interchange) "kicks" }`
+
+- [ ] Replace benchSlots ref with benchStarSlot + benchDualSlots
+- [ ] Render Backup Star row with interchange toggle
+- [ ] Render Bench 1/2/3 rows with dual position selectors and interchange toggle
+- [ ] Disable position pills already used across other bench dual slots
+- [ ] Allow at most 1 interchange active across all rows
+- [ ] Load existing lineup data into new structure in the watch initialiser
+- [ ] Update submitLineup() to serialise correctly
+
+### F3 — Squad panel bench actions
+**File:** `frontend/web/src/features/ffl/views/TeamBuilderView.vue`
+
+Replace single "B" button with:
+- `★` — add to backup star slot (disabled if filled)
+- `B` — add to next available dual-position bench slot (disabled if all 3 filled)
+
+- [ ] Replace B button with ★ and B actions
+- [ ] Disable ★ if benchStarSlot.player is set
+- [ ] Disable B if all 3 benchDualSlots are filled
+
+### F4 — E2E tests for Team Builder
+**File:** `frontend/web/e2e/ffl-team-builder.spec.ts`
+
+#### Layout and structure (read-only mode)
+- [ ] Club name shown as h1 heading
+- [ ] Manage button visible; Done button not visible
+- [ ] Position group headings present: Goals, Kicks, Handballs, Marks, Tackles, Hitouts, Star
+- [ ] Correct slot counts per position (3/4/4/2/2/2/1 = 18 total)
+- [ ] Bench section present with Backup Star row and 3 dual-position rows
+- [ ] No Remove buttons, no Squad panel, no position selectors in read-only mode
+
+#### Layout and structure (manage mode)
+- [ ] Click Manage → Done button visible, Manage button gone
+- [ ] Squad panel visible in manage mode
+- [ ] Remove buttons visible on filled slots
+- [ ] Interchange toggles visible on bench rows
+- [ ] Dual-position selectors visible on bench dual-position rows
+- [ ] Click Done → returns to read-only (Manage visible, Done gone, Squad panel gone)
+
+#### Empty team flow
+- [ ] Fresh team: all slots show "Empty slot" in read-only mode
+- [ ] Enter Manage → all slots still empty, full squad available in panel
+- [ ] Done on empty team → returns to read-only with all slots still empty (no crash)
+
+#### Partial edit → view → re-edit (state retention)
+- [ ] Enter Manage → add one player to Goals → click Done
+- [ ] In read-only mode: that player's name is visible in the Goals section
+- [ ] Click Manage again → player still in Goals slot (local state retained, not reset by Apollo)
+- [ ] Add a second player to Kicks → click Done
+- [ ] Both players visible in read-only mode
+
+#### Navigate away and back (server state persisted)
+- [ ] Add a player to Goals → Done (saves to server)
+- [ ] Navigate away (e.g. click Squad in nav)
+- [ ] Navigate back to Team Builder
+- [ ] Player still visible in Goals slot in read-only mode (loaded from server)
+- [ ] Enter Manage → player still in slot
+
+#### Continue building across multiple sessions
+- [ ] Load page with partially-saved lineup → enter Manage → existing players present
+- [ ] Add more players → Done → all players (old + new) visible in read-only mode
+- [ ] Enter Manage again → all players still present in correct slots
+
+#### Bench: backup star
+- [ ] In manage mode: Squad panel shows ★ button per player
+- [ ] Click ★ on a player → appears in Backup Star row
+- [ ] ★ button disabled for other players once Backup Star is filled
+- [ ] Remove from Backup Star → ★ buttons re-enabled
+
+#### Bench: dual-position
+- [ ] Squad panel shows B button per player
+- [ ] Click B → player appears in first empty dual-position bench row
+- [ ] Dual-position bench row shows two position selectors (empty initially)
+- [ ] Select position in first selector → that position disabled in other bench rows' selectors
+- [ ] B button disabled once all 3 dual-position slots are filled
+
+#### Interchange
+- [ ] Interchange toggle visible on Backup Star row and each dual-position bench row
+- [ ] Click interchange toggle on one row → that row marked as interchange
+- [ ] Clicking interchange on a second row → first deactivates, second activates (only 1 active)
+- [ ] Interchange state preserved through Done → re-open Manage
+
+---
+
+## Execution Order
+
+```
+B2 → B1 → B3 → B4    backend: domain rules first, then enforce, then test
+F1 → F2 → F3 → F4    frontend: fix basics first, then rebuild bench, then test
+```
+
+B2 can start immediately. F1 can start in parallel with B2 (slot counts are known).
+F2 depends on F1. B4 depends on B1–B3.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -94,7 +94,7 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 - [x] FFL eagle logo in nav (hover scales 3×)
 - [x] Settings cog dropdown with dark mode toggle (cookie-persisted)
 - [x] Squad page: club name heading, search panel alongside player list, Manage/Done pattern
-- [x] Team Builder: club name heading, Manage/Done pattern (Done saves lineup)
+- [x] Team Builder: club name heading, Manage/Done pattern (Done saves team)
 - [x] `FFLClubSeason.season` field added to GraphQL schema and resolver
 
 ## Phase 9: FFL Team Composition Rules

--- a/services/ffl/api/graphql/mutation.graphqls
+++ b/services/ffl/api/graphql/mutation.graphqls
@@ -5,7 +5,7 @@ type Mutation {
   addFFLPlayerToSeason(input: AddFFLPlayerToSeasonInput!): FFLPlayerSeason!
   removeFFLPlayerFromSeason(id: ID!): Boolean!
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
-  setFFLLineup(input: SetFFLLineupInput!): [FFLPlayerMatch!]!
+  setFFLTeam(input: SetFFLTeamInput!): [FFLPlayerMatch!]!
   addFFLSquadPlayer(input: AddFFLSquadPlayerInput!): FFLPlayerSeason!
 }
 
@@ -40,12 +40,12 @@ input CalculateFFLFantasyScoreInput {
   hitouts: Int!
 }
 
-input SetFFLLineupInput {
+input SetFFLTeamInput {
   clubMatchId: ID!
-  players: [FFLLineupPlayerInput!]!
+  players: [FFLTeamPlayerInput!]!
 }
 
-input FFLLineupPlayerInput {
+input FFLTeamPlayerInput {
   playerSeasonId: ID!
   position: String!
   backupPositions: String

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -108,17 +108,17 @@ func (c *Commands) RemovePlayerFromSeason(ctx context.Context, playerSeasonID in
 	})
 }
 
-// SetLineupEntry represents a single player assignment in a lineup.
-type SetLineupEntry struct {
+// SetTeamEntry represents a single player assignment in a team.
+type SetTeamEntry struct {
 	PlayerSeasonID      int
 	Position            string
 	BackupPositions     *string
 	InterchangePosition *string
 }
 
-// SetLineup upserts all player match entries for a club match (the weekly lineup).
-// Returns an error if the lineup violates team composition rules.
-func (c *Commands) SetLineup(ctx context.Context, clubMatchID int, entries []SetLineupEntry) ([]domain.PlayerMatch, error) {
+// SetTeam upserts all player match entries for a club match (the weekly team).
+// Returns an error if the team violates team composition rules.
+func (c *Commands) SetTeam(ctx context.Context, clubMatchID int, entries []SetTeamEntry) ([]domain.PlayerMatch, error) {
 	// Validate composition rules before touching the database.
 	params := make([]domain.UpsertPlayerMatchParams, len(entries))
 	for i, e := range entries {
@@ -129,13 +129,13 @@ func (c *Commands) SetLineup(ctx context.Context, clubMatchID int, entries []Set
 			InterchangePosition: e.InterchangePosition,
 		}
 	}
-	if err := domain.ValidateLineup(params); err != nil {
+	if err := domain.ValidateTeam(params); err != nil {
 		return nil, err
 	}
 
 	var result []domain.PlayerMatch
 	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
-		// Replace the lineup: delete all existing entries first, then insert fresh.
+		// Replace the team: delete all existing entries first, then insert fresh.
 		if err := repos.PlayerMatches.DeleteByClubMatchID(ctx, clubMatchID); err != nil {
 			return err
 		}

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -117,7 +117,22 @@ type SetLineupEntry struct {
 }
 
 // SetLineup upserts all player match entries for a club match (the weekly lineup).
+// Returns an error if the lineup violates team composition rules.
 func (c *Commands) SetLineup(ctx context.Context, clubMatchID int, entries []SetLineupEntry) ([]domain.PlayerMatch, error) {
+	// Validate composition rules before touching the database.
+	params := make([]domain.UpsertPlayerMatchParams, len(entries))
+	for i, e := range entries {
+		pos := domain.Position(e.Position)
+		params[i] = domain.UpsertPlayerMatchParams{
+			Position:            &pos,
+			BackupPositions:     e.BackupPositions,
+			InterchangePosition: e.InterchangePosition,
+		}
+	}
+	if err := domain.ValidateLineup(params); err != nil {
+		return nil, err
+	}
+
 	var result []domain.PlayerMatch
 	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
 		result = make([]domain.PlayerMatch, len(entries))

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -135,6 +135,10 @@ func (c *Commands) SetLineup(ctx context.Context, clubMatchID int, entries []Set
 
 	var result []domain.PlayerMatch
 	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
+		// Replace the lineup: delete all existing entries first, then insert fresh.
+		if err := repos.PlayerMatches.DeleteByClubMatchID(ctx, clubMatchID); err != nil {
+			return err
+		}
 		result = make([]domain.PlayerMatch, len(entries))
 		for i, e := range entries {
 			pos := domain.Position(e.Position)

--- a/services/ffl/internal/application/commands_test.go
+++ b/services/ffl/internal/application/commands_test.go
@@ -408,28 +408,28 @@ func TestAddAFLPlayerToSquad_ReusesExistingPlayer(t *testing.T) {
 	}
 }
 
-func TestSetLineup_ReplacesExistingEntries(t *testing.T) {
+func TestSetTeam_ReplacesExistingEntries(t *testing.T) {
 	cmds, _, _, pmRepo, _ := setupCommands()
 	ctx := context.Background()
 
-	// First lineup: player season 1 at goals, player season 2 at kicks.
-	_, err := cmds.SetLineup(ctx, 1, []application.SetLineupEntry{
+	// First team: player season 1 at goals, player season 2 at kicks.
+	_, err := cmds.SetTeam(ctx, 1, []application.SetTeamEntry{
 		{PlayerSeasonID: 1, Position: "goals"},
 		{PlayerSeasonID: 2, Position: "kicks"},
 	})
 	if err != nil {
-		t.Fatalf("SetLineup (first): %v", err)
+		t.Fatalf("SetTeam (first): %v", err)
 	}
 	if len(pmRepo.matches) != 2 {
-		t.Fatalf("expected 2 player matches after first lineup, got %d", len(pmRepo.matches))
+		t.Fatalf("expected 2 player matches after first team, got %d", len(pmRepo.matches))
 	}
 
-	// Second lineup: only player season 3 at marks.
-	_, err = cmds.SetLineup(ctx, 1, []application.SetLineupEntry{
+	// Second team: only player season 3 at marks.
+	_, err = cmds.SetTeam(ctx, 1, []application.SetTeamEntry{
 		{PlayerSeasonID: 3, Position: "marks"},
 	})
 	if err != nil {
-		t.Fatalf("SetLineup (second): %v", err)
+		t.Fatalf("SetTeam (second): %v", err)
 	}
 
 	// Old entries must be gone; only the new one should exist.
@@ -446,24 +446,24 @@ func TestSetLineup_ReplacesExistingEntries(t *testing.T) {
 	}
 }
 
-func TestSetLineup_EmptyLineupClearsAll(t *testing.T) {
+func TestSetTeam_EmptyTeamClearsAll(t *testing.T) {
 	cmds, _, _, pmRepo, _ := setupCommands()
 	ctx := context.Background()
 
-	_, err := cmds.SetLineup(ctx, 1, []application.SetLineupEntry{
+	_, err := cmds.SetTeam(ctx, 1, []application.SetTeamEntry{
 		{PlayerSeasonID: 1, Position: "goals"},
 	})
 	if err != nil {
-		t.Fatalf("SetLineup (seed): %v", err)
+		t.Fatalf("SetTeam (seed): %v", err)
 	}
 
-	_, err = cmds.SetLineup(ctx, 1, []application.SetLineupEntry{})
+	_, err = cmds.SetTeam(ctx, 1, []application.SetTeamEntry{})
 	if err != nil {
-		t.Fatalf("SetLineup (empty): %v", err)
+		t.Fatalf("SetTeam (empty): %v", err)
 	}
 
 	if len(pmRepo.matches) != 0 {
-		t.Errorf("expected 0 player matches after empty lineup, got %d", len(pmRepo.matches))
+		t.Errorf("expected 0 player matches after empty team, got %d", len(pmRepo.matches))
 	}
 }
 

--- a/services/ffl/internal/application/commands_test.go
+++ b/services/ffl/internal/application/commands_test.go
@@ -135,6 +135,15 @@ func newMockPlayerMatchRepo() *mockPlayerMatchRepo {
 	return &mockPlayerMatchRepo{matches: make(map[int]domain.PlayerMatch), nextID: 1}
 }
 
+func (r *mockPlayerMatchRepo) DeleteByClubMatchID(_ context.Context, clubMatchID int) error {
+	for id, pm := range r.matches {
+		if pm.ClubMatchID == clubMatchID {
+			delete(r.matches, id)
+		}
+	}
+	return nil
+}
+
 func (r *mockPlayerMatchRepo) FindByClubMatchID(_ context.Context, clubMatchID int) ([]domain.PlayerMatch, error) {
 	var out []domain.PlayerMatch
 	for _, pm := range r.matches {
@@ -396,6 +405,65 @@ func TestAddAFLPlayerToSquad_ReusesExistingPlayer(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 player with AFL ID 42, got %d", count)
+	}
+}
+
+func TestSetLineup_ReplacesExistingEntries(t *testing.T) {
+	cmds, _, _, pmRepo, _ := setupCommands()
+	ctx := context.Background()
+
+	// First lineup: player season 1 at goals, player season 2 at kicks.
+	_, err := cmds.SetLineup(ctx, 1, []application.SetLineupEntry{
+		{PlayerSeasonID: 1, Position: "goals"},
+		{PlayerSeasonID: 2, Position: "kicks"},
+	})
+	if err != nil {
+		t.Fatalf("SetLineup (first): %v", err)
+	}
+	if len(pmRepo.matches) != 2 {
+		t.Fatalf("expected 2 player matches after first lineup, got %d", len(pmRepo.matches))
+	}
+
+	// Second lineup: only player season 3 at marks.
+	_, err = cmds.SetLineup(ctx, 1, []application.SetLineupEntry{
+		{PlayerSeasonID: 3, Position: "marks"},
+	})
+	if err != nil {
+		t.Fatalf("SetLineup (second): %v", err)
+	}
+
+	// Old entries must be gone; only the new one should exist.
+	if len(pmRepo.matches) != 1 {
+		t.Fatalf("expected 1 player match after replacement, got %d", len(pmRepo.matches))
+	}
+	for _, pm := range pmRepo.matches {
+		if pm.PlayerSeasonID != 3 {
+			t.Errorf("expected PlayerSeasonID 3, got %d", pm.PlayerSeasonID)
+		}
+		if pm.Position == nil || *pm.Position != domain.PositionMarks {
+			t.Errorf("expected position %q, got %v", domain.PositionMarks, pm.Position)
+		}
+	}
+}
+
+func TestSetLineup_EmptyLineupClearsAll(t *testing.T) {
+	cmds, _, _, pmRepo, _ := setupCommands()
+	ctx := context.Background()
+
+	_, err := cmds.SetLineup(ctx, 1, []application.SetLineupEntry{
+		{PlayerSeasonID: 1, Position: "goals"},
+	})
+	if err != nil {
+		t.Fatalf("SetLineup (seed): %v", err)
+	}
+
+	_, err = cmds.SetLineup(ctx, 1, []application.SetLineupEntry{})
+	if err != nil {
+		t.Fatalf("SetLineup (empty): %v", err)
+	}
+
+	if len(pmRepo.matches) != 0 {
+		t.Errorf("expected 0 player matches after empty lineup, got %d", len(pmRepo.matches))
 	}
 }
 

--- a/services/ffl/internal/domain/club_match.go
+++ b/services/ffl/internal/domain/club_match.go
@@ -16,19 +16,23 @@ type ClubMatch struct {
 // Score computes the total fantasy score for this club match.
 //
 // A player is a starter if they occupy a position slot (no BackupPositions or
-// InterchangePosition). A player is on the bench if they have either field set.
+// InterchangePosition). Multiple players can occupy the same position (e.g. 3
+// goal kickers). Each starter slot is scored independently.
 //
-// Rules:
-//  1. Start with the sum of all starters' scores.
-//  2. Substitution: if a starter has status DNP, a bench player whose
-//     BackupPositions includes the starter's position fills in.
-//  3. Interchange: if a bench player's InterchangePosition targets a starter
-//     and the bench player's score exceeds the starter's, swap them.
+// Rules applied in order:
+//  1. Substitution: if a starter's status is DNP, the first eligible bench player
+//     whose BackupPositions includes that position fills the slot. A player who
+//     played but scored 0 is NOT eligible for substitution.
+//  2. Interchange: if a bench player's InterchangePosition targets a starter slot
+//     and the bench player's score strictly exceeds that starter's, they swap.
+//     For multi-slot positions, the bench player replaces the lowest-scoring
+//     starter they can beat.
 //
 // A bench player can only be used once (sub or interchange, not both).
 // Substitution is evaluated before interchange.
 func (cm ClubMatch) Score() int {
-	starters := make(map[Position]*PlayerMatch)
+	// starters holds all starter slots per position (multiple per position allowed).
+	starters := make(map[Position][]*PlayerMatch)
 	var bench []*PlayerMatch
 
 	for i := range cm.PlayerMatches {
@@ -36,48 +40,61 @@ func (cm ClubMatch) Score() int {
 		if pm.isBench() {
 			bench = append(bench, pm)
 		} else if pm.Position != nil {
-			starters[*pm.Position] = pm
+			starters[*pm.Position] = append(starters[*pm.Position], pm)
 		}
 	}
 
-	used := make(map[int]bool) // bench player indices already consumed
+	used := make(map[int]bool) // bench indices already consumed
 
-	// Substitution: bench replaces DNP starters.
-	for pos, starter := range starters {
-		if starter.Status == nil || *starter.Status != PlayerMatchStatusDNP {
-			continue
-		}
-		for i, bp := range bench {
-			if used[i] || bp.BackupPositions == nil {
+	// Substitution: replace each DNP starter slot with the first eligible bench player.
+	for pos, slots := range starters {
+		for si, starter := range slots {
+			if starter.Status == nil || *starter.Status != PlayerMatchStatusDNP {
 				continue
 			}
-			if containsPosition(*bp.BackupPositions, pos) {
-				starters[pos] = bp
-				used[i] = true
-				break
+			for i, bp := range bench {
+				if used[i] || bp.BackupPositions == nil {
+					continue
+				}
+				if containsPosition(*bp.BackupPositions, pos) {
+					starters[pos][si] = bp
+					used[i] = true
+					break
+				}
 			}
 		}
 	}
 
-	// Interchange: bench outscores starter at the interchange position.
+	// Interchange: bench player beats a starter at their designated interchange position.
 	for i, bp := range bench {
 		if used[i] || bp.InterchangePosition == nil {
 			continue
 		}
 		targetPos := Position(*bp.InterchangePosition)
-		starter, ok := starters[targetPos]
+		slots, ok := starters[targetPos]
 		if !ok {
 			continue
 		}
-		if bp.Score > starter.Score {
-			starters[targetPos] = bp
+		// Replace the slot where the bench player produces the greatest gain.
+		bestSlot := -1
+		bestGain := 0
+		for si, starter := range slots {
+			if gain := bp.Score - starter.Score; gain > bestGain {
+				bestGain = gain
+				bestSlot = si
+			}
+		}
+		if bestSlot >= 0 {
+			starters[targetPos][bestSlot] = bp
 			used[i] = true
 		}
 	}
 
 	total := 0
-	for _, pm := range starters {
-		total += pm.Score
+	for _, slots := range starters {
+		for _, pm := range slots {
+			total += pm.Score
+		}
 	}
 	return total
 }

--- a/services/ffl/internal/domain/club_match_test.go
+++ b/services/ffl/internal/domain/club_match_test.go
@@ -133,4 +133,76 @@ func TestClubMatch_Score_SubTakesPriorityOverInterchange(t *testing.T) {
 	}
 }
 
+func TestClubMatch_Score_MultipleStartersPerPosition(t *testing.T) {
+	tests := []struct {
+		name string
+		cm   ClubMatch
+		want int
+	}{
+		{
+			name: "3 goal kickers each score independently",
+			cm: ClubMatch{
+				PlayerMatches: []PlayerMatch{
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusPlayed), Score: 10},
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusPlayed), Score: 15},
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusPlayed), Score: 20},
+				},
+			},
+			want: 45,
+		},
+		{
+			name: "bench subs for one DNP slot, other goal kicker keeps scoring",
+			cm: ClubMatch{
+				PlayerMatches: []PlayerMatch{
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusPlayed), Score: 20},
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusDNP), Score: 0},
+					{Status: stat(PlayerMatchStatusPlayed), Score: 12, BackupPositions: strPtr("goals")},
+				},
+			},
+			want: 32, // 20 (starter) + 12 (sub for DNP)
+		},
+		{
+			name: "bench only subs for one slot even if multiple DNP",
+			cm: ClubMatch{
+				PlayerMatches: []PlayerMatch{
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusDNP), Score: 0},
+					{Position: pos(PositionGoals), Status: stat(PlayerMatchStatusDNP), Score: 0},
+					{Status: stat(PlayerMatchStatusPlayed), Score: 12, BackupPositions: strPtr("goals")},
+				},
+			},
+			want: 12, // only one bench player, fills first DNP slot; second DNP remains 0
+		},
+		{
+			name: "interchange picks best gain across multiple slots",
+			cm: ClubMatch{
+				PlayerMatches: []PlayerMatch{
+					{Position: pos(PositionKicks), Status: stat(PlayerMatchStatusPlayed), Score: 5},
+					{Position: pos(PositionKicks), Status: stat(PlayerMatchStatusPlayed), Score: 20},
+					{Status: stat(PlayerMatchStatusPlayed), Score: 15, InterchangePosition: strPtr("kicks")},
+				},
+			},
+			want: 35, // bench (15) replaces the 5-score slot; 20-score slot unaffected
+		},
+		{
+			name: "interchange does not apply when bench does not outscore any slot",
+			cm: ClubMatch{
+				PlayerMatches: []PlayerMatch{
+					{Position: pos(PositionKicks), Status: stat(PlayerMatchStatusPlayed), Score: 20},
+					{Position: pos(PositionKicks), Status: stat(PlayerMatchStatusPlayed), Score: 25},
+					{Status: stat(PlayerMatchStatusPlayed), Score: 15, InterchangePosition: strPtr("kicks")},
+				},
+			},
+			want: 45, // bench (15) beats neither starter
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cm.Score(); got != tt.want {
+				t.Errorf("Score() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func strPtr(s string) *string { return &s }

--- a/services/ffl/internal/domain/player_match.go
+++ b/services/ffl/internal/domain/player_match.go
@@ -219,6 +219,7 @@ func PositionPtr(p Position) *Position                            { return &p }
 func PlayerMatchStatusPtr(s PlayerMatchStatus) *PlayerMatchStatus { return &s }
 
 type PlayerMatchRepository interface {
+	DeleteByClubMatchID(ctx context.Context, clubMatchID int) error
 	FindByClubMatchID(ctx context.Context, clubMatchID int) ([]PlayerMatch, error)
 	FindByID(ctx context.Context, id int) (PlayerMatch, error)
 	Upsert(ctx context.Context, params UpsertPlayerMatchParams) (PlayerMatch, error)

--- a/services/ffl/internal/domain/player_match.go
+++ b/services/ffl/internal/domain/player_match.go
@@ -106,10 +106,10 @@ func (pm PlayerMatch) CalculateScore(stats AFLStats) int {
 	}
 }
 
-// ValidateLineup enforces team composition rules against a set of lineup entries.
-// It returns a descriptive error if any rule is violated, or nil if the lineup is valid.
+// ValidateTeam enforces team composition rules against a set of team entries.
+// It returns a descriptive error if any rule is violated, or nil if the team is valid.
 // Teams need not be full — all constraints are upper bounds, not minimums.
-func ValidateLineup(entries []UpsertPlayerMatchParams) error {
+func ValidateTeam(entries []UpsertPlayerMatchParams) error {
 	starterCounts := make(map[Position]int)
 	var benchPlayers []UpsertPlayerMatchParams
 	interchangeCount := 0
@@ -123,7 +123,7 @@ func ValidateLineup(entries []UpsertPlayerMatchParams) error {
 			}
 		} else {
 			if e.Position == nil {
-				return fmt.Errorf("lineup: starter must have a position")
+				return fmt.Errorf("team: starter must have a position")
 			}
 			starterCounts[*e.Position]++
 		}
@@ -133,16 +133,16 @@ func ValidateLineup(entries []UpsertPlayerMatchParams) error {
 	for pos, count := range starterCounts {
 		max, ok := PositionSlots[pos]
 		if !ok {
-			return fmt.Errorf("lineup: unknown position %q", pos)
+			return fmt.Errorf("team: unknown position %q", pos)
 		}
 		if count > max {
-			return fmt.Errorf("lineup: position %q has %d players, maximum is %d", pos, count, max)
+			return fmt.Errorf("team: position %q has %d players, maximum is %d", pos, count, max)
 		}
 	}
 
 	// Rule 2: total bench ≤ 4.
 	if len(benchPlayers) > 4 {
-		return fmt.Errorf("lineup: bench has %d players, maximum is 4", len(benchPlayers))
+		return fmt.Errorf("team: bench has %d players, maximum is 4", len(benchPlayers))
 	}
 
 	benchStarCount := 0
@@ -160,23 +160,23 @@ func ValidateLineup(entries []UpsertPlayerMatchParams) error {
 			// Rule 3: at most 1 backup star.
 			benchStarCount++
 			if benchStarCount > 1 {
-				return fmt.Errorf("lineup: at most 1 backup star allowed on the bench")
+				return fmt.Errorf("team: at most 1 backup star allowed on the bench")
 			}
 		} else {
 			// Rule 4: non-star bench players have exactly 2 backup positions, none "star".
 			if len(positions) != 2 {
-				return fmt.Errorf("lineup: non-star bench player must have exactly 2 backup positions, got %d", len(positions))
+				return fmt.Errorf("team: non-star bench player must have exactly 2 backup positions, got %d", len(positions))
 			}
 			for _, pos := range positions {
 				if pos == PositionStar {
-					return fmt.Errorf("lineup: non-star bench player cannot list star as a backup position")
+					return fmt.Errorf("team: non-star bench player cannot list star as a backup position")
 				}
 				if _, ok := PositionSlots[pos]; !ok {
-					return fmt.Errorf("lineup: unknown backup position %q", pos)
+					return fmt.Errorf("team: unknown backup position %q", pos)
 				}
 				// Rule 5: each non-star position covered by at most one bench player.
 				if coveredPositions[pos] {
-					return fmt.Errorf("lineup: position %q is already covered by another bench player", pos)
+					return fmt.Errorf("team: position %q is already covered by another bench player", pos)
 				}
 				coveredPositions[pos] = true
 			}
@@ -185,7 +185,7 @@ func ValidateLineup(entries []UpsertPlayerMatchParams) error {
 
 	// Rule 6: at most 1 interchange position across all bench players.
 	if interchangeCount > 1 {
-		return fmt.Errorf("lineup: at most 1 interchange position allowed, got %d", interchangeCount)
+		return fmt.Errorf("team: at most 1 interchange position allowed, got %d", interchangeCount)
 	}
 
 	// Rule 7: interchange position must be a recognised Position.
@@ -193,7 +193,7 @@ func ValidateLineup(entries []UpsertPlayerMatchParams) error {
 		if bp.InterchangePosition != nil {
 			pos := Position(*bp.InterchangePosition)
 			if _, ok := PositionSlots[pos]; !ok {
-				return fmt.Errorf("lineup: interchange position %q is not a valid position", pos)
+				return fmt.Errorf("team: interchange position %q is not a valid position", pos)
 			}
 		}
 	}

--- a/services/ffl/internal/domain/player_match.go
+++ b/services/ffl/internal/domain/player_match.go
@@ -1,6 +1,10 @@
 package domain
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
 
 // Position represents a fantasy football position that determines scoring.
 type Position string
@@ -14,6 +18,17 @@ const (
 	PositionHitouts   Position = "hitouts"
 	PositionStar      Position = "star"
 )
+
+// PositionSlots defines the maximum number of starter slots per position.
+var PositionSlots = map[Position]int{
+	PositionGoals:     3,
+	PositionKicks:     4,
+	PositionHandballs: 4,
+	PositionMarks:     2,
+	PositionTackles:   2,
+	PositionHitouts:   2,
+	PositionStar:      1,
+}
 
 // Scoring multipliers per position.
 const (
@@ -89,6 +104,114 @@ func (pm PlayerMatch) CalculateScore(stats AFLStats) int {
 	default:
 		return 0
 	}
+}
+
+// ValidateLineup enforces team composition rules against a set of lineup entries.
+// It returns a descriptive error if any rule is violated, or nil if the lineup is valid.
+// Teams need not be full — all constraints are upper bounds, not minimums.
+func ValidateLineup(entries []UpsertPlayerMatchParams) error {
+	starterCounts := make(map[Position]int)
+	var benchPlayers []UpsertPlayerMatchParams
+	interchangeCount := 0
+
+	for _, e := range entries {
+		isBench := e.BackupPositions != nil || e.InterchangePosition != nil
+		if isBench {
+			benchPlayers = append(benchPlayers, e)
+			if e.InterchangePosition != nil {
+				interchangeCount++
+			}
+		} else {
+			if e.Position == nil {
+				return fmt.Errorf("lineup: starter must have a position")
+			}
+			starterCounts[*e.Position]++
+		}
+	}
+
+	// Rule 1: starter count per position ≤ PositionSlots[pos].
+	for pos, count := range starterCounts {
+		max, ok := PositionSlots[pos]
+		if !ok {
+			return fmt.Errorf("lineup: unknown position %q", pos)
+		}
+		if count > max {
+			return fmt.Errorf("lineup: position %q has %d players, maximum is %d", pos, count, max)
+		}
+	}
+
+	// Rule 2: total bench ≤ 4.
+	if len(benchPlayers) > 4 {
+		return fmt.Errorf("lineup: bench has %d players, maximum is 4", len(benchPlayers))
+	}
+
+	benchStarCount := 0
+	coveredPositions := make(map[Position]bool)
+
+	for _, bp := range benchPlayers {
+		if bp.BackupPositions == nil {
+			continue
+		}
+		positions := parsePositions(*bp.BackupPositions)
+		// A backup star has backup positions consisting solely of "star".
+		isBenchStar := len(positions) == 1 && positions[0] == PositionStar
+
+		if isBenchStar {
+			// Rule 3: at most 1 backup star.
+			benchStarCount++
+			if benchStarCount > 1 {
+				return fmt.Errorf("lineup: at most 1 backup star allowed on the bench")
+			}
+		} else {
+			// Rule 4: non-star bench players have exactly 2 backup positions, none "star".
+			if len(positions) != 2 {
+				return fmt.Errorf("lineup: non-star bench player must have exactly 2 backup positions, got %d", len(positions))
+			}
+			for _, pos := range positions {
+				if pos == PositionStar {
+					return fmt.Errorf("lineup: non-star bench player cannot list star as a backup position")
+				}
+				if _, ok := PositionSlots[pos]; !ok {
+					return fmt.Errorf("lineup: unknown backup position %q", pos)
+				}
+				// Rule 5: each non-star position covered by at most one bench player.
+				if coveredPositions[pos] {
+					return fmt.Errorf("lineup: position %q is already covered by another bench player", pos)
+				}
+				coveredPositions[pos] = true
+			}
+		}
+	}
+
+	// Rule 6: at most 1 interchange position across all bench players.
+	if interchangeCount > 1 {
+		return fmt.Errorf("lineup: at most 1 interchange position allowed, got %d", interchangeCount)
+	}
+
+	// Rule 7: interchange position must be a recognised Position.
+	for _, bp := range benchPlayers {
+		if bp.InterchangePosition != nil {
+			pos := Position(*bp.InterchangePosition)
+			if _, ok := PositionSlots[pos]; !ok {
+				return fmt.Errorf("lineup: interchange position %q is not a valid position", pos)
+			}
+		}
+	}
+
+	return nil
+}
+
+// parsePositions splits a comma-separated position string into a slice of Position values.
+func parsePositions(s string) []Position {
+	parts := strings.Split(s, ",")
+	out := make([]Position, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			out = append(out, Position(trimmed))
+		}
+	}
+	return out
 }
 
 // Ptr helpers for use in struct literals.

--- a/services/ffl/internal/domain/player_match_test.go
+++ b/services/ffl/internal/domain/player_match_test.go
@@ -7,12 +7,12 @@ import (
 
 func TestCalculateScore(t *testing.T) {
 	stats := AFLStats{
-		Goals:    3,
-		Kicks:    15,
+		Goals:     3,
+		Kicks:     15,
 		Handballs: 10,
-		Marks:    6,
-		Tackles:  4,
-		Hitouts:  2,
+		Marks:     6,
+		Tackles:   4,
+		Hitouts:   2,
 	}
 
 	tests := []struct {
@@ -20,13 +20,13 @@ func TestCalculateScore(t *testing.T) {
 		position Position
 		want     int
 	}{
-		{"goals position", PositionGoals, 15},      // 3 * 5
-		{"kicks position", PositionKicks, 15},       // 15 * 1
+		{"goals position", PositionGoals, 15},         // 3 * 5
+		{"kicks position", PositionKicks, 15},         // 15 * 1
 		{"handballs position", PositionHandballs, 10}, // 10 * 1
-		{"marks position", PositionMarks, 12},       // 6 * 2
-		{"tackles position", PositionTackles, 16},   // 4 * 4
-		{"hitouts position", PositionHitouts, 2},    // 2 * 1
-		{"star position", PositionStar, 68},         // 3*5 + 15*1 + 10*1 + 6*2 + 4*4
+		{"marks position", PositionMarks, 12},         // 6 * 2
+		{"tackles position", PositionTackles, 16},     // 4 * 4
+		{"hitouts position", PositionHitouts, 2},      // 2 * 1
+		{"star position", PositionStar, 68},           // 3*5 + 15*1 + 10*1 + 6*2 + 4*4
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,8 +48,8 @@ func TestCalculateScore_NilPosition(t *testing.T) {
 func bpPtr(s string) *string { return &s }
 func ipPtr(s string) *string { return &s }
 
-// validFullLineup builds a complete 18-starter lineup with no bench.
-func validFullLineup() []UpsertPlayerMatchParams {
+// validFullTeam builds a complete 18-starter team with no bench.
+func validFullTeam() []UpsertPlayerMatchParams {
 	entries := []UpsertPlayerMatchParams{}
 	for pos, count := range PositionSlots {
 		p := pos
@@ -60,21 +60,21 @@ func validFullLineup() []UpsertPlayerMatchParams {
 	return entries
 }
 
-func TestValidateLineup_ValidCases(t *testing.T) {
-	t.Run("empty lineup is valid", func(t *testing.T) {
-		if err := ValidateLineup(nil); err != nil {
+func TestValidateTeam_ValidCases(t *testing.T) {
+	t.Run("empty team is valid", func(t *testing.T) {
+		if err := ValidateTeam(nil); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("full 18-starter lineup is valid", func(t *testing.T) {
-		if err := ValidateLineup(validFullLineup()); err != nil {
+	t.Run("full 18-starter team is valid", func(t *testing.T) {
+		if err := ValidateTeam(validFullTeam()); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("starters with backup star and 3 dual-position bench", func(t *testing.T) {
-		entries := validFullLineup()
+		entries := validFullTeam()
 		// Backup star
 		star := PositionStar
 		entries = append(entries, UpsertPlayerMatchParams{Position: &star, BackupPositions: bpPtr("star")})
@@ -85,34 +85,34 @@ func TestValidateLineup_ValidCases(t *testing.T) {
 		entries = append(entries, UpsertPlayerMatchParams{Position: &handballs, BackupPositions: bpPtr("handballs,marks")})
 		tackles := PositionTackles
 		entries = append(entries, UpsertPlayerMatchParams{Position: &tackles, BackupPositions: bpPtr("tackles,hitouts")})
-		if err := ValidateLineup(entries); err != nil {
+		if err := ValidateTeam(entries); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("interchange on bench star is valid", func(t *testing.T) {
-		entries := validFullLineup()
+		entries := validFullTeam()
 		star := PositionStar
 		ic := "star"
 		entries = append(entries, UpsertPlayerMatchParams{Position: &star, BackupPositions: bpPtr("star"), InterchangePosition: &ic})
-		if err := ValidateLineup(entries); err != nil {
+		if err := ValidateTeam(entries); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("partial lineup is valid", func(t *testing.T) {
+	t.Run("partial team is valid", func(t *testing.T) {
 		goals := PositionGoals
 		entries := []UpsertPlayerMatchParams{
 			{Position: &goals},
 			{Position: &goals},
 		}
-		if err := ValidateLineup(entries); err != nil {
+		if err := ValidateTeam(entries); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 }
 
-func TestValidateLineup_InvalidCases(t *testing.T) {
+func TestValidateTeam_InvalidCases(t *testing.T) {
 	tests := []struct {
 		name        string
 		entries     []UpsertPlayerMatchParams
@@ -225,7 +225,7 @@ func TestValidateLineup_InvalidCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateLineup(tt.entries)
+			err := ValidateTeam(tt.entries)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/services/ffl/internal/domain/player_match_test.go
+++ b/services/ffl/internal/domain/player_match_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestCalculateScore(t *testing.T) {
 	stats := AFLStats{
@@ -39,6 +42,197 @@ func TestCalculateScore_NilPosition(t *testing.T) {
 	pm := PlayerMatch{}
 	if got := pm.CalculateScore(AFLStats{Goals: 5}); got != 0 {
 		t.Errorf("CalculateScore() with nil position = %d, want 0", got)
+	}
+}
+
+func bpPtr(s string) *string { return &s }
+func ipPtr(s string) *string { return &s }
+
+// validFullLineup builds a complete 18-starter lineup with no bench.
+func validFullLineup() []UpsertPlayerMatchParams {
+	entries := []UpsertPlayerMatchParams{}
+	for pos, count := range PositionSlots {
+		p := pos
+		for range count {
+			entries = append(entries, UpsertPlayerMatchParams{Position: &p})
+		}
+	}
+	return entries
+}
+
+func TestValidateLineup_ValidCases(t *testing.T) {
+	t.Run("empty lineup is valid", func(t *testing.T) {
+		if err := ValidateLineup(nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("full 18-starter lineup is valid", func(t *testing.T) {
+		if err := ValidateLineup(validFullLineup()); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("starters with backup star and 3 dual-position bench", func(t *testing.T) {
+		entries := validFullLineup()
+		// Backup star
+		star := PositionStar
+		entries = append(entries, UpsertPlayerMatchParams{Position: &star, BackupPositions: bpPtr("star")})
+		// Dual-position bench (each covers 2 unique non-star positions)
+		goals := PositionGoals
+		entries = append(entries, UpsertPlayerMatchParams{Position: &goals, BackupPositions: bpPtr("goals,kicks")})
+		handballs := PositionHandballs
+		entries = append(entries, UpsertPlayerMatchParams{Position: &handballs, BackupPositions: bpPtr("handballs,marks")})
+		tackles := PositionTackles
+		entries = append(entries, UpsertPlayerMatchParams{Position: &tackles, BackupPositions: bpPtr("tackles,hitouts")})
+		if err := ValidateLineup(entries); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("interchange on bench star is valid", func(t *testing.T) {
+		entries := validFullLineup()
+		star := PositionStar
+		ic := "star"
+		entries = append(entries, UpsertPlayerMatchParams{Position: &star, BackupPositions: bpPtr("star"), InterchangePosition: &ic})
+		if err := ValidateLineup(entries); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("partial lineup is valid", func(t *testing.T) {
+		goals := PositionGoals
+		entries := []UpsertPlayerMatchParams{
+			{Position: &goals},
+			{Position: &goals},
+		}
+		if err := ValidateLineup(entries); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestValidateLineup_InvalidCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		entries     []UpsertPlayerMatchParams
+		errContains string
+	}{
+		{
+			name: "too many goal kickers",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				return []UpsertPlayerMatchParams{{Position: &p}, {Position: &p}, {Position: &p}, {Position: &p}}
+			}(),
+			errContains: "goals",
+		},
+		{
+			name: "too many star starters",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionStar
+				return []UpsertPlayerMatchParams{{Position: &p}, {Position: &p}}
+			}(),
+			errContains: "star",
+		},
+		{
+			name: "5 bench players",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				entries := []UpsertPlayerMatchParams{}
+				for range 5 {
+					entries = append(entries, UpsertPlayerMatchParams{Position: &p, BackupPositions: bpPtr("goals,kicks")})
+				}
+				return entries
+			}(),
+			errContains: "bench has 5",
+		},
+		{
+			name: "two backup stars",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionStar
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("star")},
+					{Position: &p, BackupPositions: bpPtr("star")},
+				}
+			}(),
+			errContains: "backup star",
+		},
+		{
+			name: "non-star bench with only 1 backup position",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("goals")},
+				}
+			}(),
+			errContains: "exactly 2",
+		},
+		{
+			name: "non-star bench with 3 backup positions",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("goals,kicks,handballs")},
+				}
+			}(),
+			errContains: "exactly 2",
+		},
+		{
+			name: "non-star bench with star in backup positions",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("goals,star")},
+				}
+			}(),
+			errContains: "star",
+		},
+		{
+			name: "same position covered by two bench players",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("goals,kicks")},
+					{Position: &p, BackupPositions: bpPtr("goals,marks")},
+				}
+			}(),
+			errContains: "goals",
+		},
+		{
+			name: "two interchange positions",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				ic := "goals"
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("goals,kicks"), InterchangePosition: &ic},
+					{Position: &p, BackupPositions: bpPtr("marks,tackles"), InterchangePosition: &ic},
+				}
+			}(),
+			errContains: "interchange",
+		},
+		{
+			name: "unknown interchange position",
+			entries: func() []UpsertPlayerMatchParams {
+				p := PositionGoals
+				ic := "unknown"
+				return []UpsertPlayerMatchParams{
+					{Position: &p, BackupPositions: bpPtr("goals,kicks"), InterchangePosition: &ic},
+				}
+			}(),
+			errContains: "interchange position",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLineup(tt.entries)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+			}
+		})
 	}
 }
 

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -434,6 +434,10 @@ func toPlayerMatch(id, clubMatchID, playerSeasonID int32, position, status *stri
 	}
 }
 
+func (r *PlayerMatchRepository) DeleteByClubMatchID(ctx context.Context, clubMatchID int) error {
+	return r.q.DeletePlayerMatchesByClubMatchID(ctx, int32(clubMatchID))
+}
+
 func (r *PlayerMatchRepository) FindByClubMatchID(ctx context.Context, clubMatchID int) ([]domain.PlayerMatch, error) {
 	rows, err := r.q.FindPlayerMatchesByClubMatchID(ctx, int32(clubMatchID))
 	if err != nil {

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
@@ -10,6 +10,10 @@ SELECT id, club_match_id, player_season_id,
 FROM ffl.player_match
 WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: DeletePlayerMatchesByClubMatchID :exec
+DELETE FROM ffl.player_match
+WHERE club_match_id = $1;
+
 -- name: UpsertPlayerMatch :one
 INSERT INTO ffl.player_match (club_match_id, player_season_id, position, status, backup_positions, interchange_position, drv_score)
 VALUES ($1, $2, $3, $4, $5, $6, $7)

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
@@ -94,6 +94,16 @@ func (q *Queries) FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchI
 	return items, nil
 }
 
+const deletePlayerMatchesByClubMatchID = `-- name: DeletePlayerMatchesByClubMatchID :exec
+DELETE FROM ffl.player_match
+WHERE club_match_id = $1
+`
+
+func (q *Queries) DeletePlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) error {
+	_, err := q.db.Exec(ctx, deletePlayerMatchesByClubMatchID, clubMatchID)
+	return err
+}
+
 const upsertPlayerMatch = `-- name: UpsertPlayerMatch :one
 INSERT INTO ffl.player_match (club_match_id, player_season_id, position, status, backup_positions, interchange_position, drv_score)
 VALUES ($1, $2, $3, $4, $5, $6, $7)

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -12,6 +12,7 @@ type Querier interface {
 	CreatePlayer(ctx context.Context, arg CreatePlayerParams) (CreatePlayerRow, error)
 	CreatePlayerSeason(ctx context.Context, arg CreatePlayerSeasonParams) (CreatePlayerSeasonRow, error)
 	DeletePlayer(ctx context.Context, id int32) error
+	DeletePlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) error
 	DeletePlayerSeason(ctx context.Context, id int32) error
 	FindAllClubs(ctx context.Context) ([]FindAllClubsRow, error)
 	FindAllPlayers(ctx context.Context) ([]FindAllPlayersRow, error)

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -125,7 +125,7 @@ type ComplexityRoot struct {
 		CreateFFLPlayer           func(childComplexity int, input CreateFFLPlayerInput) int
 		DeleteFFLPlayer           func(childComplexity int, id string) int
 		RemoveFFLPlayerFromSeason func(childComplexity int, id string) int
-		SetFFLLineup              func(childComplexity int, input SetFFLLineupInput) int
+		SetFFLTeam              func(childComplexity int, input SetFFLTeamInput) int
 		UpdateFFLPlayer           func(childComplexity int, input UpdateFFLPlayerInput) int
 	}
 
@@ -171,7 +171,7 @@ type MutationResolver interface {
 	AddFFLPlayerToSeason(ctx context.Context, input AddFFLPlayerToSeasonInput) (*FFLPlayerSeason, error)
 	RemoveFFLPlayerFromSeason(ctx context.Context, id string) (bool, error)
 	CalculateFFLFantasyScore(ctx context.Context, input CalculateFFLFantasyScoreInput) (*FFLPlayerMatch, error)
-	SetFFLLineup(ctx context.Context, input SetFFLLineupInput) ([]*FFLPlayerMatch, error)
+	SetFFLTeam(ctx context.Context, input SetFFLTeamInput) ([]*FFLPlayerMatch, error)
 	AddFFLSquadPlayer(ctx context.Context, input AddFFLSquadPlayerInput) (*FFLPlayerSeason, error)
 }
 type QueryResolver interface {
@@ -574,17 +574,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.RemoveFFLPlayerFromSeason(childComplexity, args["id"].(string)), true
-	case "Mutation.setFFLLineup":
-		if e.ComplexityRoot.Mutation.SetFFLLineup == nil {
+	case "Mutation.setFFLTeam":
+		if e.ComplexityRoot.Mutation.SetFFLTeam == nil {
 			break
 		}
 
-		args, err := ec.field_Mutation_setFFLLineup_args(ctx, rawArgs)
+		args, err := ec.field_Mutation_setFFLTeam_args(ctx, rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.ComplexityRoot.Mutation.SetFFLLineup(childComplexity, args["input"].(SetFFLLineupInput)), true
+		return e.ComplexityRoot.Mutation.SetFFLTeam(childComplexity, args["input"].(SetFFLTeamInput)), true
 	case "Mutation.updateFFLPlayer":
 		if e.ComplexityRoot.Mutation.UpdateFFLPlayer == nil {
 			break
@@ -691,9 +691,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAddFFLSquadPlayerInput,
 		ec.unmarshalInputCalculateFFLFantasyScoreInput,
 		ec.unmarshalInputCreateFFLPlayerInput,
-		ec.unmarshalInputFFLLineupPlayerInput,
+		ec.unmarshalInputFFLTeamPlayerInput,
 		ec.unmarshalInputFFLPlayerSeasonFilter,
-		ec.unmarshalInputSetFFLLineupInput,
+		ec.unmarshalInputSetFFLTeamInput,
 		ec.unmarshalInputUpdateFFLPlayerInput,
 	)
 	first := true
@@ -782,7 +782,7 @@ var sources = []*ast.Source{
   addFFLPlayerToSeason(input: AddFFLPlayerToSeasonInput!): FFLPlayerSeason!
   removeFFLPlayerFromSeason(id: ID!): Boolean!
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
-  setFFLLineup(input: SetFFLLineupInput!): [FFLPlayerMatch!]!
+  setFFLTeam(input: SetFFLTeamInput!): [FFLPlayerMatch!]!
   addFFLSquadPlayer(input: AddFFLSquadPlayerInput!): FFLPlayerSeason!
 }
 
@@ -817,12 +817,12 @@ input CalculateFFLFantasyScoreInput {
   hitouts: Int!
 }
 
-input SetFFLLineupInput {
+input SetFFLTeamInput {
   clubMatchId: ID!
-  players: [FFLLineupPlayerInput!]!
+  players: [FFLTeamPlayerInput!]!
 }
 
-input FFLLineupPlayerInput {
+input FFLTeamPlayerInput {
   playerSeasonId: ID!
   position: String!
   backupPositions: String
@@ -1017,10 +1017,10 @@ func (ec *executionContext) field_Mutation_removeFFLPlayerFromSeason_args(ctx co
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_setFFLLineup_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+func (ec *executionContext) field_Mutation_setFFLTeam_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNSetFFLLineupInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐSetFFLLineupInput)
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNSetFFLTeamInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐSetFFLTeamInput)
 	if err != nil {
 		return nil, err
 	}
@@ -3032,15 +3032,15 @@ func (ec *executionContext) fieldContext_Mutation_calculateFFLFantasyScore(ctx c
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_setFFLLineup(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+func (ec *executionContext) _Mutation_setFFLTeam(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
-		ec.fieldContext_Mutation_setFFLLineup,
+		ec.fieldContext_Mutation_setFFLTeam,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Mutation().SetFFLLineup(ctx, fc.Args["input"].(SetFFLLineupInput))
+			return ec.Resolvers.Mutation().SetFFLTeam(ctx, fc.Args["input"].(SetFFLTeamInput))
 		},
 		nil,
 		ec.marshalNFFLPlayerMatch2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayerMatchᚄ,
@@ -3049,7 +3049,7 @@ func (ec *executionContext) _Mutation_setFFLLineup(ctx context.Context, field gr
 	)
 }
 
-func (ec *executionContext) fieldContext_Mutation_setFFLLineup(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_setFFLTeam(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -3084,7 +3084,7 @@ func (ec *executionContext) fieldContext_Mutation_setFFLLineup(ctx context.Conte
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_setFFLLineup_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_setFFLTeam_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5306,8 +5306,8 @@ func (ec *executionContext) unmarshalInputCreateFFLPlayerInput(ctx context.Conte
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputFFLLineupPlayerInput(ctx context.Context, obj any) (FFLLineupPlayerInput, error) {
-	var it FFLLineupPlayerInput
+func (ec *executionContext) unmarshalInputFFLTeamPlayerInput(ctx context.Context, obj any) (FFLTeamPlayerInput, error) {
+	var it FFLTeamPlayerInput
 	if obj == nil {
 		return it, nil
 	}
@@ -5387,8 +5387,8 @@ func (ec *executionContext) unmarshalInputFFLPlayerSeasonFilter(ctx context.Cont
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputSetFFLLineupInput(ctx context.Context, obj any) (SetFFLLineupInput, error) {
-	var it SetFFLLineupInput
+func (ec *executionContext) unmarshalInputSetFFLTeamInput(ctx context.Context, obj any) (SetFFLTeamInput, error) {
+	var it SetFFLTeamInput
 	if obj == nil {
 		return it, nil
 	}
@@ -5414,7 +5414,7 @@ func (ec *executionContext) unmarshalInputSetFFLLineupInput(ctx context.Context,
 			it.ClubMatchID = data
 		case "players":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("players"))
-			data, err := ec.unmarshalNFFLLineupPlayerInput2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInputᚄ(ctx, v)
+			data, err := ec.unmarshalNFFLTeamPlayerInput2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLTeamPlayerInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6333,9 +6333,9 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "setFFLLineup":
+		case "setFFLTeam":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_setFFLLineup(ctx, field)
+				return ec._Mutation_setFFLTeam(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -7061,14 +7061,14 @@ func (ec *executionContext) marshalNFFLClubSeason2ᚖxfflᚋservicesᚋfflᚋint
 	return ec._FFLClubSeason(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNFFLLineupPlayerInput2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInputᚄ(ctx context.Context, v any) ([]*FFLLineupPlayerInput, error) {
+func (ec *executionContext) unmarshalNFFLTeamPlayerInput2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLTeamPlayerInputᚄ(ctx context.Context, v any) ([]*FFLTeamPlayerInput, error) {
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
 	var err error
-	res := make([]*FFLLineupPlayerInput, len(vSlice))
+	res := make([]*FFLTeamPlayerInput, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNFFLLineupPlayerInput2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInput(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNFFLTeamPlayerInput2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLTeamPlayerInput(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -7076,8 +7076,8 @@ func (ec *executionContext) unmarshalNFFLLineupPlayerInput2ᚕᚖxfflᚋservices
 	return res, nil
 }
 
-func (ec *executionContext) unmarshalNFFLLineupPlayerInput2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLLineupPlayerInput(ctx context.Context, v any) (*FFLLineupPlayerInput, error) {
-	res, err := ec.unmarshalInputFFLLineupPlayerInput(ctx, v)
+func (ec *executionContext) unmarshalNFFLTeamPlayerInput2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLTeamPlayerInput(ctx context.Context, v any) (*FFLTeamPlayerInput, error) {
+	res, err := ec.unmarshalInputFFLTeamPlayerInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -7329,8 +7329,8 @@ func (ec *executionContext) marshalNPageInfo2ᚖxfflᚋservicesᚋfflᚋinternal
 	return ec._PageInfo(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNSetFFLLineupInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐSetFFLLineupInput(ctx context.Context, v any) (SetFFLLineupInput, error) {
-	res, err := ec.unmarshalInputSetFFLLineupInput(ctx, v)
+func (ec *executionContext) unmarshalNSetFFLTeamInput2xfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐSetFFLTeamInput(ctx context.Context, v any) (SetFFLTeamInput, error) {
+	res, err := ec.unmarshalInputSetFFLTeamInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/services/ffl/internal/interface/graphql/integration_test.go
+++ b/services/ffl/internal/interface/graphql/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	gqlhandler "github.com/99designs/gqlgen/graphql/handler"
@@ -1176,5 +1177,67 @@ func TestSetFFLLineup_MultipleStartersScoreCorrectly(t *testing.T) {
 	// 3 goal kickers × 10 = 30
 	if totalScore != 30 {
 		t.Errorf("expected total starter score 30, got %d", totalScore)
+	}
+}
+
+func TestSetFFLLineup_ReplacesStaleEntries(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	extras := seedExtraPlayers(t, pool, ids, 1)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	ctx := context.Background()
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	extraID := extras[0]
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	// First lineup: original player at goals.
+	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: psID, position: "goals"},
+	}))
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors setting first lineup: %v", result.Errors)
+	}
+
+	// Second lineup: different player at kicks — replaces the first.
+	result = execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: extraID, position: "kicks"},
+	}))
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors setting second lineup: %v", result.Errors)
+	}
+
+	// Only the new player_match should exist in the DB.
+	rows, err := pool.Query(ctx,
+		"SELECT player_season_id, position FROM ffl.player_match WHERE club_match_id = $1",
+		ids.homeClubMatchID)
+	if err != nil {
+		t.Fatalf("failed to query player_match: %v", err)
+	}
+	defer rows.Close()
+
+	type row struct {
+		playerSeasonID int
+		position       string
+	}
+	var found []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.playerSeasonID, &r.position); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		found = append(found, r)
+	}
+
+	if len(found) != 1 {
+		t.Fatalf("expected 1 player_match after replacement, got %d", len(found))
+	}
+	extraIDInt, _ := strconv.Atoi(extraID)
+	if found[0].playerSeasonID != extraIDInt {
+		t.Errorf("expected player_season_id %d, got %d", extraIDInt, found[0].playerSeasonID)
+	}
+	if found[0].position != "kicks" {
+		t.Errorf("expected position %q, got %q", "kicks", found[0].position)
 	}
 }

--- a/services/ffl/internal/interface/graphql/integration_test.go
+++ b/services/ffl/internal/interface/graphql/integration_test.go
@@ -930,3 +930,251 @@ func TestCalculateFFLFantasyScore_InvalidPlayerMatchID(t *testing.T) {
 		t.Fatal("expected error for invalid playerMatchId, got none")
 	}
 }
+
+// ── SetFFLLineup: team composition rule tests ─────────────────────────────────
+
+// lineupMutation builds a setFFLLineup mutation string for testing.
+// players is a slice of (playerSeasonId, position, backupPositions, interchangePosition) tuples.
+type lineupPlayer struct {
+	playerSeasonID      string
+	position            string
+	backupPositions     *string
+	interchangePosition *string
+}
+
+func buildSetLineupMutation(clubMatchID string, players []lineupPlayer) string {
+	playersStr := ""
+	for _, p := range players {
+		bp := "null"
+		if p.backupPositions != nil {
+			bp = `"` + *p.backupPositions + `"`
+		}
+		ic := "null"
+		if p.interchangePosition != nil {
+			ic = `"` + *p.interchangePosition + `"`
+		}
+		playersStr += fmt.Sprintf(`
+			{
+				playerSeasonId: "%s"
+				position: "%s"
+				backupPositions: %s
+				interchangePosition: %s
+			}`, p.playerSeasonID, p.position, bp, ic)
+	}
+	return fmt.Sprintf(`mutation {
+		setFFLLineup(input: {
+			clubMatchId: "%s"
+			players: [%s]
+		}) { id position backupPositions interchangePosition }
+	}`, clubMatchID, playersStr)
+}
+
+// seedExtraPlayers inserts n additional players into the home club season and returns their playerSeasonIDs.
+func seedExtraPlayers(t *testing.T, pool *pgxpool.Pool, ids testIDs, count int) []string {
+	t.Helper()
+	ctx := context.Background()
+	psIDs := make([]string, count)
+	for i := range count {
+		var aflID, playerID, psID int
+		if err := pool.QueryRow(ctx,
+			fmt.Sprintf("INSERT INTO afl.player (name) VALUES ('Extra Player %d') RETURNING id", i)).Scan(&aflID); err != nil {
+			t.Fatalf("seed extra afl player %d: %v", i, err)
+		}
+		if err := pool.QueryRow(ctx,
+			"INSERT INTO ffl.player (drv_name, afl_player_id) VALUES ($1, $2) RETURNING id",
+			fmt.Sprintf("Extra Player %d", i), aflID).Scan(&playerID); err != nil {
+			t.Fatalf("seed extra ffl player %d: %v", i, err)
+		}
+		if err := pool.QueryRow(ctx,
+			"INSERT INTO ffl.player_season (player_id, club_season_id) VALUES ($1, $2) RETURNING id",
+			playerID, ids.homeClubSeaID).Scan(&psID); err != nil {
+			t.Fatalf("seed extra player season %d: %v", i, err)
+		}
+		psIDs[i] = fmt.Sprintf("%d", psID)
+	}
+	return psIDs
+}
+
+func strp(s string) *string { return &s }
+
+func TestSetFFLLineup_ValidLineupSaves(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: psID, position: "goals"},
+	}))
+
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+}
+
+func TestSetFFLLineup_TooManyStartersForPosition(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	// Need 4 players for goals (max is 3)
+	extras := seedExtraPlayers(t, pool, ids, 3)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	players := []lineupPlayer{
+		{playerSeasonID: psID, position: "goals"},
+		{playerSeasonID: extras[0], position: "goals"},
+		{playerSeasonID: extras[1], position: "goals"},
+		{playerSeasonID: extras[2], position: "goals"}, // 4th goals kicker — invalid
+	}
+	result := execQuery(t, server, buildSetLineupMutation(cmID, players))
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error for too many goal kickers, got none")
+	}
+}
+
+func TestSetFFLLineup_TooManyBenchPlayers(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	extras := seedExtraPlayers(t, pool, ids, 5)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+	players := []lineupPlayer{}
+	positions := [][2]string{
+		{"goals,kicks"}, {"goals,kicks"}, {"handballs,marks"}, {"tackles,hitouts"}, {"goals,kicks"},
+	}
+	_ = positions
+	// 5 bench players (max is 4)
+	for i, id := range extras {
+		_ = i
+		players = append(players, lineupPlayer{
+			playerSeasonID:  id,
+			position:        "goals",
+			backupPositions: strp(fmt.Sprintf("goals,kicks")),
+		})
+		_ = extras
+	}
+	result := execQuery(t, server, buildSetLineupMutation(cmID, players))
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error for 5 bench players, got none")
+	}
+}
+
+func TestSetFFLLineup_TwoBenchStars(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	extras := seedExtraPlayers(t, pool, ids, 1)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: psID, position: "star", backupPositions: strp("star")},
+		{playerSeasonID: extras[0], position: "star", backupPositions: strp("star")},
+	}))
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error for two backup stars, got none")
+	}
+}
+
+func TestSetFFLLineup_SamePositionCoveredByTwoBenchPlayers(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	extras := seedExtraPlayers(t, pool, ids, 1)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: psID, position: "goals", backupPositions: strp("goals,kicks")},
+		{playerSeasonID: extras[0], position: "goals", backupPositions: strp("goals,marks")}, // goals covered twice
+	}))
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error for duplicate bench position coverage, got none")
+	}
+}
+
+func TestSetFFLLineup_TwoInterchangePositions(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	extras := seedExtraPlayers(t, pool, ids, 1)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: psID, position: "goals", backupPositions: strp("goals,kicks"), interchangePosition: strp("goals")},
+		{playerSeasonID: extras[0], position: "marks", backupPositions: strp("marks,tackles"), interchangePosition: strp("marks")},
+	}))
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error for two interchange positions, got none")
+	}
+}
+
+func TestSetFFLLineup_MultipleStartersScoreCorrectly(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	extras := seedExtraPlayers(t, pool, ids, 2)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	ctx := context.Background()
+	psID := fmt.Sprintf("%d", ids.playerSeasonID)
+	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
+
+	// Set 3 goal kickers
+	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+		{playerSeasonID: psID, position: "goals"},
+		{playerSeasonID: extras[0], position: "goals"},
+		{playerSeasonID: extras[1], position: "goals"},
+	}))
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors setting lineup: %v", result.Errors)
+	}
+
+	// Directly set scores for all 3 goal kickers in the DB, then recalculate
+	_, err := pool.Exec(ctx,
+		"UPDATE ffl.player_match SET drv_score = 10 WHERE club_match_id = $1",
+		ids.homeClubMatchID)
+	if err != nil {
+		t.Fatalf("failed to update scores: %v", err)
+	}
+	// Recalculate club match score
+	playerMatches, err := pool.Query(ctx,
+		"SELECT id, position, backup_positions, interchange_position, status, drv_score FROM ffl.player_match WHERE club_match_id = $1",
+		ids.homeClubMatchID)
+	if err != nil {
+		t.Fatalf("failed to query player matches: %v", err)
+	}
+	defer playerMatches.Close()
+
+	totalScore := 0
+	for playerMatches.Next() {
+		var score int
+		var pos, bp, ic, status *string
+		if err := playerMatches.Scan(&ids.playerMatchID, &pos, &bp, &ic, &status, &score); err != nil {
+			t.Fatalf("failed to scan: %v", err)
+		}
+		if bp == nil && ic == nil {
+			totalScore += score // starters only
+		}
+	}
+
+	// 3 goal kickers × 10 = 30
+	if totalScore != 30 {
+		t.Errorf("expected total starter score 30, got %d", totalScore)
+	}
+}

--- a/services/ffl/internal/interface/graphql/integration_test.go
+++ b/services/ffl/internal/interface/graphql/integration_test.go
@@ -572,7 +572,7 @@ func TestFflClubSeason(t *testing.T) {
 
 	var data struct {
 		FflClubSeason struct {
-			ID     string `json:"id"`
+			ID     string                `json:"id"`
 			Club   struct{ Name string } `json:"club"`
 			Season struct {
 				ID   string `json:"id"`
@@ -759,8 +759,8 @@ func TestAddAndRemoveFFLPlayerFromSeason(t *testing.T) {
 
 	var addData struct {
 		AddFFLPlayerToSeason struct {
-			ID           string `json:"id"`
-			Player       struct {
+			ID     string `json:"id"`
+			Player struct {
 				ID string `json:"id"`
 			} `json:"player"`
 			ClubSeasonID string `json:"clubSeasonId"`
@@ -932,18 +932,18 @@ func TestCalculateFFLFantasyScore_InvalidPlayerMatchID(t *testing.T) {
 	}
 }
 
-// ── SetFFLLineup: team composition rule tests ─────────────────────────────────
+// ── SetFFLTeam: team composition rule tests ─────────────────────────────────
 
-// lineupMutation builds a setFFLLineup mutation string for testing.
+// teamMutation builds a setFFLTeam mutation string for testing.
 // players is a slice of (playerSeasonId, position, backupPositions, interchangePosition) tuples.
-type lineupPlayer struct {
+type teamPlayer struct {
 	playerSeasonID      string
 	position            string
 	backupPositions     *string
 	interchangePosition *string
 }
 
-func buildSetLineupMutation(clubMatchID string, players []lineupPlayer) string {
+func buildSetTeamMutation(clubMatchID string, players []teamPlayer) string {
 	playersStr := ""
 	for _, p := range players {
 		bp := "null"
@@ -963,7 +963,7 @@ func buildSetLineupMutation(clubMatchID string, players []lineupPlayer) string {
 			}`, p.playerSeasonID, p.position, bp, ic)
 	}
 	return fmt.Sprintf(`mutation {
-		setFFLLineup(input: {
+		setFFLTeam(input: {
 			clubMatchId: "%s"
 			players: [%s]
 		}) { id position backupPositions interchangePosition }
@@ -998,7 +998,7 @@ func seedExtraPlayers(t *testing.T, pool *pgxpool.Pool, ids testIDs, count int) 
 
 func strp(s string) *string { return &s }
 
-func TestSetFFLLineup_ValidLineupSaves(t *testing.T) {
+func TestSetFFLTeam_ValidTeamSaves(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	server := setupTestServer(t, pool)
@@ -1007,7 +1007,7 @@ func TestSetFFLLineup_ValidLineupSaves(t *testing.T) {
 	psID := fmt.Sprintf("%d", ids.playerSeasonID)
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
-	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	result := execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: psID, position: "goals"},
 	}))
 
@@ -1016,7 +1016,7 @@ func TestSetFFLLineup_ValidLineupSaves(t *testing.T) {
 	}
 }
 
-func TestSetFFLLineup_TooManyStartersForPosition(t *testing.T) {
+func TestSetFFLTeam_TooManyStartersForPosition(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	// Need 4 players for goals (max is 3)
@@ -1027,19 +1027,19 @@ func TestSetFFLLineup_TooManyStartersForPosition(t *testing.T) {
 	psID := fmt.Sprintf("%d", ids.playerSeasonID)
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
-	players := []lineupPlayer{
+	players := []teamPlayer{
 		{playerSeasonID: psID, position: "goals"},
 		{playerSeasonID: extras[0], position: "goals"},
 		{playerSeasonID: extras[1], position: "goals"},
 		{playerSeasonID: extras[2], position: "goals"}, // 4th goals kicker — invalid
 	}
-	result := execQuery(t, server, buildSetLineupMutation(cmID, players))
+	result := execQuery(t, server, buildSetTeamMutation(cmID, players))
 	if len(result.Errors) == 0 {
 		t.Fatal("expected error for too many goal kickers, got none")
 	}
 }
 
-func TestSetFFLLineup_TooManyBenchPlayers(t *testing.T) {
+func TestSetFFLTeam_TooManyBenchPlayers(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	extras := seedExtraPlayers(t, pool, ids, 5)
@@ -1047,7 +1047,7 @@ func TestSetFFLLineup_TooManyBenchPlayers(t *testing.T) {
 	defer server.Close()
 
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
-	players := []lineupPlayer{}
+	players := []teamPlayer{}
 	positions := [][2]string{
 		{"goals,kicks"}, {"goals,kicks"}, {"handballs,marks"}, {"tackles,hitouts"}, {"goals,kicks"},
 	}
@@ -1055,20 +1055,20 @@ func TestSetFFLLineup_TooManyBenchPlayers(t *testing.T) {
 	// 5 bench players (max is 4)
 	for i, id := range extras {
 		_ = i
-		players = append(players, lineupPlayer{
+		players = append(players, teamPlayer{
 			playerSeasonID:  id,
 			position:        "goals",
 			backupPositions: strp(fmt.Sprintf("goals,kicks")),
 		})
 		_ = extras
 	}
-	result := execQuery(t, server, buildSetLineupMutation(cmID, players))
+	result := execQuery(t, server, buildSetTeamMutation(cmID, players))
 	if len(result.Errors) == 0 {
 		t.Fatal("expected error for 5 bench players, got none")
 	}
 }
 
-func TestSetFFLLineup_TwoBenchStars(t *testing.T) {
+func TestSetFFLTeam_TwoBenchStars(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	extras := seedExtraPlayers(t, pool, ids, 1)
@@ -1078,7 +1078,7 @@ func TestSetFFLLineup_TwoBenchStars(t *testing.T) {
 	psID := fmt.Sprintf("%d", ids.playerSeasonID)
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
-	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	result := execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: psID, position: "star", backupPositions: strp("star")},
 		{playerSeasonID: extras[0], position: "star", backupPositions: strp("star")},
 	}))
@@ -1087,7 +1087,7 @@ func TestSetFFLLineup_TwoBenchStars(t *testing.T) {
 	}
 }
 
-func TestSetFFLLineup_SamePositionCoveredByTwoBenchPlayers(t *testing.T) {
+func TestSetFFLTeam_SamePositionCoveredByTwoBenchPlayers(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	extras := seedExtraPlayers(t, pool, ids, 1)
@@ -1097,7 +1097,7 @@ func TestSetFFLLineup_SamePositionCoveredByTwoBenchPlayers(t *testing.T) {
 	psID := fmt.Sprintf("%d", ids.playerSeasonID)
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
-	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	result := execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: psID, position: "goals", backupPositions: strp("goals,kicks")},
 		{playerSeasonID: extras[0], position: "goals", backupPositions: strp("goals,marks")}, // goals covered twice
 	}))
@@ -1106,7 +1106,7 @@ func TestSetFFLLineup_SamePositionCoveredByTwoBenchPlayers(t *testing.T) {
 	}
 }
 
-func TestSetFFLLineup_TwoInterchangePositions(t *testing.T) {
+func TestSetFFLTeam_TwoInterchangePositions(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	extras := seedExtraPlayers(t, pool, ids, 1)
@@ -1116,7 +1116,7 @@ func TestSetFFLLineup_TwoInterchangePositions(t *testing.T) {
 	psID := fmt.Sprintf("%d", ids.playerSeasonID)
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
-	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	result := execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: psID, position: "goals", backupPositions: strp("goals,kicks"), interchangePosition: strp("goals")},
 		{playerSeasonID: extras[0], position: "marks", backupPositions: strp("marks,tackles"), interchangePosition: strp("marks")},
 	}))
@@ -1125,7 +1125,7 @@ func TestSetFFLLineup_TwoInterchangePositions(t *testing.T) {
 	}
 }
 
-func TestSetFFLLineup_MultipleStartersScoreCorrectly(t *testing.T) {
+func TestSetFFLTeam_MultipleStartersScoreCorrectly(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	extras := seedExtraPlayers(t, pool, ids, 2)
@@ -1137,13 +1137,13 @@ func TestSetFFLLineup_MultipleStartersScoreCorrectly(t *testing.T) {
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
 	// Set 3 goal kickers
-	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	result := execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: psID, position: "goals"},
 		{playerSeasonID: extras[0], position: "goals"},
 		{playerSeasonID: extras[1], position: "goals"},
 	}))
 	if len(result.Errors) > 0 {
-		t.Fatalf("unexpected errors setting lineup: %v", result.Errors)
+		t.Fatalf("unexpected errors setting team: %v", result.Errors)
 	}
 
 	// Directly set scores for all 3 goal kickers in the DB, then recalculate
@@ -1180,7 +1180,7 @@ func TestSetFFLLineup_MultipleStartersScoreCorrectly(t *testing.T) {
 	}
 }
 
-func TestSetFFLLineup_ReplacesStaleEntries(t *testing.T) {
+func TestSetFFLTeam_ReplacesStaleEntries(t *testing.T) {
 	pool := connectDB(t)
 	ids := seedTestData(t, pool)
 	extras := seedExtraPlayers(t, pool, ids, 1)
@@ -1192,20 +1192,20 @@ func TestSetFFLLineup_ReplacesStaleEntries(t *testing.T) {
 	extraID := extras[0]
 	cmID := fmt.Sprintf("%d", ids.homeClubMatchID)
 
-	// First lineup: original player at goals.
-	result := execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	// First team: original player at goals.
+	result := execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: psID, position: "goals"},
 	}))
 	if len(result.Errors) > 0 {
-		t.Fatalf("unexpected errors setting first lineup: %v", result.Errors)
+		t.Fatalf("unexpected errors setting first team: %v", result.Errors)
 	}
 
-	// Second lineup: different player at kicks — replaces the first.
-	result = execQuery(t, server, buildSetLineupMutation(cmID, []lineupPlayer{
+	// Second team: different player at kicks — replaces the first.
+	result = execQuery(t, server, buildSetTeamMutation(cmID, []teamPlayer{
 		{playerSeasonID: extraID, position: "kicks"},
 	}))
 	if len(result.Errors) > 0 {
-		t.Fatalf("unexpected errors setting second lineup: %v", result.Errors)
+		t.Fatalf("unexpected errors setting second team: %v", result.Errors)
 	}
 
 	// Only the new player_match should exist in the DB.

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -54,7 +54,7 @@ type FFLClubSeason struct {
 	Players    *FFLPlayerSeasonConnection `json:"players"`
 }
 
-type FFLLineupPlayerInput struct {
+type FFLTeamPlayerInput struct {
 	PlayerSeasonID      string  `json:"playerSeasonId"`
 	Position            string  `json:"position"`
 	BackupPositions     *string `json:"backupPositions,omitempty"`
@@ -129,9 +129,9 @@ type PageInfo struct {
 type Query struct {
 }
 
-type SetFFLLineupInput struct {
-	ClubMatchID string                  `json:"clubMatchId"`
-	Players     []*FFLLineupPlayerInput `json:"players"`
+type SetFFLTeamInput struct {
+	ClubMatchID string                 `json:"clubMatchId"`
+	Players     []*FFLTeamPlayerInput  `json:"players"`
 }
 
 type UpdateFFLPlayerInput struct {

--- a/services/ffl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/ffl/internal/interface/graphql/mutation.resolvers.go
@@ -107,26 +107,26 @@ func (r *mutationResolver) CalculateFFLFantasyScore(ctx context.Context, input C
 	return convertPlayerMatch(pm, player), nil
 }
 
-// SetFFLLineup is the resolver for the setFFLLineup field.
-func (r *mutationResolver) SetFFLLineup(ctx context.Context, input SetFFLLineupInput) ([]*FFLPlayerMatch, error) {
+// SetFFLTeam is the resolver for the setFFLTeam field.
+func (r *mutationResolver) SetFFLTeam(ctx context.Context, input SetFFLTeamInput) ([]*FFLPlayerMatch, error) {
 	clubMatchID, err := fromID(input.ClubMatchID)
 	if err != nil {
 		return nil, err
 	}
-	entries := make([]application.SetLineupEntry, len(input.Players))
+	entries := make([]application.SetTeamEntry, len(input.Players))
 	for i, p := range input.Players {
 		psID, err := fromID(p.PlayerSeasonID)
 		if err != nil {
 			return nil, err
 		}
-		entries[i] = application.SetLineupEntry{
+		entries[i] = application.SetTeamEntry{
 			PlayerSeasonID:      psID,
 			Position:            p.Position,
 			BackupPositions:     p.BackupPositions,
 			InterchangePosition: p.InterchangePosition,
 		}
 	}
-	pms, err := r.Commands.SetLineup(ctx, clubMatchID, entries)
+	pms, err := r.Commands.SetTeam(ctx, clubMatchID, entries)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Implements FFL team composition rules in the domain layer (`ValidateTeam`) enforcing starter slots per position (3 goals, 4 kicks, 4 handballs, 2 marks, 2 tackles, 2 hitouts, 1 star), bench limits (≤4, ≤1 star, dual-position constraints), and substitution/interchange logic
- Fixes `Score()` for multi-starter positions — starters map changed from `map[Position]*PlayerMatch` to `map[Position][]*PlayerMatch` so all slots score correctly
- Enforces validation in the `SetTeam` command and exposes errors through the GraphQL mutation
- Rebuilds the Team Builder UI with a structured position-by-position layout, interchange selection, and bench management
- Adds comprehensive domain unit tests and GraphQL integration tests
- Renames "lineup" → "team" throughout the codebase

## Test plan

- [ ] `go test ./...` in `services/ffl/` passes
- [ ] `go test ./...` in `services/afl/` passes  
- [ ] GraphQL integration tests pass (`services/ffl/internal/interface/graphql/`)
- [ ] Team Builder UI loads and enforces composition rules
- [ ] E2E Playwright tests pass (`just test-e2e`)