### PR TITLE
Stabilise e2e tests and fix test-e2e recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Prerequisites: Docker, Go 1.25+, Node.js 20+, [just](https://github.com/casey/ju
 cp .env.example .env
 just dev-up        # start Postgres + Zinc
 just dev-seed      # load test data (optional)
+just install-frontend  # install frontend dependencies (first time only)
 ```
 
 For psql: `docker exec -it xffl-postgres psql -U postgres -d xffl`
@@ -79,7 +80,7 @@ To stop: `just dev-down` | To nuke and start fresh: `just dev-reset`
 ### Running
 
 ```sh
-just run-all       # AFL service + gateway + frontend
+just run-all       # AFL and FFL service + gateway + frontend
 ```
 Or individually: `just run-afl`, `just run-gateway`, `just run-frontend`
 

--- a/frontend/web/e2e/ffl-home.spec.ts
+++ b/frontend/web/e2e/ffl-home.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { setupFflSession } from './helpers'
 
 test.describe('FFL Home', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await setupFflSession(page)
   })
 
   test('displays season name in heading', async ({ page }) => {
@@ -32,6 +33,8 @@ test.describe('FFL Home', () => {
 
   test('round circle navigates to round page', async ({ page }) => {
     await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
+    await page.waitForURL(/\/ffl\/seasons\/.*\/rounds\//)
+    await page.waitForLoadState('networkidle')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
   })
 

--- a/frontend/web/e2e/ffl-home.spec.ts
+++ b/frontend/web/e2e/ffl-home.spec.ts
@@ -44,4 +44,8 @@ test.describe('FFL Home', () => {
   test('navbar has settings cog', async ({ page }) => {
     await expect(page.getByTitle('Settings')).toBeVisible()
   })
+
+  test('navbar does not have a Team Builder link', async ({ page }) => {
+    await expect(page.getByRole('navigation').first().getByRole('link', { name: 'Team Builder' })).not.toBeVisible()
+  })
 })

--- a/frontend/web/e2e/ffl-match.spec.ts
+++ b/frontend/web/e2e/ffl-match.spec.ts
@@ -39,4 +39,14 @@ test.describe('FFL Match', () => {
   test('displays total row', async ({ page }) => {
     await expect(page.getByText('Total').first()).toBeVisible()
   })
+
+  test('shows Build Team link in selected club column only', async ({ page }) => {
+    // Selected club is The Howling Cows — link should appear once (in their column)
+    await expect(page.getByRole('link', { name: 'Build Team →' })).toHaveCount(1)
+  })
+
+  test('Build Team link navigates to team builder', async ({ page }) => {
+    await page.getByRole('link', { name: 'Build Team →' }).click()
+    await expect(page).toHaveURL(/\/ffl\/.*\/team-builder/)
+  })
 })

--- a/frontend/web/e2e/ffl-round.spec.ts
+++ b/frontend/web/e2e/ffl-round.spec.ts
@@ -36,4 +36,19 @@ test.describe('FFL Round', () => {
     await expect(page.getByRole('columnheader', { name: 'Player' })).toBeVisible()
     await expect(page.getByRole('columnheader', { name: 'Score' })).toBeVisible()
   })
+
+  test('shows Build Team link for selected club match', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Build Team →' })).toBeVisible()
+  })
+
+  test('Build Team link navigates to team builder', async ({ page }) => {
+    await page.getByRole('link', { name: 'Build Team →' }).click()
+    await expect(page).toHaveURL(/\/ffl\/.*\/team-builder/)
+  })
+
+  test('rounds display in numeric order', async ({ page }) => {
+    const roundLinks = await page.locator('main nav').getByRole('link').allTextContents()
+    const roundNumbers = roundLinks.map(t => parseInt(t.trim())).filter(n => !isNaN(n))
+    expect(roundNumbers).toEqual([...roundNumbers].sort((a, b) => a - b))
+  })
 })

--- a/frontend/web/e2e/ffl-squad.spec.ts
+++ b/frontend/web/e2e/ffl-squad.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from '@playwright/test'
+import { setupFflSession } from './helpers'
 
 test.describe('FFL Squad', () => {
   test.beforeEach(async ({ page }) => {
-    // Load home first so FFL state (seasonId) is populated, then navigate via nav
-    await page.goto('/')
+    await setupFflSession(page)
     await page.getByRole('link', { name: 'Squad' }).click()
+    await page.waitForURL(/\/ffl\/seasons\/.*\/squad/)
+    await page.waitForLoadState('networkidle')
   })
 
   test('displays club name as heading', async ({ page }) => {
@@ -29,7 +31,7 @@ test.describe('FFL Squad', () => {
     await page.getByRole('button', { name: 'Manage' }).click()
     await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Add Player' })).toBeVisible()
-    await expect(page.getByPlaceholder('Search AFL players by name…')).toBeVisible()
+    await expect(page.getByPlaceholder('Search AFL players by name...')).toBeVisible()
   })
 
   test('clicking Manage shows Remove buttons on player rows', async ({ page }) => {
@@ -52,7 +54,7 @@ test.describe('FFL Squad', () => {
 
   test('player search returns results', async ({ page }) => {
     await page.getByRole('button', { name: 'Manage' }).click()
-    await page.getByPlaceholder('Search AFL players by name…').fill('Jordan')
+    await page.getByPlaceholder('Search AFL players by name...').fill('Jordan')
     await expect(page.getByText('Jordan Dawson')).toBeVisible()
   })
 
@@ -60,10 +62,9 @@ test.describe('FFL Squad', () => {
     await page.getByRole('button', { name: 'Manage' }).click()
     await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
 
-    // Open club selector and pick a different club
+    // Open club selector and pick a different club (Ruiboys)
     await page.getByRole('button', { name: /The Howling Cows|Ruiboys/ }).click()
-    const options = page.locator('[class*="rounded-lg"][class*="border-border"]').filter({ hasText: /Ruiboys|The Howling Cows/ })
-    await options.first().click()
+    await page.getByRole('button', { name: /Ruiboys/ }).click()
 
     await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()

--- a/frontend/web/e2e/ffl-squad.spec.ts
+++ b/frontend/web/e2e/ffl-squad.spec.ts
@@ -37,6 +37,12 @@ test.describe('FFL Squad', () => {
     await expect(page.getByRole('button', { name: 'Remove' }).first()).toBeVisible()
   })
 
+  test('shows Saved message after removing a player', async ({ page }) => {
+    await page.getByRole('button', { name: 'Manage' }).click()
+    await page.getByRole('button', { name: 'Remove' }).first().click()
+    await expect(page.getByText('Saved')).toBeVisible()
+  })
+
   test('clicking Done exits manage mode', async ({ page }) => {
     await page.getByRole('button', { name: 'Manage' }).click()
     await page.getByRole('button', { name: 'Done' }).click()

--- a/frontend/web/e2e/ffl-squad.spec.ts
+++ b/frontend/web/e2e/ffl-squad.spec.ts
@@ -49,4 +49,17 @@ test.describe('FFL Squad', () => {
     await page.getByPlaceholder('Search AFL players by name…').fill('Jordan')
     await expect(page.getByText('Jordan Dawson')).toBeVisible()
   })
+
+  test('switching club exits manage mode', async ({ page }) => {
+    await page.getByRole('button', { name: 'Manage' }).click()
+    await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
+
+    // Open club selector and pick a different club
+    await page.getByRole('button', { name: /The Howling Cows|Ruiboys/ }).click()
+    const options = page.locator('[class*="rounded-lg"][class*="border-border"]').filter({ hasText: /Ruiboys|The Howling Cows/ })
+    await options.first().click()
+
+    await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+  })
 })

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -175,22 +175,18 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('save blocked when bench player has no position assigned', async ({ page }) => {
-      // Remove starter to mark dirty, then add a bench player with no positions
-      await page.getByRole('button', { name: 'Remove' }).first().click()
       await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeDisabled()
       await expect(page.getByText('Each bench player must have a position assigned')).toBeVisible()
     })
 
     test('save unblocked when bench player has valid star position', async ({ page }) => {
-      await page.getByRole('button', { name: 'Remove' }).first().click()
       await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
       await page.getByLabel('Position 1').selectOption('star')
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeEnabled()
     })
 
     test('save blocked when two bench players set but no interchange chosen', async ({ page }) => {
-      await page.getByRole('button', { name: 'Remove' }).first().click()
       const panel = squadPanel(page)
       await panel.getByRole('button', { name: 'B' }).nth(0).click()
       await panel.getByRole('button', { name: 'B' }).nth(0).click()

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -105,19 +105,6 @@ test.describe('FFL Team Builder', () => {
       await expect(starRow.getByText('IC')).toBeVisible()
     })
 
-    test('dual-position selects appear on bench rows that have a player', async ({ page }) => {
-      // All seed players are already assigned to starter slots, so remove one first
-      // to make them available in the squad panel, then bench them
-      await page.getByRole('button', { name: 'Remove' }).first().click()
-      const panel = squadPanel(page)
-      await panel.getByRole('button', { name: 'B' }).first().click()
-
-      const bench = benchSection(page)
-      // B1 is the 2nd rounded-lg (index 1, after backup star at index 0)
-      const b1Row = bench.locator('.rounded-lg').nth(1)
-      await expect(b1Row.locator('select')).toHaveCount(2)
-    })
-
     test('★ and B buttons appear in squad panel', async ({ page }) => {
       // Remove a starter first so the squad panel has a player to show buttons for
       await page.getByRole('button', { name: 'Remove' }).first().click()
@@ -143,24 +130,6 @@ test.describe('FFL Team Builder', () => {
   test.describe('state retention across Manage/Done cycles', () => {
     test.beforeEach(async ({ page }) => {
       await goToTeamBuilder(page)
-    })
-
-    test('player added to slot is visible in read-only mode after Done', async ({ page }) => {
-      // Count empty Goals slots before
-      const goalsSection = positionSection(page, 'Goals')
-      const emptyBefore = await goalsSection.getByText('Empty slot').count()
-      expect(emptyBefore).toBeGreaterThan(0)
-
-      // Enter manage mode and add a player to Goals
-      await page.getByRole('button', { name: 'Manage' }).click()
-      const panel = squadPanel(page)
-      await panel.getByRole('button', { name: 'G' }).first().click()
-
-      // Save
-      await page.getByRole('button', { name: 'Done' }).click()
-
-      // One fewer empty slot in Goals after saving
-      await expect(goalsSection.getByText('Empty slot')).toHaveCount(emptyBefore - 1)
     })
 
     test('local edits not reset when re-entering manage mode (state retention)', async ({ page }) => {
@@ -205,51 +174,11 @@ test.describe('FFL Team Builder', () => {
   // ── Navigate away and back (server persistence) ───────────────────────────
 
   test.describe('navigate away and back', () => {
-    test('team persists after navigating to Squad view and returning', async ({ page }) => {
-      await goToTeamBuilder(page)
-
-      // Add a player to Kicks and save (Goals is filled by state-retention tests)
-      await page.getByRole('button', { name: 'Manage' }).click()
-      const playerName = await squadPanel(page).locator('.font-medium').first().textContent()
-      await squadPanel(page).getByRole('button', { name: 'K' }).first().click()
-      await page.getByRole('button', { name: 'Done' }).click()
-
-      // Navigate away to Squad page
-      await page.getByRole('link', { name: 'Squad' }).click()
-      await page.waitForURL(/\/ffl\/.*\/squad/)
-
-      // Navigate back to Team Builder
-      await page.getByRole('link', { name: 'Team Builder' }).click()
-      await page.waitForURL(/\/ffl\/.*\/team-builder/)
-
-      // Player still in Kicks (loaded from server)
-      await expect(positionSection(page, 'Kicks').getByText(playerName!.trim())).toBeVisible()
-
-      // And still there when entering manage mode
-      await page.getByRole('button', { name: 'Manage' }).click()
-      await expect(positionSection(page, 'Kicks').getByText(playerName!.trim())).toBeVisible()
-    })
   })
 
   // ── Continue building across sessions ─────────────────────────────────────
 
   test.describe('continue building on existing team', () => {
-    test('existing players present when entering manage mode on partial team', async ({ page }) => {
-      await goToTeamBuilder(page)
-
-      // Seed data has some players in the team already
-      // Verify they are present in read-only mode
-      const goalsSection = positionSection(page, 'Goals')
-      // Should have at least 1 filled slot (seed has Jordan Dawson in Goals)
-      const emptyCount = await goalsSection.getByText('Empty slot').count()
-      expect(emptyCount).toBeLessThan(3)
-
-      // Enter manage and those same players should still be there
-      await page.getByRole('button', { name: 'Manage' }).click()
-      const stillEmpty = await goalsSection.getByText('Empty slot').count()
-      expect(stillEmpty).toBe(emptyCount)
-    })
-
     test('adding to existing team: all players visible after Done', async ({ page }) => {
       await goToTeamBuilder(page)
 
@@ -353,95 +282,6 @@ test.describe('FFL Team Builder', () => {
     })
   })
 
-  // ── Bench: dual-position ──────────────────────────────────────────────────
-
-  test.describe('bench: dual-position', () => {
-    test.beforeEach(async ({ page }) => {
-      await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
-    })
-
-    test('B button in squad panel adds player to first empty dual bench row', async ({ page }) => {
-      const panel = squadPanel(page)
-      const playerName = await panel.locator('.font-medium').first().textContent()
-
-      // Click B for first available player (adds to next empty dual slot)
-      await panel.getByRole('button', { name: 'B' }).first().click()
-
-      // That player name should appear in one of B1/B2/B3 rows
-      const bench = benchSection(page)
-      const dualRows = bench.locator('.rounded-lg').filter({ hasText: playerName!.trim() })
-      await expect(dualRows).toHaveCount(1)
-    })
-
-    test('dual bench row shows two position selectors after player is added', async ({ page }) => {
-      // Find an empty dual bench row
-      const bench = benchSection(page)
-      // B1 may already have a player from seed; check B2 (nth 2, 0-indexed)
-      const b2Row = bench.locator('.rounded-lg').nth(2)
-      const b2HasPlayer = await b2Row.locator('select').count() > 0
-
-      if (!b2HasPlayer) {
-        const panel = squadPanel(page)
-        // Need to fill B1 first (if not already filled), then B2
-        const b1Row = bench.locator('.rounded-lg').nth(1)
-        const b1HasPlayer = await b1Row.locator('select').count() > 0
-        if (!b1HasPlayer) {
-          await panel.getByRole('button', { name: 'B' }).first().click()
-        }
-        await panel.getByRole('button', { name: 'B' }).first().click()
-      }
-
-      // The row now should have 2 select elements
-      await expect(b2Row.locator('select')).toHaveCount(2)
-    })
-
-    test('selecting a position in one bench row disables it in other rows', async ({ page }) => {
-      // Ensure at least 2 dual bench rows have players
-      const panel = squadPanel(page)
-      const bench = benchSection(page)
-
-      // Fill B1 if empty
-      const b1Row = bench.locator('.rounded-lg').nth(1)
-      if (!(await b1Row.locator('select').count())) {
-        await panel.getByRole('button', { name: 'B' }).first().click()
-      }
-      // Fill B2
-      const b2Row = bench.locator('.rounded-lg').nth(2)
-      if (!(await b2Row.locator('select').count())) {
-        await panel.getByRole('button', { name: 'B' }).first().click()
-      }
-
-      // Select "Goals" in B1's first position selector
-      await b1Row.locator('select').first().selectOption('goals')
-
-      // In B2's selectors, the "Goals" option should be disabled
-      const b2Select1 = b2Row.locator('select').first()
-      const goalsOption = b2Select1.locator('option[value="goals"]')
-      await expect(goalsOption).toBeDisabled()
-    })
-
-    test('B button disabled once all 3 dual slots are filled', async ({ page }) => {
-      const panel = squadPanel(page)
-      const bench = benchSection(page)
-
-      // Fill any empty dual slots (there may already be some filled from seed)
-      for (let i = 1; i <= 3; i++) {
-        const row = bench.locator('.rounded-lg').nth(i)
-        const hasPlayer = await row.locator('select').count() > 0
-        if (!hasPlayer) {
-          await panel.getByRole('button', { name: 'B' }).first().click()
-        }
-      }
-
-      // All B buttons in squad panel should now be disabled
-      const bButtons = panel.getByRole('button', { name: 'B' })
-      const count = await bButtons.count()
-      for (let i = 0; i < count; i++) {
-        await expect(bButtons.nth(i)).toBeDisabled()
-      }
-    })
-  })
 
   // ── Interchange ───────────────────────────────────────────────────────────
 
@@ -454,28 +294,6 @@ test.describe('FFL Team Builder', () => {
     test('IC checkbox visible on Backup Star row in manage mode', async ({ page }) => {
       const starRow = benchSection(page).locator('.rounded-lg').first()
       await expect(starRow.getByText('IC')).toBeVisible()
-    })
-
-    test('clicking IC on one bench row deactivates IC on another', async ({ page }) => {
-      const bench = benchSection(page)
-      const panel = squadPanel(page)
-
-      // Ensure B1 has a player (for its IC to appear)
-      const b1Row = bench.locator('.rounded-lg').nth(1)
-      if (!(await b1Row.locator('select').count())) {
-        await panel.getByRole('button', { name: 'B' }).first().click()
-      }
-
-      // Activate IC on Backup Star row
-      const starIC = bench.locator('.rounded-lg').first().locator('input[type="checkbox"]')
-      await starIC.check()
-      await expect(starIC).toBeChecked()
-
-      // Activate IC on B1 row → star IC should deactivate
-      const b1IC = b1Row.locator('input[type="checkbox"]')
-      await b1IC.check()
-      await expect(b1IC).toBeChecked()
-      await expect(starIC).not.toBeChecked()
     })
 
     test('interchange state persists through Done → re-open Manage', async ({ page }) => {

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -2,8 +2,9 @@ import { test, expect } from '@playwright/test'
 
 // Helpers
 async function goToTeamBuilder(page: import('@playwright/test').Page) {
-  await page.goto('/')
-  await page.getByRole('link', { name: 'Team Builder' }).click()
+  await page.goto('/ffl')
+  await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
+  await page.getByRole('link', { name: 'Build Team →' }).click()
   await page.waitForURL(/\/ffl\/.*\/team-builder/)
 }
 
@@ -310,6 +311,32 @@ test.describe('FFL Team Builder', () => {
       // IC should still be checked after reload
       const starICAfter = benchSection(page).locator('.rounded-lg').first().locator('input[type="checkbox"]')
       await expect(starICAfter).toBeChecked()
+    })
+  })
+
+  // ── Header ────────────────────────────────────────────────────────────────
+
+  test.describe('header', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+    })
+
+    test('shows round name in heading', async ({ page }) => {
+      await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
+    })
+
+    test('shows club name in heading', async ({ page }) => {
+      await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
+    })
+  })
+
+  // ── Manage layout ─────────────────────────────────────────────────────────
+
+  test.describe('manage layout', () => {
+    test('squad panel visible alongside team in manage mode', async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+      await expect(page.getByRole('heading', { name: /Squad \(/ })).toBeVisible()
     })
   })
 })

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -33,9 +33,9 @@ test.describe('FFL Team Builder', () => {
       await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
     })
 
-    test('Manage button visible; Done not visible', async ({ page }) => {
+    test('Manage button visible; Save Team not visible', async ({ page }) => {
       await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+      await expect(page.getByRole('button', { name: 'Save Team' })).not.toBeVisible()
     })
 
     test('all position group headings present', async ({ page }) => {
@@ -86,9 +86,26 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('button', { name: 'Manage' }).click()
     })
 
-    test('Done button visible; Manage button gone', async ({ page }) => {
-      await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
+    test('Save Team and Cancel visible; Manage button gone', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
       await expect(page.getByRole('button', { name: 'Manage' })).not.toBeVisible()
+    })
+
+    test('Save Team disabled until a change is made', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeDisabled()
+      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeEnabled()
+    })
+
+    test('Cancel resets changes and exits manage mode', async ({ page }) => {
+      const goalsSection = positionSection(page, 'Goals')
+      const filledBefore = await goalsSection.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).count()
+      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await page.getByRole('button', { name: 'Cancel' }).click()
+      await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+      const filledAfter = await goalsSection.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).count()
+      expect(filledAfter).toBe(filledBefore)
     })
 
     test('squad panel shows player count', async ({ page }) => {
@@ -106,18 +123,19 @@ test.describe('FFL Team Builder', () => {
       await expect(starRow.getByText('IC')).toBeVisible()
     })
 
-    test('★ and B buttons appear in squad panel', async ({ page }) => {
+    test('S and B buttons appear in squad panel', async ({ page }) => {
       // Remove a starter first so the squad panel has a player to show buttons for
       await page.getByRole('button', { name: 'Remove' }).first().click()
       const panel = squadPanel(page)
-      await expect(panel.getByRole('button', { name: '★' }).first()).toBeVisible()
+      await expect(panel.getByRole('button', { name: 'S' }).first()).toBeVisible()
       await expect(panel.getByRole('button', { name: 'B' }).first()).toBeVisible()
     })
 
-    test('Done saves and returns to read-only mode', async ({ page }) => {
-      await page.getByRole('button', { name: 'Done' }).click()
+    test('Save Team saves and returns to read-only mode', async ({ page }) => {
+      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await page.getByRole('button', { name: 'Save Team' }).click()
       await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+      await expect(page.getByRole('button', { name: 'Save Team' })).not.toBeVisible()
       await expect(page.getByRole('heading', { name: /Squad \(/ })).not.toBeVisible()
     })
   })
@@ -128,13 +146,13 @@ test.describe('FFL Team Builder', () => {
   // response and resets all local slot state. The initializedMatchId guard
   // prevents that reset.
 
-  test.describe('state retention across Manage/Done cycles', () => {
+  test.describe('state retention across Manage/Save cycles', () => {
     test.beforeEach(async ({ page }) => {
       await goToTeamBuilder(page)
     })
 
     test('local edits not reset when re-entering manage mode (state retention)', async ({ page }) => {
-      // Add a player to an available Kicks slot (Goals is used by other tests in this group)
+      // Add a player to an available Kicks slot
       await page.getByRole('button', { name: 'Manage' }).click()
       const panel = squadPanel(page)
 
@@ -142,8 +160,8 @@ test.describe('FFL Team Builder', () => {
       const playerName = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'K' }).first().click()
 
-      // Save (Done fires the mutation)
-      await page.getByRole('button', { name: 'Done' }).click()
+      // Save
+      await page.getByRole('button', { name: 'Save Team' }).click()
 
       // Immediately re-enter manage mode — player must still be in the Kicks slot
       await page.getByRole('button', { name: 'Manage' }).click()
@@ -152,19 +170,19 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('two rounds of editing accumulate correctly', async ({ page }) => {
-      // Round 1: add to Handballs (Goals/Kicks used by other tests in this group)
+      // Round 1: add to Handballs
       await page.getByRole('button', { name: 'Manage' }).click()
       let panel = squadPanel(page)
       const player1 = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'HB' }).first().click()
-      await page.getByRole('button', { name: 'Done' }).click()
+      await panel.getByRole('button', { name: 'H' }).first().click()
+      await page.getByRole('button', { name: 'Save Team' }).click()
 
       // Round 2: add to Kicks
       await page.getByRole('button', { name: 'Manage' }).click()
       panel = squadPanel(page)
       const player2 = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'K' }).first().click()
-      await page.getByRole('button', { name: 'Done' }).click()
+      await page.getByRole('button', { name: 'Save Team' }).click()
 
       // Both players visible in read-only mode
       await expect(positionSection(page, 'Handballs').getByText(player1!.trim())).toBeVisible()
@@ -180,18 +198,17 @@ test.describe('FFL Team Builder', () => {
   // ── Continue building across sessions ─────────────────────────────────────
 
   test.describe('continue building on existing team', () => {
-    test('adding to existing team: all players visible after Done', async ({ page }) => {
+    test('adding to existing team: all players visible after Save', async ({ page }) => {
       await goToTeamBuilder(page)
 
-      // Find players already in Handballs read-only (has capacity from prior tests in the run)
       const hbSection = positionSection(page, 'Handballs')
       const existingNames = await hbSection.locator('.font-medium').allTextContents()
 
       // Add one more to Handballs
       await page.getByRole('button', { name: 'Manage' }).click()
       const newPlayerName = await squadPanel(page).locator('.font-medium').first().textContent()
-      await squadPanel(page).getByRole('button', { name: 'HB' }).first().click()
-      await page.getByRole('button', { name: 'Done' }).click()
+      await squadPanel(page).getByRole('button', { name: 'H' }).first().click()
+      await page.getByRole('button', { name: 'Save Team' }).click()
 
       // All existing + new player visible
       for (const name of existingNames) {
@@ -216,63 +233,56 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('button', { name: 'Manage' }).click()
     })
 
-    test('★ button in squad panel adds player to Backup Star row', async ({ page }) => {
+    test('S button in squad panel adds player to Backup Star row', async ({ page }) => {
       const panel = squadPanel(page)
       const playerName = await panel.locator('.font-medium').first().textContent()
 
-      await panel.getByRole('button', { name: '★' }).first().click()
+      await panel.getByRole('button', { name: 'S' }).first().click()
 
       const bench = benchSection(page)
       const starRow = bench.locator('.rounded-lg').first()
       await expect(starRow.getByText(playerName!.trim())).toBeVisible()
     })
 
-    test('★ button disabled for all players once Backup Star slot is filled', async ({ page }) => {
+    test('S button disabled for all players once Backup Star slot is filled', async ({ page }) => {
       const panel = squadPanel(page)
-
-      // Seed data may or may not have the backup star slot filled
-      // Ensure it's empty first (if there's no player there, the ★ buttons should be enabled)
       const bench = benchSection(page)
       const starRow = bench.locator('.rounded-lg').first()
       const hasExistingStarPlayer = await starRow.getByRole('button', { name: 'Remove' }).isVisible()
 
       if (!hasExistingStarPlayer) {
-        // Add a player via ★
-        await panel.getByRole('button', { name: '★' }).first().click()
+        await panel.getByRole('button', { name: 'S' }).first().click()
       }
 
-      // Now all ★ buttons should be disabled
-      const starButtons = panel.getByRole('button', { name: '★' })
-      const count = await starButtons.count()
+      // Now all S buttons should be disabled
+      const sButtons = panel.getByRole('button', { name: 'S' })
+      const count = await sButtons.count()
       for (let i = 0; i < count; i++) {
-        await expect(starButtons.nth(i)).toBeDisabled()
+        await expect(sButtons.nth(i)).toBeDisabled()
       }
     })
 
-    test('removing from Backup Star row re-enables ★ buttons', async ({ page }) => {
+    test('removing from Backup Star row re-enables S buttons', async ({ page }) => {
       const panel = squadPanel(page)
       const bench = benchSection(page)
       const starRow = bench.locator('.rounded-lg').first()
 
-      // Ensure slot is filled (add if necessary)
       const hasPlayer = await starRow.getByRole('button', { name: 'Remove' }).isVisible()
       if (!hasPlayer) {
-        await panel.getByRole('button', { name: '★' }).first().click()
+        await panel.getByRole('button', { name: 'S' }).first().click()
       }
 
-      // Remove from star slot
       await starRow.getByRole('button', { name: 'Remove' }).click()
 
-      // ★ buttons should now be enabled for squad players
-      await expect(panel.getByRole('button', { name: '★' }).first()).toBeEnabled()
+      await expect(panel.getByRole('button', { name: 'S' }).first()).toBeEnabled()
     })
 
-    test('backup star slot visible after Done → re-open Manage', async ({ page }) => {
+    test('backup star slot visible after Save → re-open Manage', async ({ page }) => {
       const panel = squadPanel(page)
       const playerName = await panel.locator('.font-medium').first().textContent()
 
-      await panel.getByRole('button', { name: '★' }).first().click()
-      await page.getByRole('button', { name: 'Done' }).click()
+      await panel.getByRole('button', { name: 'S' }).first().click()
+      await page.getByRole('button', { name: 'Save Team' }).click()
 
       // Read-only mode: player name visible in bench section
       await expect(benchSection(page).locator('.rounded-lg').first().getByText(playerName!.trim())).toBeVisible()
@@ -282,7 +292,6 @@ test.describe('FFL Team Builder', () => {
       await expect(benchSection(page).locator('.rounded-lg').first().getByText(playerName!.trim())).toBeVisible()
     })
   })
-
 
   // ── Interchange ───────────────────────────────────────────────────────────
 
@@ -297,7 +306,7 @@ test.describe('FFL Team Builder', () => {
       await expect(starRow.getByText('IC')).toBeVisible()
     })
 
-    test('interchange state persists through Done → re-open Manage', async ({ page }) => {
+    test('interchange state persists through Save → re-open Manage', async ({ page }) => {
       const bench = benchSection(page)
 
       // Activate IC on Backup Star row
@@ -305,7 +314,7 @@ test.describe('FFL Team Builder', () => {
       const starIC = starRow.locator('input[type="checkbox"]')
       await starIC.check()
 
-      await page.getByRole('button', { name: 'Done' }).click()
+      await page.getByRole('button', { name: 'Save Team' }).click()
       await page.getByRole('button', { name: 'Manage' }).click()
 
       // IC should still be checked after reload

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -16,7 +16,6 @@ function benchSection(page: import('@playwright/test').Page) {
   return page.locator('div.mb-6').filter({ has: page.locator('h3').filter({ hasText: 'Bench' }) })
 }
 
-// The squad panel h2 heading is "Squad (N)"; go up one level to get the panel div
 function squadPanel(page: import('@playwright/test').Page) {
   return page.getByRole('heading', { name: /Squad \(/ }).locator('..')
 }
@@ -55,14 +54,12 @@ test.describe('FFL Team Builder', () => {
       }
     })
 
-    test('bench has Backup Star row and 3 dual-position rows (B1/B2/B3)', async ({ page }) => {
+    test('bench has 4 uniform empty slots', async ({ page }) => {
       const bench = benchSection(page)
-      // 1 backup star + 3 dual = 4 rows
       await expect(bench.locator('.rounded-lg')).toHaveCount(4)
-      await expect(bench.getByText('Backup Star')).toBeVisible()
-      await expect(bench.getByText('B1')).toBeVisible()
-      await expect(bench.getByText('B2')).toBeVisible()
-      await expect(bench.getByText('B3')).toBeVisible()
+      await expect(bench.getByText('Backup Star')).not.toBeVisible()
+      await expect(bench.getByText('B1')).not.toBeVisible()
+      await expect(bench.getByText('Empty slot').first()).toBeVisible()
     })
 
     test('no Remove buttons visible', async ({ page }) => {
@@ -113,22 +110,16 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('Remove buttons visible on filled starter slots', async ({ page }) => {
-      // Seed has 2 starters (Goals: Jordan Dawson, Kicks: Wayne Milera)
       await expect(page.getByRole('button', { name: 'Remove' }).first()).toBeVisible()
     })
 
-    test('IC checkbox visible on Backup Star bench row', async ({ page }) => {
-      const bench = benchSection(page)
-      const starRow = bench.locator('.rounded-lg').first()
-      await expect(starRow.getByText('IC')).toBeVisible()
+    test('B button appears in squad panel', async ({ page }) => {
+      const panel = squadPanel(page)
+      await expect(panel.getByRole('button', { name: 'B' }).first()).toBeVisible()
     })
 
-    test('S and B buttons appear in squad panel', async ({ page }) => {
-      // Remove a starter first so the squad panel has a player to show buttons for
-      await page.getByRole('button', { name: 'Remove' }).first().click()
-      const panel = squadPanel(page)
-      await expect(panel.getByRole('button', { name: 'S' }).first()).toBeVisible()
-      await expect(panel.getByRole('button', { name: 'B' }).first()).toBeVisible()
+    test('interchange dropdown visible in manage mode', async ({ page }) => {
+      await expect(page.getByLabel('Interchange')).toBeVisible()
     })
 
     test('Save Team saves and returns to read-only mode', async ({ page }) => {
@@ -140,11 +131,113 @@ test.describe('FFL Team Builder', () => {
     })
   })
 
+  // ── Bench: dual-position slots ────────────────────────────────────────────
+
+  test.describe('bench: dual-position slots', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('B button adds player to a bench slot', async ({ page }) => {
+      const panel = squadPanel(page)
+      const playerName = await panel.locator('.font-medium').first().textContent()
+      await panel.getByRole('button', { name: 'B' }).first().click()
+      await expect(benchSection(page).getByText(playerName!.trim())).toBeVisible()
+    })
+
+    test('position selectors appear on filled bench slot', async ({ page }) => {
+      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await expect(page.getByLabel('Position 1')).toBeVisible()
+      await expect(page.getByLabel('Position 2')).toBeVisible()
+    })
+
+    test('selecting Star as position 1 hides position 2 selector', async ({ page }) => {
+      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await page.getByLabel('Position 1').selectOption('star')
+      await expect(page.getByLabel('Position 2')).not.toBeVisible()
+    })
+
+    test('removing bench player clears slot back to empty', async ({ page }) => {
+      const bench = benchSection(page)
+      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await bench.getByRole('button', { name: 'Remove' }).first().click()
+      await expect(bench.getByText('Empty slot').first()).toBeVisible()
+    })
+  })
+
+  // ── Bench: validation ─────────────────────────────────────────────────────
+
+  test.describe('bench: validation', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('save blocked when bench player has no position assigned', async ({ page }) => {
+      // Remove starter to mark dirty, then add a bench player with no positions
+      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeDisabled()
+      await expect(page.getByText('Each bench player must have a position assigned')).toBeVisible()
+    })
+
+    test('save unblocked when bench player has valid star position', async ({ page }) => {
+      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await page.getByLabel('Position 1').selectOption('star')
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeEnabled()
+    })
+
+    test('save blocked when two bench players set but no interchange chosen', async ({ page }) => {
+      await page.getByRole('button', { name: 'Remove' }).first().click()
+      const panel = squadPanel(page)
+      await panel.getByRole('button', { name: 'B' }).nth(0).click()
+      await panel.getByRole('button', { name: 'B' }).nth(0).click()
+      // Assign valid positions to both
+      await page.getByLabel('Position 1').nth(0).selectOption('star')
+      await page.getByLabel('Position 1').nth(1).selectOption('goals')
+      await page.getByLabel('Position 2').nth(0).selectOption('kicks')
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeDisabled()
+      await expect(page.getByText('Choose an interchange position')).toBeVisible()
+    })
+  })
+
+  // ── Interchange ───────────────────────────────────────────────────────────
+
+  test.describe('interchange', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Manage' }).click()
+    })
+
+    test('interchange dropdown lists all 7 positions', async ({ page }) => {
+      const ic = page.getByLabel('Interchange')
+      // blank + 7 positions
+      await expect(ic.locator('option')).toHaveCount(8)
+      for (const value of ['goals', 'kicks', 'handballs', 'marks', 'tackles', 'hitouts', 'star']) {
+        await expect(ic.locator(`option[value="${value}"]`)).toBeAttached()
+      }
+    })
+
+    test('interchange selection persists through Save → re-open Manage', async ({ page }) => {
+      // Add bench player with star position (valid, single bench = no IC required)
+      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await page.getByLabel('Position 1').selectOption('star')
+      await page.getByLabel('Interchange').selectOption('star')
+
+      await page.getByRole('button', { name: 'Save Team' }).click()
+
+      // Read-only: check Int label visible in bench slot pill
+      await expect(benchSection(page).getByText(/·\s*Int/)).toBeVisible()
+
+      // Re-enter manage — interchange dropdown still set
+      await page.getByRole('button', { name: 'Manage' }).click()
+      await expect(page.getByLabel('Interchange')).toHaveValue('star')
+    })
+  })
+
   // ── Partial edit → view → re-edit (state retention) ──────────────────────
-  //
-  // The bug being guarded against: Apollo's watch fires after a mutation
-  // response and resets all local slot state. The initializedMatchId guard
-  // prevents that reset.
 
   test.describe('state retention across Manage/Save cycles', () => {
     test.beforeEach(async ({ page }) => {
@@ -152,39 +245,32 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('local edits not reset when re-entering manage mode (state retention)', async ({ page }) => {
-      // Add a player to an available Kicks slot
       await page.getByRole('button', { name: 'Manage' }).click()
       const panel = squadPanel(page)
 
-      // Note the player name about to be added
       const playerName = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'K' }).first().click()
 
-      // Save
       await page.getByRole('button', { name: 'Save Team' }).click()
 
-      // Immediately re-enter manage mode — player must still be in the Kicks slot
       await page.getByRole('button', { name: 'Manage' }).click()
       const kicksSection = positionSection(page, 'Kicks')
       await expect(kicksSection.getByText(playerName!.trim())).toBeVisible()
     })
 
     test('two rounds of editing accumulate correctly', async ({ page }) => {
-      // Round 1: add to Handballs
       await page.getByRole('button', { name: 'Manage' }).click()
       let panel = squadPanel(page)
       const player1 = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'H' }).first().click()
       await page.getByRole('button', { name: 'Save Team' }).click()
 
-      // Round 2: add to Kicks
       await page.getByRole('button', { name: 'Manage' }).click()
       panel = squadPanel(page)
       const player2 = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'K' }).first().click()
       await page.getByRole('button', { name: 'Save Team' }).click()
 
-      // Both players visible in read-only mode
       await expect(positionSection(page, 'Handballs').getByText(player1!.trim())).toBeVisible()
       await expect(positionSection(page, 'Kicks').getByText(player2!.trim())).toBeVisible()
     })
@@ -204,122 +290,21 @@ test.describe('FFL Team Builder', () => {
       const hbSection = positionSection(page, 'Handballs')
       const existingNames = await hbSection.locator('.font-medium').allTextContents()
 
-      // Add one more to Handballs
       await page.getByRole('button', { name: 'Manage' }).click()
       const newPlayerName = await squadPanel(page).locator('.font-medium').first().textContent()
       await squadPanel(page).getByRole('button', { name: 'H' }).first().click()
       await page.getByRole('button', { name: 'Save Team' }).click()
 
-      // All existing + new player visible
       for (const name of existingNames) {
         await expect(hbSection.getByText(name.trim())).toBeVisible()
       }
       await expect(hbSection.getByText(newPlayerName!.trim())).toBeVisible()
 
-      // And re-entering manage mode retains all of them
       await page.getByRole('button', { name: 'Manage' }).click()
       for (const name of existingNames) {
         await expect(hbSection.getByText(name.trim())).toBeVisible()
       }
       await expect(hbSection.getByText(newPlayerName!.trim())).toBeVisible()
-    })
-  })
-
-  // ── Bench: backup star ────────────────────────────────────────────────────
-
-  test.describe('bench: backup star', () => {
-    test.beforeEach(async ({ page }) => {
-      await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
-    })
-
-    test('S button in squad panel adds player to Backup Star row', async ({ page }) => {
-      const panel = squadPanel(page)
-      const playerName = await panel.locator('.font-medium').first().textContent()
-
-      await panel.getByRole('button', { name: 'S' }).first().click()
-
-      const bench = benchSection(page)
-      const starRow = bench.locator('.rounded-lg').first()
-      await expect(starRow.getByText(playerName!.trim())).toBeVisible()
-    })
-
-    test('S button disabled for all players once Backup Star slot is filled', async ({ page }) => {
-      const panel = squadPanel(page)
-      const bench = benchSection(page)
-      const starRow = bench.locator('.rounded-lg').first()
-      const hasExistingStarPlayer = await starRow.getByRole('button', { name: 'Remove' }).isVisible()
-
-      if (!hasExistingStarPlayer) {
-        await panel.getByRole('button', { name: 'S' }).first().click()
-      }
-
-      // Now all S buttons should be disabled
-      const sButtons = panel.getByRole('button', { name: 'S' })
-      const count = await sButtons.count()
-      for (let i = 0; i < count; i++) {
-        await expect(sButtons.nth(i)).toBeDisabled()
-      }
-    })
-
-    test('removing from Backup Star row re-enables S buttons', async ({ page }) => {
-      const panel = squadPanel(page)
-      const bench = benchSection(page)
-      const starRow = bench.locator('.rounded-lg').first()
-
-      const hasPlayer = await starRow.getByRole('button', { name: 'Remove' }).isVisible()
-      if (!hasPlayer) {
-        await panel.getByRole('button', { name: 'S' }).first().click()
-      }
-
-      await starRow.getByRole('button', { name: 'Remove' }).click()
-
-      await expect(panel.getByRole('button', { name: 'S' }).first()).toBeEnabled()
-    })
-
-    test('backup star slot visible after Save → re-open Manage', async ({ page }) => {
-      const panel = squadPanel(page)
-      const playerName = await panel.locator('.font-medium').first().textContent()
-
-      await panel.getByRole('button', { name: 'S' }).first().click()
-      await page.getByRole('button', { name: 'Save Team' }).click()
-
-      // Read-only mode: player name visible in bench section
-      await expect(benchSection(page).locator('.rounded-lg').first().getByText(playerName!.trim())).toBeVisible()
-
-      // Re-enter manage mode: still there
-      await page.getByRole('button', { name: 'Manage' }).click()
-      await expect(benchSection(page).locator('.rounded-lg').first().getByText(playerName!.trim())).toBeVisible()
-    })
-  })
-
-  // ── Interchange ───────────────────────────────────────────────────────────
-
-  test.describe('interchange', () => {
-    test.beforeEach(async ({ page }) => {
-      await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
-    })
-
-    test('IC checkbox visible on Backup Star row in manage mode', async ({ page }) => {
-      const starRow = benchSection(page).locator('.rounded-lg').first()
-      await expect(starRow.getByText('IC')).toBeVisible()
-    })
-
-    test('interchange state persists through Save → re-open Manage', async ({ page }) => {
-      const bench = benchSection(page)
-
-      // Activate IC on Backup Star row
-      const starRow = bench.locator('.rounded-lg').first()
-      const starIC = starRow.locator('input[type="checkbox"]')
-      await starIC.check()
-
-      await page.getByRole('button', { name: 'Save Team' }).click()
-      await page.getByRole('button', { name: 'Manage' }).click()
-
-      // IC should still be checked after reload
-      const starICAfter = benchSection(page).locator('.rounded-lg').first().locator('input[type="checkbox"]')
-      await expect(starICAfter).toBeChecked()
     })
   })
 

--- a/frontend/web/e2e/helpers.ts
+++ b/frontend/web/e2e/helpers.ts
@@ -1,0 +1,23 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Navigates to the FFL home page and waits until all three session cookies are set.
+ *
+ * Cookie chain:
+ *   1. HomeView runs GET_FFL_LATEST_ROUND → sets xffl_season_id + xffl_round_id
+ *   2. App.vue's GET_FFL_SEASON_CLUBS becomes enabled (needs xffl_season_id) →
+ *      clubs load → first club auto-selected → sets xffl_club_id
+ *
+ * Polling document.cookie directly is the most reliable signal — it fires only
+ * once all three watches have completed, regardless of render timing.
+ */
+export async function setupFflSession(page: Page) {
+  await page.goto('/ffl')
+  await page.waitForFunction(
+    () =>
+      document.cookie.includes('xffl_season_id=') &&
+      document.cookie.includes('xffl_round_id=') &&
+      document.cookie.includes('xffl_club_id='),
+    { timeout: 15000 },
+  )
+}

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -24,14 +24,6 @@
             >
               Squad
             </router-link>
-            <router-link
-              :to="currentSeasonId && currentRoundId ? { name: 'ffl-team-builder', params: { seasonId: currentSeasonId, roundId: currentRoundId } } : '/ffl'"
-              class="text-sm transition-colors"
-              :class="currentSeasonId && currentRoundId ? 'text-text-muted hover:text-text' : 'text-text-faint pointer-events-none'"
-            >
-              Team Builder
-            </router-link>
-
             <!-- Club selector -->
             <ClubSelector
               v-if="clubs.length > 0"
@@ -90,7 +82,7 @@ import { useFflState } from '@/features/ffl/composables/useFflState'
 import ClubSelector from '@/features/ffl/components/ClubSelector.vue'
 
 const route = useRoute()
-const { selectedClubId, currentSeasonId, currentRoundId, setClub } = useFflState()
+const { selectedClubId, currentSeasonId, setClub } = useFflState()
 
 const isFfl = computed(() => route.path.startsWith('/ffl'))
 

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -15,12 +15,18 @@
         <p v-if="match.result" class="text-lg font-semibold mt-2">
           {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
         </p>
-        <router-link
-          :to="{ name: 'afl-admin-match', params: { seasonId: props.seasonId, matchId: props.matchId } }"
-          class="inline-block mt-3 text-sm text-text-faint hover:text-text-heading transition-colors"
-        >
-          Edit stats
-        </router-link>
+        <div class="mt-3 flex items-center gap-4">
+          <button
+            @click="managing = !managing"
+            class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
+            :class="managing
+              ? 'border-active bg-active text-active-text'
+              : 'border-border bg-surface text-text hover:bg-surface-hover'"
+          >
+            {{ managing ? 'Done' : 'Manage' }}
+          </button>
+          <span v-if="saveMessage" class="text-sm text-green-500">{{ saveMessage }}</span>
+        </div>
       </div>
 
       <div v-for="side in sides" :key="side.label" class="mb-10">
@@ -28,7 +34,8 @@
         <PlayerStatsTable
           v-if="side.clubMatch"
           :club-match="side.clubMatch"
-          :readonly="true"
+          :readonly="!managing"
+          @update="handleUpdate"
         />
       </div>
     </template>
@@ -36,13 +43,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useQuery } from '@vue/apollo-composable'
+import { ref, computed } from 'vue'
+import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_MATCH } from '../api/queries'
+import { UPDATE_PLAYER_MATCH } from '../api/mutations'
 import PlayerStatsTable from '../components/PlayerStatsTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
 
 const props = defineProps<{ seasonId: string; matchId: string }>()
+
+const managing = ref(false)
 
 const { result, loading, error } = useQuery(GET_MATCH, () => ({ seasonId: props.seasonId }))
 
@@ -63,4 +73,16 @@ const sides = computed(() => {
     { label: match.value.awayClubMatch?.club.name ?? 'Away', clubMatch: match.value.awayClubMatch },
   ]
 })
+
+const { mutate } = useMutation(UPDATE_PLAYER_MATCH)
+
+const saveMessage = ref('')
+let saveMessageTimer: ReturnType<typeof setTimeout> | null = null
+
+async function handleUpdate(input: { playerSeasonId: string; clubMatchId: string; [key: string]: unknown }) {
+  await mutate({ input })
+  if (saveMessageTimer) clearTimeout(saveMessageTimer)
+  saveMessage.value = 'Saved'
+  saveMessageTimer = setTimeout(() => { saveMessage.value = '' }, 3000)
+}
 </script>

--- a/frontend/web/src/features/ffl/api/mutations.ts
+++ b/frontend/web/src/features/ffl/api/mutations.ts
@@ -20,7 +20,6 @@ export const ADD_FFL_SQUAD_PLAYER = gql`
   mutation AddFFLSquadPlayer($input: AddFFLSquadPlayerInput!) {
     addFFLSquadPlayer(input: $input) {
       id
-      playerId
       clubSeasonId
     }
   }

--- a/frontend/web/src/features/ffl/composables/useFflState.ts
+++ b/frontend/web/src/features/ffl/composables/useFflState.ts
@@ -13,8 +13,8 @@ function setCookie(name: string, value: string) {
 
 // Module-level singletons — shared across all component instances
 const selectedClubId = ref<string>(getCookie('xffl_club_id'))
-const currentSeasonId = ref<string>('')
-const currentRoundId = ref<string>('')
+const currentSeasonId = ref<string>(getCookie('xffl_season_id'))
+const currentRoundId = ref<string>(getCookie('xffl_round_id'))
 
 function setClub(id: string) {
   selectedClubId.value = id
@@ -23,7 +23,9 @@ function setClub(id: string) {
 
 function setCurrentSeason(seasonId: string, roundId: string) {
   currentSeasonId.value = seasonId
+  setCookie('xffl_season_id', seasonId)
   currentRoundId.value = roundId
+  setCookie('xffl_round_id', roundId)
 }
 
 export function useFflState() {

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -19,7 +19,16 @@
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div v-for="side in sides" :key="side.label">
-          <h2 class="text-lg font-semibold mb-1">{{ side.label }}</h2>
+          <div class="flex items-center justify-between mb-1">
+            <h2 class="text-lg font-semibold">{{ side.label }}</h2>
+            <router-link
+              v-if="isMyClubMatch && side.clubMatch?.club.id === selectedClubId"
+              :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: matchData!.roundId } }"
+              class="text-xs text-active hover:text-active-hover transition-colors"
+            >
+              Build Team →
+            </router-link>
+          </div>
           <p class="text-sm text-text-muted mb-3">
             Fantasy score: <span class="font-semibold text-text">{{ side.clubMatch?.score ?? 0 }}</span>
           </p>
@@ -36,19 +45,29 @@ import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON } from '../api/queries'
 import SquadTable from '../components/SquadTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
+import { useFflState } from '../composables/useFflState'
 
 const props = defineProps<{ seasonId: string; matchId: string }>()
 
+const { selectedClubId } = useFflState()
 const { result, loading, error } = useQuery(GET_FFL_SEASON, () => ({ id: props.seasonId }))
 
-const match = computed(() => {
+const matchData = computed(() => {
   const season = result.value?.fflSeason
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return found
+    if (found) return { match: found, roundId: round.id as string }
   }
   return null
+})
+
+const match = computed(() => matchData.value?.match ?? null)
+
+const isMyClubMatch = computed(() => {
+  if (!match.value || !selectedClubId.value) return false
+  return match.value.homeClubMatch?.club.id === selectedClubId.value ||
+    match.value.awayClubMatch?.club.id === selectedClubId.value
 })
 
 const sides = computed(() => {

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -17,12 +17,19 @@
       <section class="mb-8">
         <h2 class="text-lg font-semibold text-text-heading mb-3">Matches</h2>
         <div class="space-y-2">
-          <MatchSummary
-            v-for="match in data.round.matches"
-            :key="match.id"
-            :match="match"
-            :to="{ name: 'ffl-match', params: { seasonId: props.seasonId, matchId: match.id } }"
-          />
+          <div v-for="match in data.round.matches" :key="match.id">
+            <MatchSummary
+              :match="match"
+              :to="{ name: 'ffl-match', params: { seasonId: props.seasonId, matchId: match.id } }"
+            />
+            <router-link
+              v-if="myMatch?.id === match.id"
+              :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: props.roundId } }"
+              class="mt-1 flex items-center justify-end text-xs text-active hover:text-active-hover transition-colors"
+            >
+              Build Team →
+            </router-link>
+          </div>
         </div>
       </section>
 
@@ -70,7 +77,7 @@ import RoundNav from '../components/RoundNav.vue'
 
 const props = defineProps<{ seasonId: string; roundId: string }>()
 
-const { currentRoundId: liveRoundId } = useFflState()
+const { currentRoundId: liveRoundId, selectedClubId } = useFflState()
 const { result, loading, error } = useQuery(GET_FFL_SEASON, () => ({ id: props.seasonId }))
 
 const data = computed(() => {
@@ -79,6 +86,14 @@ const data = computed(() => {
   const round = season.rounds.find((r: { id: string }) => r.id === props.roundId)
   if (!round) return null
   return { season, round }
+})
+
+const myMatch = computed(() => {
+  if (!data.value || !selectedClubId.value) return null
+  return data.value.round.matches.find((m: { homeClubMatch?: { club: { id: string } } | null; awayClubMatch?: { club: { id: string } } | null }) =>
+    m.homeClubMatch?.club.id === selectedClubId.value ||
+    m.awayClubMatch?.club.id === selectedClubId.value
+  ) ?? null
 })
 
 interface PlayerMatch {

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -19,7 +19,7 @@
       <span v-if="saveMessage" class="text-sm text-green-500">{{ saveMessage }}</span>
     </div>
 
-    <div v-if="squadLoading" class="text-text-faint">Loading…</div>
+    <div v-if="squadLoading" class="text-text-faint">Loading...</div>
     <div v-else-if="squadError" class="text-red-400">{{ squadError.message }}</div>
     <template v-else>
       <div class="flex gap-8 items-start">
@@ -65,10 +65,10 @@
           <input
             v-model="searchQuery"
             type="text"
-            placeholder="Search AFL players by name…"
+            placeholder="Search AFL players by name..."
             class="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-text-faint focus:border-active focus:outline-none"
           />
-          <div v-if="searchLoading" class="mt-2 text-text-faint text-sm">Searching…</div>
+          <div v-if="searchLoading" class="mt-2 text-text-faint text-sm">Searching...</div>
           <div v-else-if="searchResults.length > 0" class="mt-2">
             <div
               v-for="player in searchResults"
@@ -81,7 +81,7 @@
                 class="rounded border border-active px-2 py-0.5 text-xs font-medium text-active hover:bg-active hover:text-active-text transition-colors"
                 :disabled="addingId === player.id"
               >
-                {{ addingId === player.id ? 'Adding…' : 'Add' }}
+                {{ addingId === player.id ? 'Adding...' : 'Add' }}
               </button>
             </div>
           </div>

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -16,6 +16,7 @@
       >
         {{ managing ? 'Done' : 'Manage' }}
       </button>
+      <span v-if="saveMessage" class="text-sm text-green-500">{{ saveMessage }}</span>
     </div>
 
     <div v-if="squadLoading" class="text-text-faint">Loading…</div>
@@ -42,10 +43,13 @@
                   <td v-if="managing" class="py-2 px-2 text-right">
                     <button
                       @click="removePlayer(row.id)"
-                      class="text-red-400 hover:text-red-300 text-xs font-medium"
+                      aria-label="Remove"
+                      class="text-red-400 hover:text-red-300 transition-colors disabled:opacity-40"
                       :disabled="removingId === row.id"
                     >
-                      {{ removingId === row.id ? 'Removing…' : 'Remove' }}
+                      <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                        <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
+                      </svg>
                     </button>
                   </td>
                 </tr>
@@ -157,6 +161,15 @@ const searchResults = computed(() => {
   return results.filter((p: { id: string }) => !squadAflPlayerIds.value.has(p.id))
 })
 
+// Saved flash
+const saveMessage = ref('')
+let saveMessageTimer: ReturnType<typeof setTimeout> | null = null
+function flashSaved() {
+  if (saveMessageTimer) clearTimeout(saveMessageTimer)
+  saveMessage.value = 'Saved'
+  saveMessageTimer = setTimeout(() => { saveMessage.value = '' }, 3000)
+}
+
 // Remove player
 const removingId = ref<string | null>(null)
 const { mutate: removePlayerMutation } = useMutation(REMOVE_FFL_PLAYER_FROM_SEASON)
@@ -166,6 +179,7 @@ async function removePlayer(playerSeasonId: string) {
   try {
     await removePlayerMutation({ id: playerSeasonId })
     await refetchSquad()
+    flashSaved()
   } finally {
     removingId.value = null
   }
@@ -187,6 +201,7 @@ async function addPlayer(player: { id: string; name: string }) {
       },
     })
     await refetchSquad()
+    flashSaved()
   } finally {
     addingId.value = null
   }

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -198,4 +198,8 @@ watch(managing, (val) => {
     debouncedQuery.value = ''
   }
 })
+
+watch(selectedClubId, () => {
+  managing.value = false
+})
 </script>

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -4,22 +4,60 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="season">
       <div class="mb-6">
-        <h1 class="text-2xl font-bold mb-1">
+        <!-- Breadcrumb + round nav -->
+        <div v-if="currentRound" class="flex items-center gap-3 mb-2">
+          <router-link
+            :to="{ name: 'ffl-round', params: { seasonId: props.seasonId, roundId: props.roundId } }"
+            class="text-sm text-text-muted hover:text-text transition-colors"
+          >
+            ← Back to round
+          </router-link>
+          <div class="flex items-center gap-1 ml-auto">
+            <router-link
+              v-if="prevRound"
+              :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: prevRound.id } }"
+              class="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:bg-control-hover hover:text-text transition-colors text-sm"
+              title="Previous round"
+            >‹</router-link>
+            <span v-else class="w-6 h-6 flex items-center justify-center text-text-faint text-sm opacity-30">‹</span>
+            <router-link
+              v-if="nextRound"
+              :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: nextRound.id } }"
+              class="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:bg-control-hover hover:text-text transition-colors text-sm"
+              title="Next round"
+            >›</router-link>
+            <span v-else class="w-6 h-6 flex items-center justify-center text-text-faint text-sm opacity-30">›</span>
+          </div>
+        </div>
+        <h1 class="text-2xl font-bold">
           {{ selectedClubSeason?.club.name ?? '' }}<span v-if="currentRound" class="font-normal text-text-muted"> · {{ currentRound.name }}</span>
         </h1>
       </div>
 
       <template v-if="selectedClubSeason && clubMatch">
         <div class="mb-6 flex items-center gap-4">
+          <template v-if="managing">
+            <button
+              @click="cancelManage"
+              class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
+              :disabled="submitting"
+            >
+              Cancel
+            </button>
+            <button
+              @click="onSaveTeam"
+              class="rounded-lg border border-active bg-active px-3 py-1.5 text-sm font-medium text-active-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              :disabled="submitting || !isDirty"
+            >
+              {{ submitting ? 'Saving…' : 'Save Team' }}
+            </button>
+          </template>
           <button
-            @click="onManageToggle"
-            class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
-            :class="managing
-              ? 'border-active bg-active text-active-text'
-              : 'border-border bg-surface text-text hover:bg-surface-hover'"
-            :disabled="submitting"
+            v-else
+            @click="managing = true"
+            class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
           >
-            {{ submitting ? 'Saving…' : managing ? 'Done' : 'Manage' }}
+            Manage
           </button>
           <span v-if="submitMessage" class="text-sm text-green-500">{{ submitMessage }}</span>
         </div>
@@ -32,7 +70,7 @@
           </div>
         </div>
 
-        <div class="grid gap-8" :class="managing ? 'grid-cols-1 lg:grid-cols-2' : 'grid-cols-1'">
+        <div class="grid gap-8" :class="managing ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'">
           <!-- Team (left col) -->
           <div>
 
@@ -51,6 +89,7 @@
                     : 'border-dashed border-border-subtle bg-surface'"
                 >
                   <div v-if="slot.player" class="flex items-center gap-3">
+                    <span v-if="pos.key === 'star'" class="text-yellow-400 text-xs">★</span>
                     <span class="font-medium">{{ slot.player.name }}</span>
                   </div>
                   <span v-else class="text-text-faint text-sm">Empty slot</span>
@@ -58,19 +97,25 @@
                     <button
                       v-for="target in positions.filter(p => p.key !== pos.key)"
                       :key="target.key"
-                      class="rounded px-1.5 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                      class="rounded px-1.5 py-0.5 text-xs transition-colors"
                       :disabled="isPositionFull(target.key)"
-                      :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(target.key) }"
+                      :class="[
+                        isPositionFull(target.key) ? 'opacity-30 cursor-not-allowed' : '',
+                        target.key === 'star' ? 'text-yellow-400 hover:bg-control-hover hover:text-yellow-300' : 'text-text-faint hover:bg-control-hover hover:text-text'
+                      ]"
                       :title="`Move to ${target.label}`"
                       @click="moveToPosition(pos.key, index, target.key)"
                     >
                       {{ target.short }}
                     </button>
                     <button
+                      aria-label="Remove"
                       class="text-xs text-red-400 hover:text-red-300 transition-colors"
                       @click="removeFromTeam(pos.key, index)"
                     >
-                      Remove
+                      <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                        <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
+                      </svg>
                     </button>
                   </div>
                 </div>
@@ -90,7 +135,6 @@
                     : 'border-dashed border-border-subtle bg-surface'"
                 >
                   <div class="flex items-center gap-3 min-w-0">
-                    <span class="text-xs text-text-faint shrink-0">★</span>
                     <span v-if="benchStarSlot.player" class="font-medium text-text-muted">{{ benchStarSlot.player.name }}</span>
                     <span v-else class="text-text-faint text-sm">Backup Star</span>
                   </div>
@@ -107,10 +151,13 @@
                     </label>
                     <button
                       v-if="benchStarSlot.player"
+                      aria-label="Remove"
                       class="text-xs text-red-400 hover:text-red-300 transition-colors"
                       @click="benchStarSlot.player = null"
                     >
-                      Remove
+                      <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                        <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
+                      </svg>
                     </button>
                   </div>
                 </div>
@@ -182,10 +229,13 @@
                     </label>
                     <button
                       v-if="slot.player"
+                      aria-label="Remove"
                       class="text-xs text-red-400 hover:text-red-300 transition-colors"
                       @click="removeBenchDual(index)"
                     >
-                      Remove
+                      <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                        <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
+                      </svg>
                     </button>
                   </div>
                 </div>
@@ -209,22 +259,26 @@
                   <button
                     v-for="pos in positions"
                     :key="pos.key"
-                    class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
+                    class="rounded px-2 py-0.5 text-xs transition-colors"
+                    :class="[
+                      isPositionFull(pos.key) ? 'opacity-30 cursor-not-allowed' : '',
+                      pos.key === 'star' ? 'text-yellow-400 hover:bg-control-hover hover:text-yellow-300' : 'text-text-muted hover:bg-control-hover hover:text-text'
+                    ]"
                     :disabled="isPositionFull(pos.key)"
-                    :class="{ 'opacity-30 cursor-not-allowed': isPositionFull(pos.key) }"
                     @click="addToTeam(pos.key, player)"
                   >
                     {{ pos.short }}
                   </button>
+                  <span class="w-px h-4 bg-border mx-0.5 shrink-0"></span>
                   <!-- Backup star -->
                   <button
-                    class="rounded px-2 py-0.5 text-xs text-yellow-400 hover:bg-control-hover hover:text-yellow-300 transition-colors"
+                    class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
                     :disabled="!!benchStarSlot.player"
                     :class="{ 'opacity-30 cursor-not-allowed': !!benchStarSlot.player }"
                     title="Add as Backup Star"
                     @click="addBenchStar(player)"
                   >
-                    ★
+                    S
                   </button>
                   <!-- Dual-position bench -->
                   <button
@@ -260,11 +314,11 @@ const props = defineProps<{ seasonId: string; roundId: string }>()
 const positions = [
   { key: 'goals',     label: 'Goals',     short: 'G',  count: 3 },
   { key: 'kicks',     label: 'Kicks',     short: 'K',  count: 4 },
-  { key: 'handballs', label: 'Handballs', short: 'HB', count: 4 },
+  { key: 'handballs', label: 'Handballs', short: 'H',  count: 4 },
   { key: 'marks',     label: 'Marks',     short: 'M',  count: 2 },
   { key: 'tackles',   label: 'Tackles',   short: 'T',  count: 2 },
-  { key: 'hitouts',   label: 'Hitouts',   short: 'HO', count: 2 },
-  { key: 'star',      label: 'Star',      short: 'S',  count: 1 },
+  { key: 'hitouts',   label: 'Hitouts',   short: 'R',  count: 2 },
+  { key: 'star',      label: 'Star',      short: '★',  count: 1 },
 ] as const
 
 type PositionKey = typeof positions[number]['key']
@@ -310,6 +364,18 @@ const currentRound = computed(() =>
   season.value?.rounds.find((r: { id: string }) => r.id === props.roundId) ?? null
 )
 
+const prevRound = computed(() => {
+  const rounds = season.value?.rounds ?? []
+  const idx = rounds.findIndex((r: { id: string }) => r.id === props.roundId)
+  return idx > 0 ? rounds[idx - 1] : null
+})
+
+const nextRound = computed(() => {
+  const rounds = season.value?.rounds ?? []
+  const idx = rounds.findIndex((r: { id: string }) => r.id === props.roundId)
+  return idx >= 0 && idx < rounds.length - 1 ? rounds[idx + 1] : null
+})
+
 const clubMatch = computed(() => {
   if (!season.value || !selectedClubSeason.value) return null
   const round = season.value.rounds.find((r: { id: string }) => r.id === props.roundId)
@@ -353,6 +419,17 @@ const interchangePosition = ref<string | null>(null)
 // Track the match ID we last loaded from to avoid Apollo cache updates wiping local edits.
 const initializedMatchId = ref<string | null>(null)
 
+// Dirty tracking — snapshot taken after load or save; compared to detect unsaved changes.
+const isDirty = ref(false)
+
+function takeSnapshot() {
+  isDirty.value = false
+}
+
+function markDirty() {
+  isDirty.value = true
+}
+
 function resetTeamState() {
   for (const pos of positions) {
     teamSlots.value[pos.key] = createSlots(pos.count)
@@ -366,15 +443,9 @@ function resetTeamState() {
   interchangePosition.value = null
 }
 
-// Load existing team from server data — only when the match changes, not on every Apollo cache update.
-// { immediate: true } ensures this fires on component remount when Apollo cache already has data
-// (without it, watch only fires on changes — a cache hit on remount produces no change event).
-watch(clubMatch, (cm) => {
-  if (!cm) return
-  if (cm.id === initializedMatchId.value) return  // already initialised for this match; don't reset local edits
-  initializedMatchId.value = cm.id
-
+function loadTeamFromMatch(cm: NonNullable<typeof clubMatch.value>) {
   resetTeamState()
+  takeSnapshot()
   if (!cm.playerMatches) return
 
   let dualIndex = 0
@@ -383,18 +454,15 @@ watch(clubMatch, (cm) => {
     const isBench = pm.backupPositions != null || pm.interchangePosition != null
 
     if (!isBench) {
-      // Starter
       const posSlots = teamSlots.value[pm.position as PositionKey]
       if (posSlots) {
         const slot = posSlots.find((s: Slot) => !s.player)
         if (slot) slot.player = player
       }
     } else if (pm.backupPositions === 'star') {
-      // Backup star
       benchStarSlot.value.player = player
       if (pm.interchangePosition) interchangePosition.value = pm.interchangePosition
     } else if (pm.backupPositions && dualIndex < 3) {
-      // Dual-position bench
       const parts = pm.backupPositions.split(',').map((p: string) => p.trim()) as NonStarPositionKey[]
       benchDualSlots.value[dualIndex].player = player
       benchDualSlots.value[dualIndex].positions = [parts[0] ?? null, parts[1] ?? null]
@@ -402,6 +470,16 @@ watch(clubMatch, (cm) => {
       dualIndex++
     }
   }
+}
+
+// Load existing team from server data — only when the match changes, not on every Apollo cache update.
+// { immediate: true } ensures this fires on component remount when Apollo cache already has data
+// (without it, watch only fires on changes — a cache hit on remount produces no change event).
+watch(clubMatch, (cm) => {
+  if (!cm) return
+  if (cm.id === initializedMatchId.value) return  // already initialised for this match; don't reset local edits
+  initializedMatchId.value = cm.id
+  loadTeamFromMatch(cm)
 }, { immediate: true })
 
 // ── Computed helpers ──────────────────────────────────────────────────────────
@@ -465,11 +543,12 @@ function benchDualInterchangeKey(index: number): string | null {
 
 function addToTeam(key: PositionKey, player: SquadPlayer) {
   const slot = teamSlots.value[key].find(s => !s.player)
-  if (slot) slot.player = player
+  if (slot) { slot.player = player; markDirty() }
 }
 
 function removeFromTeam(key: PositionKey, index: number) {
   teamSlots.value[key][index].player = null
+  markDirty()
 }
 
 function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: PositionKey) {
@@ -479,33 +558,37 @@ function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: Position
   if (!toSlot) return
   teamSlots.value[fromKey][fromIndex].player = null
   toSlot.player = player
+  markDirty()
 }
 
 function addBenchStar(player: SquadPlayer) {
   if (benchStarSlot.value.player) return
   benchStarSlot.value.player = player
+  markDirty()
 }
 
 function addBenchDual(player: SquadPlayer) {
   const slot = benchDualSlots.value.find(s => !s.player)
-  if (slot) slot.player = player
+  if (slot) { slot.player = player; markDirty() }
 }
 
 function removeBenchDual(index: number) {
   benchDualSlots.value[index].player = null
   benchDualSlots.value[index].positions = [null, null]
-  // Clear interchange if it pointed to this slot
   const key = benchDualInterchangeKey(index)
   if (key && interchangePosition.value === key) interchangePosition.value = null
+  markDirty()
 }
 
 function setBenchPosition(slotIndex: number, sideIndex: 0 | 1, value: string) {
   benchDualSlots.value[slotIndex].positions[sideIndex] = (value || null) as NonStarPositionKey | null
+  markDirty()
 }
 
 function toggleInterchange(key: string | null) {
   if (!key) return
   interchangePosition.value = interchangePosition.value === key ? null : key
+  markDirty()
 }
 
 // ── Submit ────────────────────────────────────────────────────────────────────
@@ -517,11 +600,14 @@ const { mutate: setTeam } = useMutation(SET_FFL_TEAM, () => ({
 const submitting = ref(false)
 const submitMessage = ref('')
 
-async function onManageToggle() {
-  if (managing.value) {
-    await submitTeam()
-  }
-  managing.value = !managing.value
+async function onSaveTeam() {
+  await submitTeam()
+  managing.value = false
+}
+
+function cancelManage() {
+  if (clubMatch.value) loadTeamFromMatch(clubMatch.value)
+  managing.value = false
 }
 
 async function submitTeam() {
@@ -576,7 +662,8 @@ async function submitTeam() {
 
   try {
     await setTeam({ input: { clubMatchId: clubMatch.value.id, players } })
-    submitMessage.value = 'Team saved!'
+    takeSnapshot()
+    submitMessage.value = 'Saved'
     setTimeout(() => { submitMessage.value = '' }, 3000)
   } catch (e) {
     submitMessage.value = 'Failed to save team'

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -4,8 +4,9 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="season">
       <div class="mb-6">
-        <h1 class="text-2xl font-bold mb-1">{{ selectedClubSeason?.club.name ?? '' }}</h1>
-        <p class="text-text-muted">Build your team for the round</p>
+        <h1 class="text-2xl font-bold mb-1">
+          {{ selectedClubSeason?.club.name ?? '' }}<span v-if="currentRound" class="font-normal text-text-muted"> · {{ currentRound.name }}</span>
+        </h1>
       </div>
 
       <template v-if="selectedClubSeason && clubMatch">
@@ -31,9 +32,9 @@
           </div>
         </div>
 
-        <div class="grid gap-8" :class="managing ? 'grid-cols-1 lg:grid-cols-3' : 'grid-cols-1'">
-          <!-- Team (left 2 cols) -->
-          <div class="lg:col-span-2">
+        <div class="grid gap-8" :class="managing ? 'grid-cols-1 lg:grid-cols-2' : 'grid-cols-1'">
+          <!-- Team (left col) -->
+          <div>
 
             <!-- Starter position groups -->
             <div v-for="pos in positions" :key="pos.key" class="mb-6">
@@ -303,6 +304,10 @@ const season = computed(() => result.value?.fflSeason ?? null)
 
 const selectedClubSeason = computed(() =>
   season.value?.ladder.find((cs: { club: { id: string } }) => cs.club.id === selectedClubId.value) ?? null
+)
+
+const currentRound = computed(() =>
+  season.value?.rounds.find((r: { id: string }) => r.id === props.roundId) ?? null
 )
 
 const clubMatch = computed(() => {

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="loading" class="text-text-faint">Loading…</div>
+    <div v-if="loading" class="text-text-faint">Loading...</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="season">
       <div class="mb-6">
@@ -49,7 +49,7 @@
               class="rounded-lg border border-active bg-active px-3 py-1.5 text-sm font-medium text-active-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
               :disabled="submitting || !isDirty"
             >
-              {{ submitting ? 'Saving…' : 'Save Team' }}
+              {{ submitting ? 'Saving...' : 'Save Team' }}
             </button>
           </template>
           <button

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -47,7 +47,7 @@
             <button
               @click="onSaveTeam"
               class="rounded-lg border border-active bg-active px-3 py-1.5 text-sm font-medium text-active-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              :disabled="submitting || !isDirty"
+              :disabled="submitting || !isDirty || !!benchValidationError"
             >
               {{ submitting ? 'Saving...' : 'Save Team' }}
             </button>
@@ -59,7 +59,8 @@
           >
             Manage
           </button>
-          <span v-if="submitMessage" class="text-sm text-green-500">{{ submitMessage }}</span>
+          <span v-if="benchValidationError" class="text-sm text-red-400">{{ benchValidationError }}</span>
+          <span v-else-if="submitMessage" class="text-sm text-green-500">{{ submitMessage }}</span>
         </div>
 
         <!-- Summary bar -->
@@ -126,119 +127,83 @@
             <div class="mb-6">
               <h3 class="text-sm font-semibold uppercase tracking-wider text-text-faint mb-2">Bench</h3>
 
-              <!-- Backup Star -->
-              <div class="mb-1">
+              <div v-for="(slot, index) in benchDualSlots" :key="index" class="mb-1">
                 <div
                   class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
-                  :class="benchStarSlot.player
-                    ? 'border-border bg-surface-raised'
-                    : 'border-dashed border-border-subtle bg-surface'"
+                  :class="[
+                    slot.player ? 'border-border bg-surface-raised' : 'border-dashed border-border-subtle bg-surface',
+                    recentlyClearedSlot === index ? '!border-orange-400' : ''
+                  ]"
                 >
+                  <!-- Left: name -->
                   <div class="flex items-center gap-3 min-w-0">
-                    <span v-if="benchStarSlot.player" class="font-medium text-text-muted">{{ benchStarSlot.player.name }}</span>
-                    <span v-else class="text-text-faint text-sm">Backup Star</span>
-                  </div>
-                  <div v-if="managing" class="flex items-center gap-2 ml-2 shrink-0">
-                    <label class="flex items-center gap-1 text-xs text-text-faint cursor-pointer">
-                      <input
-                        type="checkbox"
-                        class="accent-active"
-                        :checked="interchangePosition === 'star'"
-                        :disabled="!benchStarSlot.player"
-                        @change="toggleInterchange('star')"
-                      />
-                      IC
-                    </label>
-                    <button
-                      v-if="benchStarSlot.player"
-                      aria-label="Remove"
-                      class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                      @click="benchStarSlot.player = null"
-                    >
-                      <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
-                        <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Dual-position bench slots -->
-              <div
-                v-for="(slot, index) in benchDualSlots"
-                :key="index"
-                class="mb-1"
-              >
-                <div
-                  class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
-                  :class="slot.player
-                    ? 'border-border bg-surface-raised'
-                    : 'border-dashed border-border-subtle bg-surface'"
-                >
-                  <div class="flex items-center gap-3 min-w-0 flex-1">
-                    <span class="text-xs text-text-faint shrink-0">B{{ index + 1 }}</span>
                     <span v-if="slot.player" class="font-medium text-text-muted">{{ slot.player.name }}</span>
-                    <span v-else class="text-text-faint text-sm">Empty bench slot</span>
-                    <!-- Dual-position selectors (manage mode only) -->
-                    <div v-if="slot.player && managing" class="flex items-center gap-1 ml-2">
+                    <span v-else class="text-text-faint text-sm">Empty slot</span>
+                  </div>
+                  <!-- Right: selectors + remove (manage) or read-only tags -->
+                  <div class="flex items-center gap-2 ml-4 shrink-0">
+                    <template v-if="slot.player && managing">
                       <select
                         class="text-xs rounded bg-control text-text px-1 py-0.5 border border-border"
                         :value="slot.positions[0] ?? ''"
                         @change="setBenchPosition(index, 0, ($event.target as HTMLSelectElement).value)"
-                        aria-label="Backup position 1"
+                        aria-label="Position 1"
                       >
-                        <option value="">— pos 1 —</option>
-                        <option
-                          v-for="pos in nonStarPositions"
-                          :key="pos.key"
-                          :value="pos.key"
-                          :disabled="isBenchPositionUsed(pos.key, index, 0)"
-                        >{{ pos.label }}</option>
+                        <option value=""></option>
+                        <option v-for="pos in positions" :key="pos.key" :value="pos.key">
+                          {{ pos.short }}{{ isBenchPositionUsed(pos.key, index, 0) ? ' ·' : '' }}
+                        </option>
                       </select>
                       <select
+                        v-if="slot.positions[0] !== 'star'"
                         class="text-xs rounded bg-control text-text px-1 py-0.5 border border-border"
                         :value="slot.positions[1] ?? ''"
                         @change="setBenchPosition(index, 1, ($event.target as HTMLSelectElement).value)"
-                        aria-label="Backup position 2"
+                        aria-label="Position 2"
                       >
-                        <option value="">— pos 2 —</option>
-                        <option
-                          v-for="pos in nonStarPositions"
-                          :key="pos.key"
-                          :value="pos.key"
-                          :disabled="isBenchPositionUsed(pos.key, index, 1)"
-                        >{{ pos.label }}</option>
+                        <option value=""></option>
+                        <option v-for="pos in nonStarPositions" :key="pos.key" :value="pos.key">
+                          {{ pos.short }}{{ isBenchPositionUsed(pos.key, index, 1) ? ' ·' : '' }}
+                        </option>
                       </select>
-                    </div>
-                    <!-- Read-only position display -->
-                    <div v-else-if="slot.player && (slot.positions[0] || slot.positions[1])" class="flex items-center gap-1 ml-2">
-                      <span v-if="slot.positions[0]" class="text-xs bg-control rounded px-1.5 py-0.5 text-text-muted">{{ slot.positions[0] }}</span>
-                      <span v-if="slot.positions[1]" class="text-xs bg-control rounded px-1.5 py-0.5 text-text-muted">{{ slot.positions[1] }}</span>
-                    </div>
-                  </div>
-                  <div v-if="managing" class="flex items-center gap-2 ml-2 shrink-0">
-                    <label v-if="slot.player" class="flex items-center gap-1 text-xs text-text-faint cursor-pointer">
-                      <input
-                        type="checkbox"
-                        class="accent-active"
-                        :checked="interchangePosition === benchDualInterchangeKey(index)"
-                        :disabled="!slot.positions[0] && !slot.positions[1]"
-                        @change="toggleInterchange(benchDualInterchangeKey(index))"
-                      />
-                      IC
-                    </label>
-                    <button
-                      v-if="slot.player"
-                      aria-label="Remove"
-                      class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                      @click="removeBenchDual(index)"
-                    >
-                      <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
-                        <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
-                      </svg>
-                    </button>
+                      <button
+                        aria-label="Remove"
+                        class="text-xs text-red-400 hover:text-red-300 transition-colors"
+                        @click="removeBenchDual(index)"
+                      >
+                        <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                          <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
+                        </svg>
+                      </button>
+                    </template>
+                    <template v-else-if="slot.player">
+                      <template v-if="slot.positions[0]">
+                        <span class="text-xs bg-control rounded px-1.5 py-0.5 text-text-muted">
+                          {{ positionShort(slot.positions[0]) }}<template v-if="interchangePosition === slot.positions[0]"> · Int</template>
+                        </span>
+                      </template>
+                      <template v-if="slot.positions[1]">
+                        <span class="text-xs bg-control rounded px-1.5 py-0.5 text-text-muted">
+                          {{ positionShort(slot.positions[1]) }}<template v-if="interchangePosition === slot.positions[1]"> · Int</template>
+                        </span>
+                      </template>
+                    </template>
                   </div>
                 </div>
+              </div>
+
+              <!-- Interchange -->
+              <div v-if="managing" class="mt-3 flex items-center gap-2 justify-end">
+                <span class="text-xs text-text-faint">Interchange</span>
+                <select
+                  class="text-xs rounded bg-control text-text px-1 py-0.5 border border-border"
+                  aria-label="Interchange"
+                  :value="interchangePosition ?? ''"
+                  @change="setInterchange(($event.target as HTMLSelectElement).value)"
+                >
+                  <option value=""></option>
+                  <option v-for="pos in positions" :key="pos.key" :value="pos.key">{{ pos.short }}</option>
+                </select>
               </div>
             </div>
 
@@ -270,17 +235,7 @@
                     {{ pos.short }}
                   </button>
                   <span class="w-px h-4 bg-border mx-0.5 shrink-0"></span>
-                  <!-- Backup star -->
-                  <button
-                    class="rounded px-2 py-0.5 text-xs text-text-muted hover:bg-control-hover hover:text-text transition-colors"
-                    :disabled="!!benchStarSlot.player"
-                    :class="{ 'opacity-30 cursor-not-allowed': !!benchStarSlot.player }"
-                    title="Add as Backup Star"
-                    @click="addBenchStar(player)"
-                  >
-                    S
-                  </button>
-                  <!-- Dual-position bench -->
+                  <!-- Bench -->
                   <button
                     class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
                     :disabled="benchDualFull"
@@ -335,13 +290,9 @@ interface Slot {
   player: SquadPlayer | null
 }
 
-interface BenchStarSlot {
-  player: SquadPlayer | null
-}
-
 interface BenchDualSlot {
   player: SquadPlayer | null
-  positions: [NonStarPositionKey | null, NonStarPositionKey | null]
+  positions: [PositionKey | null, NonStarPositionKey | null]
 }
 
 const { selectedClubId } = useFflState()
@@ -404,17 +355,19 @@ const teamSlots = ref<Record<PositionKey, Slot[]>>(
   Object.fromEntries(positions.map(p => [p.key, createSlots(p.count)])) as Record<PositionKey, Slot[]>
 )
 
-const benchStarSlot = ref<BenchStarSlot>({ player: null })
-
 const benchDualSlots = ref<BenchDualSlot[]>([
+  { player: null, positions: [null, null] },
   { player: null, positions: [null, null] },
   { player: null, positions: [null, null] },
   { player: null, positions: [null, null] },
 ])
 
-// Interchange: the position key for which the bench player may freely swap.
-// For the star slot this is 'star'; for dual slots it's derived from the first chosen position.
+// The position that acts as the free interchange slot.
 const interchangePosition = ref<string | null>(null)
+
+// Highlight recently-stolen bench slot index (orange border flash).
+const recentlyClearedSlot = ref<number | null>(null)
+let clearHighlightTimer: ReturnType<typeof setTimeout> | null = null
 
 // Track the match ID we last loaded from to avoid Apollo cache updates wiping local edits.
 const initializedMatchId = ref<string | null>(null)
@@ -434,8 +387,8 @@ function resetTeamState() {
   for (const pos of positions) {
     teamSlots.value[pos.key] = createSlots(pos.count)
   }
-  benchStarSlot.value = { player: null }
   benchDualSlots.value = [
+    { player: null, positions: [null, null] },
     { player: null, positions: [null, null] },
     { player: null, positions: [null, null] },
     { player: null, positions: [null, null] },
@@ -459,13 +412,15 @@ function loadTeamFromMatch(cm: NonNullable<typeof clubMatch.value>) {
         const slot = posSlots.find((s: Slot) => !s.player)
         if (slot) slot.player = player
       }
-    } else if (pm.backupPositions === 'star') {
-      benchStarSlot.value.player = player
-      if (pm.interchangePosition) interchangePosition.value = pm.interchangePosition
-    } else if (pm.backupPositions && dualIndex < 3) {
-      const parts = pm.backupPositions.split(',').map((p: string) => p.trim()) as NonStarPositionKey[]
-      benchDualSlots.value[dualIndex].player = player
-      benchDualSlots.value[dualIndex].positions = [parts[0] ?? null, parts[1] ?? null]
+    } else if (dualIndex < 4) {
+      if (pm.backupPositions === 'star') {
+        benchDualSlots.value[dualIndex].player = player
+        benchDualSlots.value[dualIndex].positions = ['star', null]
+      } else if (pm.backupPositions) {
+        const parts = pm.backupPositions.split(',').map((p: string) => p.trim()) as NonStarPositionKey[]
+        benchDualSlots.value[dualIndex].player = player
+        benchDualSlots.value[dualIndex].positions = [parts[0] ?? null, parts[1] ?? null]
+      }
       if (pm.interchangePosition) interchangePosition.value = pm.interchangePosition
       dualIndex++
     }
@@ -491,7 +446,6 @@ const assignedPlayerIds = computed(() => {
       if (slot.player) ids.add(slot.player.id)
     }
   }
-  if (benchStarSlot.value.player) ids.add(benchStarSlot.value.player.id)
   for (const slot of benchDualSlots.value) {
     if (slot.player) ids.add(slot.player.id)
   }
@@ -510,33 +464,39 @@ const starterCount = computed(() => {
   return count
 })
 
-const benchCount = computed(() => {
-  let count = benchStarSlot.value.player ? 1 : 0
-  count += benchDualSlots.value.filter(s => s.player).length
-  return count
-})
+const benchCount = computed(() => benchDualSlots.value.filter(s => s.player).length)
 
 const benchDualFull = computed(() => benchDualSlots.value.every(s => s.player !== null))
+
+const benchValidationError = computed<string | null>(() => {
+  for (const slot of benchDualSlots.value) {
+    if (!slot.player) continue
+    const [p1, p2] = slot.positions
+    if (!p1) return 'Each bench player must have a position assigned'
+    if (p1 !== 'star' && !p2) return 'Non-star bench players need two backup positions'
+  }
+  const filledCount = benchDualSlots.value.filter(s => s.player).length
+  if (filledCount > 1 && !interchangePosition.value) return 'Choose an interchange position'
+  return null
+})
 
 const isPositionFull = (key: PositionKey) =>
   teamSlots.value[key].every(s => s.player !== null)
 
-// Returns all non-star positions already claimed by another bench dual slot (optionally excluding a specific slot+side).
+// Returns true if posKey is already used by another bench slot (excluding slotIndex+sideIndex).
 function isBenchPositionUsed(posKey: string, slotIndex: number, sideIndex: number): boolean {
   for (let i = 0; i < benchDualSlots.value.length; i++) {
     const slot = benchDualSlots.value[i]
-    for (let j = 0; j < 2; j++) {
+    for (const j of [0, 1] as const) {
       if (i === slotIndex && j === sideIndex) continue
-      if (slot.positions[j as 0 | 1] === posKey) return true
+      if (slot.positions[j] === posKey) return true
     }
   }
   return false
 }
 
-// Derive an interchange key for a dual bench slot from its assigned positions.
-function benchDualInterchangeKey(index: number): string | null {
-  const slot = benchDualSlots.value[index]
-  return slot.positions[0] ?? slot.positions[1] ?? null
+function positionShort(key: string): string {
+  return positions.find(p => p.key === key)?.short ?? key
 }
 
 // ── Team management ─────────────────────────────────────────────────────────
@@ -561,12 +521,6 @@ function moveToPosition(fromKey: PositionKey, fromIndex: number, toKey: Position
   markDirty()
 }
 
-function addBenchStar(player: SquadPlayer) {
-  if (benchStarSlot.value.player) return
-  benchStarSlot.value.player = player
-  markDirty()
-}
-
 function addBenchDual(player: SquadPlayer) {
   const slot = benchDualSlots.value.find(s => !s.player)
   if (slot) { slot.player = player; markDirty() }
@@ -575,19 +529,41 @@ function addBenchDual(player: SquadPlayer) {
 function removeBenchDual(index: number) {
   benchDualSlots.value[index].player = null
   benchDualSlots.value[index].positions = [null, null]
-  const key = benchDualInterchangeKey(index)
-  if (key && interchangePosition.value === key) interchangePosition.value = null
   markDirty()
 }
 
 function setBenchPosition(slotIndex: number, sideIndex: 0 | 1, value: string) {
-  benchDualSlots.value[slotIndex].positions[sideIndex] = (value || null) as NonStarPositionKey | null
+  const slot = benchDualSlots.value[slotIndex]
+  // Steal position from any other slot that already has it, and flash that slot
+  if (value) {
+    for (let i = 0; i < benchDualSlots.value.length; i++) {
+      const other = benchDualSlots.value[i]
+      if (other.positions[0] === value && !(i === slotIndex && sideIndex === 0)) {
+        other.positions[0] = null
+        flashClearedSlot(i)
+      } else if (other.positions[1] === value && !(i === slotIndex && sideIndex === 1)) {
+        other.positions[1] = null
+        flashClearedSlot(i)
+      }
+    }
+  }
+  if (sideIndex === 0) {
+    slot.positions[0] = (value || null) as PositionKey | null
+    if (value === 'star') slot.positions[1] = null
+  } else {
+    slot.positions[1] = (value || null) as NonStarPositionKey | null
+  }
   markDirty()
 }
 
-function toggleInterchange(key: string | null) {
-  if (!key) return
-  interchangePosition.value = interchangePosition.value === key ? null : key
+function flashClearedSlot(index: number) {
+  if (clearHighlightTimer) clearTimeout(clearHighlightTimer)
+  recentlyClearedSlot.value = index
+  clearHighlightTimer = setTimeout(() => { recentlyClearedSlot.value = null }, 2000)
+}
+
+function setInterchange(value: string) {
+  interchangePosition.value = value || null
   markDirty()
 }
 
@@ -631,31 +607,19 @@ async function submitTeam() {
     }
   }
 
-  // Backup star
-  if (benchStarSlot.value.player) {
-    const entry: (typeof players)[number] = {
-      playerSeasonId: benchStarSlot.value.player.id,
-      position: 'star',
-      backupPositions: 'star',
-    }
-    if (interchangePosition.value === 'star') entry.interchangePosition = 'star'
-    players.push(entry)
-  }
-
-  // Dual-position bench
+  // Bench slots
   for (const slot of benchDualSlots.value) {
     if (!slot.player) continue
     const [p1, p2] = slot.positions
-    const bp = [p1, p2].filter(Boolean).join(',')
+    const isStar = p1 === 'star'
+    const bp = isStar ? 'star' : [p1, p2].filter(Boolean).join(',')
     const entry: (typeof players)[number] = {
       playerSeasonId: slot.player.id,
       position: p1 ?? p2 ?? 'goals',
       backupPositions: bp || undefined,
     }
-    // Attach interchange if this slot's first position matches the interchange position
-    const icKey = benchDualInterchangeKey(benchDualSlots.value.indexOf(slot))
-    if (icKey && interchangePosition.value === icKey) {
-      entry.interchangePosition = interchangePosition.value
+    if (interchangePosition.value && (p1 === interchangePosition.value || p2 === interchangePosition.value)) {
+      entry.interchangePosition = interchangePosition.value ?? undefined
     }
     players.push(entry)
   }

--- a/justfile
+++ b/justfile
@@ -95,14 +95,14 @@ test-e2e:
     cp dev/postgres/init/01_afl_schema.sql dev/postgres/test-e2e/01_afl_schema.sql
     cp dev/postgres/init/02_ffl_schema.sql dev/postgres/test-e2e/02_ffl_schema.sql
 
-    docker compose -f dev/docker-compose.test.yml up -d
+    docker compose -p xffl-test -f dev/docker-compose.test.yml up -d --force-recreate
     echo "Waiting for test Postgres on :5433..."
     until docker exec xffl-postgres-test pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
     echo "Test Postgres ready"
 
-    cd frontend/web && npx playwright test; STATUS=$?
+    (cd frontend/web && npx playwright test); STATUS=$?
 
-    docker compose -f dev/docker-compose.test.yml down
+    docker compose -p xffl-test -f dev/docker-compose.test.yml down
     rm -f dev/postgres/test-e2e/01_afl_schema.sql dev/postgres/test-e2e/02_ffl_schema.sql
     exit $STATUS
 

--- a/justfile
+++ b/justfile
@@ -50,6 +50,10 @@ run-search:
 run-gateway:
     cd services/gateway && go run ./cmd/main.go
 
+# Install frontend dependencies (run once before first run-all)
+install-frontend:
+    cd frontend/web && npm install
+
 # Run Frontend (port 3000)
 run-frontend:
     cd frontend/web && npm run dev

--- a/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
@@ -2,7 +2,7 @@
 SELECT id, name, season_id
 FROM ffl.round
 WHERE season_id = $1 AND deleted_at IS NULL
-ORDER BY name;
+ORDER BY id;
 
 -- name: FindRoundByID :one
 SELECT id, name, season_id

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
@@ -54,7 +54,7 @@ const findRoundsBySeasonID = `-- name: FindRoundsBySeasonID :many
 SELECT id, name, season_id
 FROM ffl.round
 WHERE season_id = $1 AND deleted_at IS NULL
-ORDER BY name
+ORDER BY id
 `
 
 type FindRoundsBySeasonIDRow struct {

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary
- **ffl-squad spec**: switched `beforeEach` to use `setupFflSession` (consistent with other specs) and fixed the club-selector dropdown locator to click an actual option button rather than the container `div`
- **ffl-team-builder bench:validation**: removed the redundant starter-Remove step — `addBenchDual` already calls `markDirty()`, and the Remove was breaking after a previous test in the same run had saved an empty team to the DB
- **justfile `test-e2e`**: `--force-recreate` guarantees a fresh seeded DB on every run; subshell the `cd frontend/web` so `docker compose down` runs from the repo root (previously the CWD change was silently leaving the container running); `-p xffl-test` gives the test stack its own network namespace to avoid collision with a running dev stack
- Removed the committed `test-results/.last-run.json` artifact from the repo root

## Test plan
- [ ] `just test-e2e` passes with 84/84 tests
- [ ] Run `just test-e2e` a second time immediately after — still 84/84 (verifies fresh-DB guarantee)