### PR TITLE
Phase 11 ffl event integration

### DIFF
--- a/contracts/events/events.go
+++ b/contracts/events/events.go
@@ -15,6 +15,7 @@ type PlayerMatchUpdatedPayload struct {
 	PlayerMatchID  int `json:"player_match_id"`
 	PlayerSeasonID int `json:"player_season_id"`
 	ClubMatchID    int `json:"club_match_id"`
+	RoundID        int `json:"round_id"`
 	Kicks          int `json:"kicks"`
 	Handballs      int `json:"handballs"`
 	Marks          int `json:"marks"`

--- a/dev/postgres/init/02_ffl_schema.sql
+++ b/dev/postgres/init/02_ffl_schema.sql
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS ffl.round (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP WITH TIME ZONE,
     season_id INTEGER NOT NULL REFERENCES ffl.season(id) ON DELETE CASCADE,
-    name VARCHAR(255) NOT NULL
+    name VARCHAR(255) NOT NULL,
+    afl_round_id INTEGER
 );
 
 -- Create match table

--- a/dev/postgres/seed/01_afl_seed.sql
+++ b/dev/postgres/seed/01_afl_seed.sql
@@ -43,15 +43,15 @@ INSERT INTO afl.club (name) VALUES
 ('Western Bulldogs')
 ON CONFLICT (name) DO NOTHING;
 
--- Club seasons for Adelaide and Brisbane only
+-- Club seasons for all 18 clubs
 INSERT INTO afl.club_season (club_id, season_id)
 SELECT c.id, s.id
 FROM afl.club c, afl.season s
 JOIN afl.league l ON s.league_id = l.id
-WHERE c.name IN ('Adelaide Crows', 'Brisbane Lions') AND l.name = 'AFL' AND s.name = 'AFL 2026'
+WHERE l.name = 'AFL' AND s.name = 'AFL 2026'
 ON CONFLICT (club_id, season_id) DO NOTHING;
 
--- Players: 2 per team
+-- Players: 2 per test team
 INSERT INTO afl.player (name) VALUES
 ('Jordan Dawson'),
 ('Wayne Milera'),
@@ -81,98 +81,377 @@ WHERE p.name IN ('Henry Smith', 'Hugh McCluggage')
   AND c.name = 'Brisbane Lions' AND l.name = 'AFL' AND s.name = 'AFL 2026'
 ON CONFLICT (player_id, club_season_id) DO NOTHING;
 
--- Round 1
+-- All 25 rounds: Opening Round + Rounds 1–24
 INSERT INTO afl.round (season_id, name)
-SELECT s.id, 'Round 1'
-FROM afl.season s JOIN afl.league l ON s.league_id = l.id
+SELECT s.id, r.name
+FROM (VALUES
+    ('Opening Round'), ('Round 1'),  ('Round 2'),  ('Round 3'),  ('Round 4'),
+    ('Round 5'),       ('Round 6'),  ('Round 7'),  ('Round 8'),  ('Round 9'),
+    ('Round 10'),      ('Round 11'), ('Round 12'), ('Round 13'), ('Round 14'),
+    ('Round 15'),      ('Round 16'), ('Round 17'), ('Round 18'), ('Round 19'),
+    ('Round 20'),      ('Round 21'), ('Round 22'), ('Round 23'), ('Round 24')
+) AS r(name),
+afl.season s JOIN afl.league l ON s.league_id = l.id
 WHERE l.name = 'AFL' AND s.name = 'AFL 2026';
 
-INSERT INTO afl.match (round_id, venue, start_dt, drv_result)
-SELECT r.id, 'Adelaide Oval', '2025-03-15 14:10:00+09:30', 'no_result'
-FROM afl.round r JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
-WHERE l.name = 'AFL' AND s.name = 'AFL 2026' AND r.name = 'Round 1';
+-- Full 2026 fixture — all matches with home/away club_match records
+DO $$
+DECLARE
+    v_season_id   INTEGER;
+    v_match_id    INTEGER;
+    v_home_cm_id  INTEGER;
+    v_away_cm_id  INTEGER;
+    v_match_count INTEGER := 0;
+    v_cm_count    INTEGER := 0;
+    rec           RECORD;
+BEGIN
+    SELECT s.id INTO v_season_id
+    FROM afl.season s JOIN afl.league l ON s.league_id = l.id
+    WHERE l.name = 'AFL' AND s.name = 'AFL 2026';
 
-INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
-SELECT m.id, cs.id, 0, 0, 0
-FROM afl.match m JOIN afl.round r ON m.round_id = r.id JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
-JOIN afl.club_season cs ON cs.season_id = s.id JOIN afl.club c ON cs.club_id = c.id
-WHERE l.name = 'AFL' AND r.name = 'Round 1' AND c.name IN ('Adelaide Crows', 'Brisbane Lions')
-ON CONFLICT (club_season_id, match_id) DO NOTHING;
+    FOR rec IN
+        SELECT * FROM (VALUES
+            -- Opening Round
+            ('Opening Round', '2026-03-05 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Carlton Blues'),
+            ('Opening Round', '2026-03-06 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Geelong Cats'),
+            ('Opening Round', '2026-03-07 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'Hawthorn Hawks'),
+            ('Opening Round', '2026-03-07 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Western Bulldogs'),
+            ('Opening Round', '2026-03-08 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'St Kilda Saints',                 'Collingwood Magpies'),
+            -- Round 1
+            ('Round 1',  '2026-03-12 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Carlton Blues',                   'Richmond Tigers'),
+            ('Round 1',  '2026-03-13 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Essendon Bombers',                'Hawthorn Hawks'),
+            ('Round 1',  '2026-03-14 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Greater Western Sydney Giants'),
+            ('Round 1',  '2026-03-14 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Fremantle Dockers'),
+            ('Round 1',  '2026-03-14 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Brisbane Lions'),
+            ('Round 1',  '2026-03-14 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Adelaide Crows'),
+            ('Round 1',  '2026-03-15 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Port Adelaide Power'),
+            ('Round 1',  '2026-03-15 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'St Kilda Saints'),
+            ('Round 1',  '2026-03-15 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'West Coast Eagles'),
+            -- Round 2  (byes: Brisbane Lions, Carlton Blues, Collingwood Magpies, Geelong Cats)
+            ('Round 2',  '2026-03-19 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Hawthorn Hawks',                  'Sydney Swans'),
+            ('Round 2',  '2026-03-20 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Western Bulldogs'),
+            ('Round 2',  '2026-03-21 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Gold Coast Suns'),
+            ('Round 2',  '2026-03-21 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'St Kilda Saints'),
+            ('Round 2',  '2026-03-21 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Melbourne Demons'),
+            ('Round 2',  '2026-03-22 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Essendon Bombers'),
+            ('Round 2',  '2026-03-22 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'North Melbourne Kangaroos'),
+            -- Round 3  (byes: Gold Coast Suns, Hawthorn Hawks, Sydney Swans, Western Bulldogs)
+            ('Round 3',  '2026-03-26 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Adelaide Crows'),
+            ('Round 3',  '2026-03-27 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Collingwood Magpies',             'Greater Western Sydney Giants'),
+            ('Round 3',  '2026-03-28 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Brisbane Lions'),
+            ('Round 3',  '2026-03-28 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Richmond Tigers'),
+            ('Round 3',  '2026-03-28 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Essendon Bombers',                'North Melbourne Kangaroos'),
+            ('Round 3',  '2026-03-29 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'West Coast Eagles'),
+            ('Round 3',  '2026-03-29 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Carlton Blues',                   'Melbourne Demons'),
+            -- Round 4  (byes: Greater Western Sydney Giants, St Kilda Saints)
+            ('Round 4',  '2026-04-02 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Collingwood Magpies'),
+            ('Round 4',  '2026-04-03 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Carlton Blues'),
+            ('Round 4',  '2026-04-03 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Fremantle Dockers'),
+            ('Round 4',  '2026-04-04 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Port Adelaide Power'),
+            ('Round 4',  '2026-04-04 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Sydney Swans'),
+            ('Round 4',  '2026-04-05 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Gold Coast Suns'),
+            ('Round 4',  '2026-04-05 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Essendon Bombers'),
+            ('Round 4',  '2026-04-06 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Hawthorn Hawks',                  'Geelong Cats'),
+            -- Round 5
+            ('Round 5',  '2026-04-09 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Carlton Blues'),
+            ('Round 5',  '2026-04-10 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Collingwood Magpies',             'Fremantle Dockers'),
+            ('Round 5',  '2026-04-11 00:00:00+00'::timestamptz, 'Barossa Park',                    'North Melbourne Kangaroos',       'Brisbane Lions'),
+            ('Round 5',  '2026-04-11 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Essendon Bombers',                'Melbourne Demons'),
+            ('Round 5',  '2026-04-11 00:00:00+00'::timestamptz, 'Norwood Oval',                    'Sydney Swans',                    'Gold Coast Suns'),
+            ('Round 5',  '2026-04-11 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Hawthorn Hawks',                  'Western Bulldogs'),
+            ('Round 5',  '2026-04-12 00:00:00+00'::timestamptz, 'Norwood Oval',                    'Geelong Cats',                    'West Coast Eagles'),
+            ('Round 5',  '2026-04-12 00:00:00+00'::timestamptz, 'Barossa Park',                    'Greater Western Sydney Giants',   'Richmond Tigers'),
+            ('Round 5',  '2026-04-12 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'St Kilda Saints'),
+            -- Round 6
+            ('Round 6',  '2026-04-16 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Carlton Blues',                   'Collingwood Magpies'),
+            ('Round 6',  '2026-04-17 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Western Bulldogs'),
+            ('Round 6',  '2026-04-17 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Greater Western Sydney Giants'),
+            ('Round 6',  '2026-04-18 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Essendon Bombers'),
+            ('Round 6',  '2026-04-18 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Hawthorn Hawks',                  'Port Adelaide Power'),
+            ('Round 6',  '2026-04-18 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'St Kilda Saints'),
+            ('Round 6',  '2026-04-19 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Richmond Tigers'),
+            ('Round 6',  '2026-04-19 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Brisbane Lions'),
+            ('Round 6',  '2026-04-19 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Fremantle Dockers'),
+            -- Round 7
+            ('Round 7',  '2026-04-23 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Sydney Swans'),
+            ('Round 7',  '2026-04-24 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Melbourne Demons'),
+            ('Round 7',  '2026-04-25 00:00:00+00'::timestamptz, 'University of Tasmania Stadium',  'Hawthorn Hawks',                  'Gold Coast Suns'),
+            ('Round 7',  '2026-04-25 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Essendon Bombers',                'Collingwood Magpies'),
+            ('Round 7',  '2026-04-25 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Geelong Cats'),
+            ('Round 7',  '2026-04-25 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Carlton Blues'),
+            ('Round 7',  '2026-04-26 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'West Coast Eagles'),
+            ('Round 7',  '2026-04-26 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Adelaide Crows'),
+            ('Round 7',  '2026-04-26 00:00:00+00'::timestamptz, 'Corroboree Group Oval Manuk',     'Greater Western Sydney Giants',   'North Melbourne Kangaroos'),
+            -- Round 8
+            ('Round 8',  '2026-04-30 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Hawthorn Hawks'),
+            ('Round 8',  '2026-05-01 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Fremantle Dockers'),
+            ('Round 8',  '2026-05-01 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Port Adelaide Power'),
+            ('Round 8',  '2026-05-02 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Essendon Bombers',                'Brisbane Lions'),
+            ('Round 8',  '2026-05-02 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Richmond Tigers'),
+            ('Round 8',  '2026-05-02 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'North Melbourne Kangaroos'),
+            ('Round 8',  '2026-05-02 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Carlton Blues',                   'St Kilda Saints'),
+            ('Round 8',  '2026-05-03 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Melbourne Demons'),
+            ('Round 8',  '2026-05-03 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Greater Western Sydney Giants'),
+            -- Round 9
+            ('Round 9',  '2026-05-07 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Hawthorn Hawks'),
+            ('Round 9',  '2026-05-08 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Carlton Blues'),
+            ('Round 9',  '2026-05-08 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Western Bulldogs'),
+            ('Round 9',  '2026-05-09 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Sydney Swans'),
+            ('Round 9',  '2026-05-09 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'Essendon Bombers'),
+            ('Round 9',  '2026-05-09 00:00:00+00'::timestamptz, 'TIO Stadium',                     'Gold Coast Suns',                 'St Kilda Saints'),
+            ('Round 9',  '2026-05-09 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Geelong Cats',                    'Collingwood Magpies'),
+            ('Round 9',  '2026-05-10 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Melbourne Demons',                'West Coast Eagles'),
+            ('Round 9',  '2026-05-10 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Adelaide Crows'),
+            -- Round 10
+            ('Round 10', '2026-05-14 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Geelong Cats'),
+            ('Round 10', '2026-05-15 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Collingwood Magpies'),
+            ('Round 10', '2026-05-15 00:00:00+00'::timestamptz, 'TIO Stadium',                     'Gold Coast Suns',                 'Port Adelaide Power'),
+            ('Round 10', '2026-05-16 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'North Melbourne Kangaroos'),
+            ('Round 10', '2026-05-16 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Hawthorn Hawks'),
+            ('Round 10', '2026-05-16 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Carlton Blues',                   'Western Bulldogs'),
+            ('Round 10', '2026-05-17 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Essendon Bombers',                'Fremantle Dockers'),
+            ('Round 10', '2026-05-17 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Richmond Tigers'),
+            ('Round 10', '2026-05-17 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Greater Western Sydney Giants'),
+            -- Round 11
+            ('Round 11', '2026-05-21 00:00:00+00'::timestamptz, 'University of Tasmania Stadium',  'Hawthorn Hawks',                  'Adelaide Crows'),
+            ('Round 11', '2026-05-22 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Essendon Bombers'),
+            ('Round 11', '2026-05-22 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'St Kilda Saints'),
+            ('Round 11', '2026-05-23 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Gold Coast Suns'),
+            ('Round 11', '2026-05-23 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Sydney Swans'),
+            ('Round 11', '2026-05-23 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'West Coast Eagles'),
+            ('Round 11', '2026-05-23 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Carlton Blues'),
+            ('Round 11', '2026-05-24 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'Brisbane Lions'),
+            ('Round 11', '2026-05-24 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Melbourne Demons'),
+            -- Round 12  (byes: Adelaide Crows, Gold Coast Suns, North Melbourne Kangaroos, Port Adelaide Power)
+            ('Round 12', '2026-05-28 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Hawthorn Hawks'),
+            ('Round 12', '2026-05-29 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Carlton Blues',                   'Geelong Cats'),
+            ('Round 12', '2026-05-30 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Richmond Tigers'),
+            ('Round 12', '2026-05-30 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Fremantle Dockers'),
+            ('Round 12', '2026-05-30 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Collingwood Magpies'),
+            ('Round 12', '2026-05-31 00:00:00+00'::timestamptz, 'TIO Traeger Park',                'Melbourne Demons',                'Greater Western Sydney Giants'),
+            ('Round 12', '2026-05-31 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Essendon Bombers'),
+            -- Round 13  (byes: Greater Western Sydney Giants, Richmond Tigers)
+            ('Round 13', '2026-06-04 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Geelong Cats'),
+            ('Round 13', '2026-06-05 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Hawthorn Hawks',                  'Western Bulldogs'),
+            ('Round 13', '2026-06-06 00:00:00+00'::timestamptz, 'Hands Oval',                      'North Melbourne Kangaroos',       'Fremantle Dockers'),
+            ('Round 13', '2026-06-06 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Brisbane Lions'),
+            ('Round 13', '2026-06-06 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Port Adelaide Power'),
+            ('Round 13', '2026-06-07 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'St Kilda Saints'),
+            ('Round 13', '2026-06-07 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Essendon Bombers',                'Carlton Blues'),
+            ('Round 13', '2026-06-08 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Melbourne Demons'),
+            -- Round 14  (byes: Carlton Blues, Collingwood Magpies, Fremantle Dockers, Hawthorn Hawks)
+            ('Round 14', '2026-06-11 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Adelaide Crows'),
+            ('Round 14', '2026-06-12 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Gold Coast Suns'),
+            ('Round 14', '2026-06-13 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Essendon Bombers'),
+            ('Round 14', '2026-06-13 00:00:00+00'::timestamptz, 'Optus Stadium',                   'North Melbourne Kangaroos',       'West Coast Eagles'),
+            ('Round 14', '2026-06-13 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Sydney Swans'),
+            ('Round 14', '2026-06-14 00:00:00+00'::timestamptz, 'Ninja Stadium',                   'Richmond Tigers',                 'Brisbane Lions'),
+            ('Round 14', '2026-06-14 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Greater Western Sydney Giants'),
+            -- Round 15  (byes: Brisbane Lions, Essendon Bombers, Sydney Swans, West Coast Eagles)
+            ('Round 15', '2026-06-18 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Geelong Cats'),
+            ('Round 15', '2026-06-19 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Hawthorn Hawks'),
+            ('Round 15', '2026-06-20 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Melbourne Demons'),
+            ('Round 15', '2026-06-20 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'Carlton Blues'),
+            ('Round 15', '2026-06-20 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Port Adelaide Power'),
+            ('Round 15', '2026-06-21 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'North Melbourne Kangaroos'),
+            ('Round 15', '2026-06-21 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Western Bulldogs'),
+            -- Round 16  (byes: Geelong Cats, Melbourne Demons, St Kilda Saints, Western Bulldogs) — date range Thu Jun 25–Sun Jun 28
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Sydney Swans'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Carlton Blues',                   'West Coast Eagles'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Richmond Tigers'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Gold Coast Suns'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Hawthorn Hawks',                  'Greater Western Sydney Giants'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Essendon Bombers'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Adelaide Crows'),
+            -- Round 17  — date range Thu Jul 2–Sun Jul 5
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Essendon Bombers',                'St Kilda Saints'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Brisbane Lions'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Collingwood Magpies'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Corroboree Group Oval Manuk',     'Greater Western Sydney Giants',   'Fremantle Dockers'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'University of Tasmania Stadium',  'Hawthorn Hawks',                  'Melbourne Demons'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'North Melbourne Kangaroos'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Carlton Blues'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Western Bulldogs'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Adelaide Crows'),
+            -- Round 18  — date range Thu Jul 9–Sun Jul 12
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Gold Coast Suns'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Essendon Bombers'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Carlton Blues',                   'Hawthorn Hawks'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Collingwood Magpies',             'North Melbourne Kangaroos'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Sydney Swans'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'Geelong Cats'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Richmond Tigers'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Port Adelaide Power'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'West Coast Eagles'),
+            -- Round 19  — date range Thu Jul 16–Sun Jul 19
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Carlton Blues'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Essendon Bombers',                'Greater Western Sydney Giants'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'St Kilda Saints'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Western Bulldogs'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Melbourne Demons'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Fremantle Dockers'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'Hawthorn Hawks'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Adelaide Crows'),
+            ('Round 19', '2026-07-16 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Brisbane Lions'),
+            -- Round 20  — date range Thu Jul 23–Sun Jul 26
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Collingwood Magpies'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Port Adelaide Power'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Carlton Blues',                   'Gold Coast Suns'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'West Coast Eagles'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'Sydney Swans'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Hawthorn Hawks',                  'Essendon Bombers'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'St Kilda Saints'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Geelong Cats'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Richmond Tigers'),
+            -- Round 21  — date range Thu Jul 30–Sun Aug 2
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Carlton Blues',                   'Brisbane Lions'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Geelong Cats'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Essendon Bombers',                'Adelaide Crows'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Western Bulldogs'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'People First Stadium',            'Gold Coast Suns',                 'Melbourne Demons'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'University of Tasmania Stadium',  'Hawthorn Hawks',                  'North Melbourne Kangaroos'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Greater Western Sydney Giants'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'West Coast Eagles'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Sydney Swans'),
+            -- Round 22  — date range Thu Aug 6–Sun Aug 9
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Richmond Tigers'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Hawthorn Hawks'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Essendon Bombers'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Corroboree Group Oval Manuk',     'Greater Western Sydney Giants',   'Gold Coast Suns'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Fremantle Dockers'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Carlton Blues'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'Port Adelaide Power'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Collingwood Magpies'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'North Melbourne Kangaroos'),
+            -- Round 23  — date range Fri Aug 14–Sun Aug 16
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'The Gabba',                       'Brisbane Lions',                  'Gold Coast Suns'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Essendon Bombers',                'Sydney Swans'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Optus Stadium',                   'Fremantle Dockers',               'Adelaide Crows'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'ENGIE Stadium',                   'Greater Western Sydney Giants',   'West Coast Eagles'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Hawthorn Hawks',                  'Collingwood Magpies'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'North Melbourne Kangaroos',       'Geelong Cats'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Port Adelaide Power',             'Melbourne Demons'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Richmond Tigers',                 'St Kilda Saints'),
+            ('Round 23', '2026-08-14 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Western Bulldogs',                'Carlton Blues'),
+            -- Round 24  — date range Thu Aug 21–Sun Aug 23
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Adelaide Oval',                   'Adelaide Crows',                  'Greater Western Sydney Giants'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Collingwood Magpies',             'Brisbane Lions'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Carlton Blues',                   'Fremantle Dockers'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'Essendon Bombers',                'Port Adelaide Power'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'GMHBA Stadium',                   'Geelong Cats',                    'Richmond Tigers'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Melbourne Cricket Ground',        'Melbourne Demons',                'Western Bulldogs'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Marvel Stadium',                  'St Kilda Saints',                 'Gold Coast Suns'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Sydney Cricket Ground',           'Sydney Swans',                    'North Melbourne Kangaroos'),
+            ('Round 24', '2026-08-21 00:00:00+00'::timestamptz, 'Optus Stadium',                   'West Coast Eagles',               'Hawthorn Hawks')
+        ) AS t(round_name, start_dt, venue, home_club, away_club)
+    LOOP
+        INSERT INTO afl.match (round_id, venue, start_dt, drv_result)
+        VALUES (
+            (SELECT r.id FROM afl.round r WHERE r.name = rec.round_name AND r.season_id = v_season_id),
+            rec.venue, rec.start_dt, 'no_result'
+        )
+        RETURNING id INTO v_match_id;
+        v_match_count := v_match_count + 1;
 
-UPDATE afl.match SET
-  home_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Adelaide Crows'),
-  away_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Brisbane Lions')
-WHERE venue = 'Adelaide Oval';
+        INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
+        VALUES (v_match_id,
+            (SELECT cs.id FROM afl.club_season cs JOIN afl.club c ON cs.club_id = c.id
+             WHERE c.name = rec.home_club AND cs.season_id = v_season_id),
+            0, 0, 0)
+        RETURNING id INTO v_home_cm_id;
+        v_cm_count := v_cm_count + 1;
 
+        INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
+        VALUES (v_match_id,
+            (SELECT cs.id FROM afl.club_season cs JOIN afl.club c ON cs.club_id = c.id
+             WHERE c.name = rec.away_club AND cs.season_id = v_season_id),
+            0, 0, 0)
+        RETURNING id INTO v_away_cm_id;
+        v_cm_count := v_cm_count + 1;
+
+        UPDATE afl.match
+        SET home_club_match_id = v_home_cm_id, away_club_match_id = v_away_cm_id
+        WHERE id = v_match_id;
+    END LOOP;
+
+    RAISE NOTICE 'matches inserted: %', v_match_count;
+    RAISE NOTICE 'club_matches inserted: %', v_cm_count;
+END $$;
+
+-- Test player_match data for FFL score computation testing
+-- Round 1: Collingwood Magpies vs Adelaide Crows @ MCG (Adelaide away)
 INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 SELECT ps.id, cm.id, 'played', 18, 12, 6, 0, 4, 2, 1
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id
-WHERE p.name = 'Jordan Dawson' AND c.name = 'Adelaide Crows'
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+JOIN afl.match m ON cm.match_id = m.id
+JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Jordan Dawson' AND c.name = 'Adelaide Crows' AND r.name = 'Round 1'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
 INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 SELECT ps.id, cm.id, 'played', 22, 15, 4, 0, 6, 0, 2
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id
-WHERE p.name = 'Wayne Milera' AND c.name = 'Adelaide Crows'
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+JOIN afl.match m ON cm.match_id = m.id
+JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Wayne Milera' AND c.name = 'Adelaide Crows' AND r.name = 'Round 1'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
+-- Round 1: Sydney Swans vs Brisbane Lions @ SCG (Brisbane away)
 INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 SELECT ps.id, cm.id, 'played', 20, 16, 5, 0, 8, 3, 2
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id
-WHERE p.name = 'Henry Smith' AND c.name = 'Brisbane Lions'
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+JOIN afl.match m ON cm.match_id = m.id
+JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Henry Smith' AND c.name = 'Brisbane Lions' AND r.name = 'Round 1'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
 INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 SELECT ps.id, cm.id, 'played', 16, 10, 7, 0, 5, 1, 3
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id
-WHERE p.name = 'Hugh McCluggage' AND c.name = 'Brisbane Lions'
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+JOIN afl.match m ON cm.match_id = m.id
+JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Hugh McCluggage' AND c.name = 'Brisbane Lions' AND r.name = 'Round 1'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
--- Round 2
-INSERT INTO afl.round (season_id, name)
-SELECT s.id, 'Round 2'
-FROM afl.season s JOIN afl.league l ON s.league_id = l.id
-WHERE l.name = 'AFL' AND s.name = 'AFL 2026';
-
-INSERT INTO afl.match (round_id, venue, start_dt, drv_result)
-SELECT r.id, 'The Gabba', '2025-03-22 15:20:00+10:00', 'no_result'
-FROM afl.round r JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
-WHERE l.name = 'AFL' AND s.name = 'AFL 2026' AND r.name = 'Round 2';
-
-INSERT INTO afl.club_match (match_id, club_season_id, drv_score, drv_premiership_points, rushed_behinds)
-SELECT m.id, cs.id, 0, 0, 0
-FROM afl.match m JOIN afl.round r ON m.round_id = r.id JOIN afl.season s ON r.season_id = s.id JOIN afl.league l ON s.league_id = l.id
-JOIN afl.club_season cs ON cs.season_id = s.id JOIN afl.club c ON cs.club_id = c.id
-WHERE l.name = 'AFL' AND r.name = 'Round 2' AND c.name IN ('Adelaide Crows', 'Brisbane Lions')
-ON CONFLICT (club_season_id, match_id) DO NOTHING;
-
-UPDATE afl.match SET
-  home_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Brisbane Lions'),
-  away_club_match_id = (SELECT cm.id FROM afl.club_match cm JOIN afl.club_season cs ON cm.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id WHERE cm.match_id = afl.match.id AND c.name = 'Adelaide Crows')
-WHERE venue = 'The Gabba';
-
+-- Round 2: Adelaide Crows vs Western Bulldogs @ Adelaide Oval
 INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 SELECT ps.id, cm.id, 'played', 15, 10, 8, 0, 3, 1, 2
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id)
-WHERE p.name = 'Jordan Dawson' AND r.name = 'Round 2'
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+JOIN afl.match m ON cm.match_id = m.id
+JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Jordan Dawson' AND c.name = 'Adelaide Crows' AND r.name = 'Round 2'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
 INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
 SELECT ps.id, cm.id, 'played', 25, 11, 5, 0, 8, 1, 0
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id)
-WHERE p.name = 'Wayne Milera' AND r.name = 'Round 2'
-ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
-
-INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
-SELECT ps.id, cm.id, 'played', 18, 14, 4, 0, 6, 2, 1
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id)
-WHERE p.name = 'Henry Smith' AND r.name = 'Round 2'
-ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
-
-INSERT INTO afl.player_match (player_season_id, club_match_id, status, kicks, handballs, marks, hitouts, tackles, goals, behinds)
-SELECT ps.id, cm.id, 'played', 14, 8, 9, 0, 3, 0, 2
-FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.round r ON r.id = (SELECT round_id FROM afl.match WHERE id = cm.match_id)
-WHERE p.name = 'Hugh McCluggage' AND r.name = 'Round 2'
+FROM afl.player_season ps
+JOIN afl.player p ON ps.player_id = p.id
+JOIN afl.club_season cs ON ps.club_season_id = cs.id
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.club_match cm ON cm.club_season_id = cs.id
+JOIN afl.match m ON cm.match_id = m.id
+JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Wayne Milera' AND c.name = 'Adelaide Crows' AND r.name = 'Round 2'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
 COMMIT;

--- a/dev/postgres/seed/02_ffl_seed.sql
+++ b/dev/postgres/seed/02_ffl_seed.sql
@@ -77,9 +77,12 @@ DO $$
 DECLARE
     v_season_id  INTEGER;
     v_match_id   INTEGER;
-    v_home_cm_id INTEGER;
-    v_away_cm_id INTEGER;
-    r            RECORD;
+    v_home_cm_id  INTEGER;
+    v_away_cm_id  INTEGER;
+    v_match_count INTEGER := 0;
+    v_cm_count    INTEGER := 0;
+    v_row_count   INTEGER;
+    rec           RECORD;
 BEGIN
     SELECT id INTO v_season_id FROM ffl.season WHERE name = 'FFL 2026';
 
@@ -87,12 +90,14 @@ BEGIN
     -- afl_round_id links each FFL round to its corresponding AFL round
     INSERT INTO ffl.round (name, season_id, afl_round_id)
     SELECT n::text, v_season_id,
-           (SELECT r.id FROM afl.round r JOIN afl.season s ON r.season_id = s.id
-            WHERE r.name = 'Round ' || n::text AND s.name = 'AFL 2026')
+           (SELECT ar.id FROM afl.round ar JOIN afl.season s ON ar.season_id = s.id
+            WHERE ar.name = 'Round ' || n::text AND s.name = 'AFL 2026')
     FROM generate_series(2, 23) AS n;
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    RAISE NOTICE 'rounds inserted: %', v_row_count;
 
     -- Insert all matches (rounds 19 and 23 have none)
-    FOR r IN
+    FOR rec IN
         SELECT * FROM (VALUES
             ('2',  '2026-03-19 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
             ('2',  '2026-03-19 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
@@ -138,21 +143,26 @@ BEGIN
     LOOP
         INSERT INTO ffl.match (round_id, match_style, venue, start_dt)
         VALUES (
-            (SELECT id FROM ffl.round WHERE name = r.round_name AND season_id = v_season_id),
-            'versus', r.venue, r.start_dt
+            (SELECT id FROM ffl.round WHERE name = rec.round_name AND season_id = v_season_id),
+            'versus', rec.venue, rec.start_dt
         )
         RETURNING id INTO v_match_id;
+        v_match_count := v_match_count + 1;
 
         INSERT INTO ffl.club_match (match_id, club_season_id)
-        VALUES (v_match_id, (SELECT cs.id FROM ffl.club_season cs JOIN ffl.club c ON cs.club_id = c.id WHERE c.name = r.home_club AND cs.season_id = v_season_id))
+        VALUES (v_match_id, (SELECT cs.id FROM ffl.club_season cs JOIN ffl.club c ON cs.club_id = c.id WHERE c.name = rec.home_club AND cs.season_id = v_season_id))
         RETURNING id INTO v_home_cm_id;
+        v_cm_count := v_cm_count + 1;
 
         INSERT INTO ffl.club_match (match_id, club_season_id)
-        VALUES (v_match_id, (SELECT cs.id FROM ffl.club_season cs JOIN ffl.club c ON cs.club_id = c.id WHERE c.name = r.away_club AND cs.season_id = v_season_id))
+        VALUES (v_match_id, (SELECT cs.id FROM ffl.club_season cs JOIN ffl.club c ON cs.club_id = c.id WHERE c.name = rec.away_club AND cs.season_id = v_season_id))
         RETURNING id INTO v_away_cm_id;
+        v_cm_count := v_cm_count + 1;
 
         UPDATE ffl.match SET home_club_match_id = v_home_cm_id, away_club_match_id = v_away_cm_id WHERE id = v_match_id;
     END LOOP;
+    RAISE NOTICE 'matches inserted: %', v_match_count;
+    RAISE NOTICE 'club_matches inserted: %', v_cm_count;
 END $$;
 
 COMMIT;

--- a/dev/postgres/seed/02_ffl_seed.sql
+++ b/dev/postgres/seed/02_ffl_seed.sql
@@ -44,13 +44,15 @@ SELECT ap.id, ap.name FROM afl.player ap WHERE ap.name IN (
     'Henry Smith', 'Hugh McCluggage'
 );
 
--- Round 1
-INSERT INTO ffl.round (name, season_id) VALUES
-    ('1', (SELECT id FROM ffl.season WHERE name = 'FFL 2026'));
+-- Round 1 (afl_round_id references the AFL round for the same week)
+INSERT INTO ffl.round (name, season_id, afl_round_id) VALUES
+    ('1', (SELECT id FROM ffl.season WHERE name = 'FFL 2026'),
+     (SELECT r.id FROM afl.round r JOIN afl.season s ON r.season_id = s.id WHERE r.name = 'Round 1' AND s.name = 'AFL 2026'));
 
--- Player seasons — Ruiboys
-INSERT INTO ffl.player_season (player_id, club_season_id, from_round_id)
-SELECT p.id, cs.id, r.id
+-- Player seasons — Ruiboys (afl_player_season_id links to the AFL player's season entry)
+INSERT INTO ffl.player_season (player_id, club_season_id, from_round_id, afl_player_season_id)
+SELECT p.id, cs.id, r.id,
+       (SELECT aps.id FROM afl.player_season aps WHERE aps.player_id = ap.id LIMIT 1)
 FROM ffl.player p
 JOIN afl.player ap ON p.afl_player_id = ap.id
 JOIN ffl.club_season cs ON cs.club_id = (SELECT id FROM ffl.club WHERE name = 'Ruiboys')
@@ -59,8 +61,9 @@ WHERE r.name = '1' AND ap.name IN ('Jordan Dawson', 'Wayne Milera');
 
 -- Player seasons — The Howling Cows (Henry Smith + Hugh McCluggage assigned to positions;
 -- remaining 6 are squad-only with no player_match, available in the team builder)
-INSERT INTO ffl.player_season (player_id, club_season_id, from_round_id)
-SELECT p.id, cs.id, r.id
+INSERT INTO ffl.player_season (player_id, club_season_id, from_round_id, afl_player_season_id)
+SELECT p.id, cs.id, r.id,
+       (SELECT aps.id FROM afl.player_season aps WHERE aps.player_id = ap.id LIMIT 1)
 FROM ffl.player p
 JOIN afl.player ap ON p.afl_player_id = ap.id
 JOIN ffl.club_season cs ON cs.club_id = (SELECT id FROM ffl.club WHERE name = 'The Howling Cows')
@@ -80,9 +83,12 @@ DECLARE
 BEGIN
     SELECT id INTO v_season_id FROM ffl.season WHERE name = 'FFL 2026';
 
-    -- Insert rounds 1–23 in order (19 = SUPERBYE, 23 = no matches yet)
-    INSERT INTO ffl.round (name, season_id)
-    SELECT n::text, v_season_id
+    -- Insert rounds 2–23 in order (19 = SUPERBYE, 23 = no matches yet)
+    -- afl_round_id links each FFL round to its corresponding AFL round
+    INSERT INTO ffl.round (name, season_id, afl_round_id)
+    SELECT n::text, v_season_id,
+           (SELECT r.id FROM afl.round r JOIN afl.season s ON r.season_id = s.id
+            WHERE r.name = 'Round ' || n::text AND s.name = 'AFL 2026')
     FROM generate_series(2, 23) AS n;
 
     -- Insert all matches (rounds 19 and 23 have none)

--- a/frontend/web/src/features/afl/components/RoundNav.vue
+++ b/frontend/web/src/features/afl/components/RoundNav.vue
@@ -27,7 +27,7 @@
           ? 'ring-2 ring-active bg-control text-text-muted hover:bg-control-hover hover:text-text'
           : 'bg-control text-text-muted hover:bg-control-hover hover:text-text'"
     >
-      {{ round.name.replace(/^Round\s+/i, '') }}
+      {{ round.name === 'Opening Round' ? '0' : round.name.replace(/^Round\s+/i, '') }}
     </router-link>
   </nav>
 </template>

--- a/justfile
+++ b/justfile
@@ -11,6 +11,12 @@ dev-up:
     @until docker exec xffl-postgres pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
     @echo "Postgres ready on :${DB_PORT:-5432} | Zinc ready on :${ZINC_PORT:-4080}"
 
+# Load test data into Postgres
+dev-seed:
+    docker exec -i xffl-postgres psql -U postgres -d xffl < dev/postgres/seed/01_afl_seed.sql
+    docker exec -i xffl-postgres psql -U postgres -d xffl < dev/postgres/seed/02_ffl_seed.sql
+    @echo "Test data loaded"
+
 # Stop local infrastructure
 dev-down:
     docker compose -f dev/docker-compose.yml down
@@ -23,16 +29,6 @@ dev-reset:
 # Tail infrastructure logs
 dev-logs:
     docker compose -f dev/docker-compose.yml logs -f
-
-# Load test data into Postgres
-dev-seed:
-    docker exec -i xffl-postgres psql -U postgres -d xffl < dev/postgres/seed/01_afl_seed.sql
-    docker exec -i xffl-postgres psql -U postgres -d xffl < dev/postgres/seed/02_ffl_seed.sql
-    @echo "Test data loaded"
-
-# Snapshot AI control plane context for sharing or LLM ingestion
-ai-snapshot:
-    bash dev/ai-snapshot.sh
 
 # Run AFL service (port 8080)
 run-afl:
@@ -55,7 +51,7 @@ install-frontend:
     cd frontend/web && npm install
 
 # Run Frontend (port 3000)
-run-frontend:
+run-frontend: install-frontend
     cd frontend/web && npm run dev
 
 # Run AFL + FFL services, gateway, and frontend together
@@ -105,4 +101,14 @@ test-e2e:
     docker compose -p xffl-test -f dev/docker-compose.test.yml down
     rm -f dev/postgres/test-e2e/01_afl_schema.sql dev/postgres/test-e2e/02_ffl_schema.sql
     exit $STATUS
+
+# Run all tests (AFL unit, FFL unit, and e2e)
+test-all:
+    just test-afl
+    just test-ffl
+    just test-e2e
+
+# Snapshot AI control plane context for sharing or LLM ingestion
+ai-snapshot:
+    bash dev/ai-snapshot.sh
 

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -1,21 +1,49 @@
 # Current Sprint
 
-**Sprint goal:** Phase 10 - Test stabilisation
+**Sprint goal:** Phase 11 — FFL Event Integration
 
-Refactor tests to be accurate, extensible, and grounded in minimal seed data
+Wire up cross-service event flow: AFL stat updates automatically trigger FFL fantasy score recalculation.
 
-## Completed
+## Tasks
 
-- [x] Decided against `t.Parallel()` for domain tests (microsecond-fast, no benefit)
-- [x] Migrated AFL integration tests from dev Postgres to testcontainers (`services/afl/internal/testutil/postgres.go`)
-- [x] Added `TestMain` + shared container pool pattern to AFL graphql test package
-- [x] Rewrote AFL `integration_test.go` with testify (`require`/`assert`) and sentence-style `t.Run` names
-- [x] Added `ai/architecture/testing.md` — full conventions doc (stack, patterns, naming, examples)
-- [x] Added `/write-tests` skill at `.claude/skills/write-tests/SKILL.md`
-- [x] Updated `ai/architecture/cookbook.md` testing section to point to testing.md
-- [x] Consolidated FFL domain.md position/slot tables into one
-- [x] Migrated FFL domain tests to testify with expressive names (`club_match_test.go`, `club_season_test.go`, `player_match_test.go`)
-- [x] Migrated FFL integration tests to testcontainers (`services/ffl/internal/testutil/postgres.go`, `TestMain`)
-- [x] Rewrote FFL `integration_test.go` with testify and sentence-style `t.Run` names
-- [x] Migrated missing `commands_test.go` scenarios to integration tests (`addFFLSquadPlayer`, empty team, star position)
-- [x] Deleted `services/ffl/internal/application/commands_test.go` — all coverage now end-to-end via testcontainers
+### 1. Contract: extend event payload
+- [ ] Add `RoundID int` to `PlayerMatchUpdatedPayload` in `contracts/events/events.go`
+
+### 2. AFL: publish event on stat update
+- [ ] Add `events.Dispatcher` to AFL `Commands` (new dependency)
+- [ ] Publish `AFL.PlayerMatchUpdated` after `UpdatePlayerMatch` succeeds
+- [ ] Wire PG dispatcher in `services/afl/cmd/main.go`, start `Listen` goroutine
+- [ ] Unit/integration test: verify event is published with correct payload
+
+### 3. FFL schema: round correlation
+- [ ] Add `afl_round_id INTEGER` column to `ffl.round` in `dev/postgres/init/02_ffl_schema.sql`
+- [ ] Populate `afl_round_id` in seed data
+- [ ] Add field to FFL `domain.Round`
+
+### 4. FFL infra: new queries
+- [ ] SQLC query: `FindRoundByAFLRoundID` — find FFL round by `afl_round_id`
+- [ ] SQLC query: `FindPlayerMatchByPlayerSeasonAndRound` — join `player_match → club_match → match` to find player_match by `(player_season_id, round_id)`
+- [ ] SQLC query: `FindPlayerSeasonsByAFLPlayerSeasonID` — find all FFL player_seasons for a given AFL player_season
+- [ ] Add repository methods + domain interfaces for the above
+- [ ] `sqlc generate` + update `repository.go`
+
+### 5. FFL application: event handler
+- [ ] New `HandlePlayerMatchUpdated(ctx, payload)` method on `Commands`
+  - Decode `PlayerMatchUpdatedPayload`
+  - Find FFL round by `afl_round_id`
+  - Find FFL player_seasons by `afl_player_season_id`
+  - For each: find FFL player_match by `(player_season_id, round_id)` via join query
+  - Call `CalculateFantasyScore` with AFL stats
+  - Set `afl_player_match_id` on the FFL player_match
+  - Publish `FFL.FantasyScoreCalculated`
+- [ ] Add `events.Dispatcher` dependency to FFL `Commands`
+
+### 6. FFL main.go: wire dispatcher
+- [ ] Wire PG dispatcher in `services/ffl/cmd/main.go`
+- [ ] Subscribe `HandlePlayerMatchUpdated` to `AFL.PlayerMatchUpdated`
+- [ ] Start `Listen` goroutine
+
+### 7. Integration tests
+- [ ] Test: AFL publishes event → FFL handler scores the correct player_match
+- [ ] Test: event for player not in any FFL squad is silently ignored
+- [ ] Test: multiple FFL clubs with same AFL player all get scored

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -48,3 +48,68 @@ Wire up cross-service event flow: AFL stat updates automatically trigger FFL fan
 - [x] Test: AFL publishes event → FFL handler scores the correct player_match
 - [x] Test: event for player not in any FFL squad is silently ignored
 - [x] Test: multiple FFL clubs with same AFL player all get scored
+
+---
+
+# Phase 12 — Live Round
+
+**Sprint goal:** Compute and expose a "live round" across AFL and FFL services, drive the round nav default and indicator from it, and make the whole thing testable without real-time dependency.
+
+## Design decisions
+
+- **Live window**: midnight (Australia/Adelaide) before first game of round → midnight after last game of round. Derived from `MIN`/`MAX` of `afl.match.start_dt` per round.
+- **Fallback**: if no round window is currently open, return the most recently completed round.
+- **`RoundStatus`**: `Open` (window active) / `Closed` (fallback — most recently completed).
+- **Domain owns logic**: DB query returns round + match bounds; midnight-boundary calculation and Open/Closed determination live in Go domain code, not SQL.
+- **Injectable `Clock` interface**: wired at startup. Overridden via `CLOCK_OVERRIDE=<RFC3339>` env var — used by e2e tests to fix time without exposing time-travel on the API.
+- **Cookies**: two JSON cookies — `xffl_afl` and `xffl_ffl` — each `{ seasonId, roundId, roundStatus }`. Refreshed on page load. Trust stale value if query fails.
+- **Nav indicator**: `liveRoundId` in RoundNav is fed from cookie (not URL). Independent of the currently browsed round. `Open` vs `Closed` status can drive different ring styles.
+
+## Decision: FFL live round mapping
+
+Frontend-driven: frontend calls AFL `liveRound`, then maps to FFL round by `afl_round_id` client-side. No FFL → AFL service dependency introduced yet.
+
+## Tasks
+
+### 1. Shared: Clock interface
+- [ ] Define `Clock` interface in `shared/` (or per-service if no shared location is appropriate)
+- [ ] `RealClock` implementation wrapping `time.Now()`
+- [ ] `FixedClock` implementation for tests
+- [ ] `CLOCK_OVERRIDE` env var support: if set at startup, wire `FixedClock`; otherwise `RealClock`
+
+### 2. AFL: RoundStatus type + LiveRound use case
+- [ ] Add `RoundStatus` type (`Open` / `Closed`) to AFL domain
+- [ ] Add `LiveRoundResult` struct: `Round *Round`, `Status RoundStatus`
+- [ ] SQLC query: fetch all rounds for a season with `MIN(match.start_dt)` and `MAX(match.start_dt)`
+- [ ] `LiveRound(ctx, asOf time.Time) (*LiveRoundResult, error)` use case:
+  - Load round+match bounds for current season
+  - For each round: compute window in Australia/Adelaide timezone
+  - Return first round whose window contains `asOf`; if none, return most recently completed with `Closed`
+- [ ] Wire `Clock` into AFL `Commands`
+
+### 3. AFL: GraphQL
+- [ ] Add `liveRound: LiveRoundResult` query to AFL schema
+- [ ] Resolver calls `commands.LiveRound(ctx, clock.Now())`
+
+### 4. FFL: LiveRound use case
+- [ ] Add `RoundStatus` type + `LiveRoundResult` to FFL domain
+- [ ] `LiveRound` use case: find FFL round matching live AFL round via `afl_round_id`; fall back to most recently completed FFL round
+- [ ] Wire `Clock` into FFL `Commands`
+
+### 5. FFL: GraphQL
+- [ ] Add `liveRound: LiveRoundResult` query to FFL schema
+- [ ] Resolver calls `commands.LiveRound(ctx, clock.Now())`
+
+### 6. E2e test seed data
+- [ ] Add a dedicated e2e AFL round with `afl.match.start_dt` values around a fixed date (e.g. `2026-01-15`)
+- [ ] Add matching FFL round with `afl_round_id` pointing to above
+- [ ] Configure e2e harness to start services with `CLOCK_OVERRIDE=2026-01-15T10:00:00+10:30`
+
+### 7. Frontend: state composables
+- [ ] Create `useAflState.ts`: manages `xffl_afl` JSON cookie `{ seasonId, roundId, roundStatus }`
+- [ ] Refactor `useFflState.ts`: replace flat string refs + `setCurrentSeason` with `xffl_ffl` JSON cookie, same shape
+- [ ] On page load: call `liveRound` query for the relevant service, update cookie; trust stale value on failure
+
+### 8. Frontend: RoundNav
+- [ ] Feed `liveRoundId` from cookie (not URL)
+- [ ] Pass `roundStatus` alongside `liveRoundId`; apply distinct ring style for `Open` vs `Closed`

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -7,28 +7,29 @@ Wire up cross-service event flow: AFL stat updates automatically trigger FFL fan
 ## Tasks
 
 ### 1. Contract: extend event payload
-- [ ] Add `RoundID int` to `PlayerMatchUpdatedPayload` in `contracts/events/events.go`
+- [x] Add `RoundID int` to `PlayerMatchUpdatedPayload` in `contracts/events/events.go`
 
 ### 2. AFL: publish event on stat update
-- [ ] Add `events.Dispatcher` to AFL `Commands` (new dependency)
-- [ ] Publish `AFL.PlayerMatchUpdated` after `UpdatePlayerMatch` succeeds
-- [ ] Wire PG dispatcher in `services/afl/cmd/main.go`, start `Listen` goroutine
-- [ ] Unit/integration test: verify event is published with correct payload
+- [x] Add `events.Dispatcher` to AFL `Commands` (new dependency)
+- [x] Publish `AFL.PlayerMatchUpdated` after `UpdatePlayerMatch` succeeds
+- [x] Wire PG dispatcher in `services/afl/cmd/main.go`, start `Listen` goroutine
+- [x] Add `FindRoundIDByClubMatchID` SQLC query + domain interface + repo method
 
 ### 3. FFL schema: round correlation
-- [ ] Add `afl_round_id INTEGER` column to `ffl.round` in `dev/postgres/init/02_ffl_schema.sql`
-- [ ] Populate `afl_round_id` in seed data
-- [ ] Add field to FFL `domain.Round`
+- [x] Add `afl_round_id INTEGER` column to `ffl.round` in `dev/postgres/init/02_ffl_schema.sql`
+- [x] Populate `afl_round_id` in seed data
+- [x] Add field to FFL `domain.Round`
 
 ### 4. FFL infra: new queries
-- [ ] SQLC query: `FindRoundByAFLRoundID` — find FFL round by `afl_round_id`
-- [ ] SQLC query: `FindPlayerMatchByPlayerSeasonAndRound` — join `player_match → club_match → match` to find player_match by `(player_season_id, round_id)`
-- [ ] SQLC query: `FindPlayerSeasonsByAFLPlayerSeasonID` — find all FFL player_seasons for a given AFL player_season
-- [ ] Add repository methods + domain interfaces for the above
-- [ ] `sqlc generate` + update `repository.go`
+- [x] SQLC query: `FindRoundByAFLRoundID` — find FFL round by `afl_round_id`
+- [x] SQLC query: `FindPlayerMatchByPlayerSeasonAndRound` — join `player_match → club_match → match` to find player_match by `(player_season_id, round_id)`
+- [x] SQLC query: `FindPlayerSeasonsByAFLPlayerSeasonID` — find all FFL player_seasons for a given AFL player_season
+- [x] SQLC query: `UpdateAFLPlayerMatchID` — set the AFL link on player_match
+- [x] Add repository methods + domain interfaces for the above
+- [x] `sqlc generate` + update `repository.go`
 
 ### 5. FFL application: event handler
-- [ ] New `HandlePlayerMatchUpdated(ctx, payload)` method on `Commands`
+- [x] New `HandlePlayerMatchUpdated(ctx, payload)` method on `Commands`
   - Decode `PlayerMatchUpdatedPayload`
   - Find FFL round by `afl_round_id`
   - Find FFL player_seasons by `afl_player_season_id`
@@ -36,14 +37,14 @@ Wire up cross-service event flow: AFL stat updates automatically trigger FFL fan
   - Call `CalculateFantasyScore` with AFL stats
   - Set `afl_player_match_id` on the FFL player_match
   - Publish `FFL.FantasyScoreCalculated`
-- [ ] Add `events.Dispatcher` dependency to FFL `Commands`
+- [x] Add `events.Dispatcher` dependency to FFL `Commands`
 
 ### 6. FFL main.go: wire dispatcher
-- [ ] Wire PG dispatcher in `services/ffl/cmd/main.go`
-- [ ] Subscribe `HandlePlayerMatchUpdated` to `AFL.PlayerMatchUpdated`
-- [ ] Start `Listen` goroutine
+- [x] Wire PG dispatcher in `services/ffl/cmd/main.go`
+- [x] Subscribe `HandlePlayerMatchUpdated` to `AFL.PlayerMatchUpdated`
+- [x] Start `Listen` goroutine
 
 ### 7. Integration tests
-- [ ] Test: AFL publishes event → FFL handler scores the correct player_match
-- [ ] Test: event for player not in any FFL squad is silently ignored
-- [ ] Test: multiple FFL clubs with same AFL player all get scored
+- [x] Test: AFL publishes event → FFL handler scores the correct player_match
+- [x] Test: event for player not in any FFL squad is silently ignored
+- [x] Test: multiple FFL clubs with same AFL player all get scored

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -128,7 +128,20 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 - [x] FFL publishes `FFL.FantasyScoreCalculated`
 - [x] Tests — integration (event flow end-to-end, unknown player, multiple clubs)
 
-## Phase 12: Search Service
+## Phase 12: Live Round
+
+**Goal:** Compute and expose a contextually relevant "live round" across AFL and FFL, drive round nav defaults and indicators from it, and make the whole thing testable without real-time dependency.
+
+- [ ] Injectable `Clock` interface (shared); `CLOCK_OVERRIDE` env var for e2e
+- [ ] AFL `LiveRound` use case — midnight-bounded window (Australia/Adelaide), `RoundStatus: Open/Closed`, fallback to most recently completed
+- [ ] AFL `liveRound` GraphQL query
+- [ ] FFL `LiveRound` use case — maps via `afl_round_id`, frontend drives the AFL→FFL mapping (no FFL→AFL service dep)
+- [ ] FFL `liveRound` GraphQL query
+- [ ] E2e seed data with fixed `start_dt` values; test harness sets `CLOCK_OVERRIDE`
+- [ ] Frontend: `useAflState` + refactored `useFflState` — JSON cookies `xffl_afl` / `xffl_ffl` with `{ seasonId, roundId, roundStatus }`
+- [ ] RoundNav: `liveRoundId` from cookie; distinct ring style for `Open` vs `Closed`
+
+## Phase 13: Search Service
 
 **Goal:** Event-driven search indexing
 
@@ -139,14 +152,14 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 - [ ] Add search passthrough to gateway
 - [ ] Tests — unit (document transformation) + integration (Zinc)
 
-## Phase 13: Search Frontend
+## Phase 14: Search Frontend
 
 **Goal:** Search UI (new feature, not in first-cut)
 
 - [ ] Search view — full-text search with filters (source, type)
 - [ ] Playwright tests
 
-## Phase 14: CQRS Player Stats Read Model
+## Phase 15: CQRS Player Stats Read Model
 
 **Goal:** Move player stats reads to the search index (ADR-013)
 
@@ -154,7 +167,7 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 - [ ] SquadView: replace AFL GraphQL stats query with search index query
 - [ ] Apply pattern to other stat-heavy views as they are built
 
-## Phase 15: Deployment
+## Phase 16: Deployment
 
 - [ ] CI-ready (GitHub Actions or similar)
 - [ ] ADR — Consider deployment options (AWS, GCP, etc)

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -117,13 +117,16 @@ Rebuilding from scratch using `first-cut/` as reference. Full stack (backend + f
 - [x] Add `ai/architecture/testing.md` conventions doc + `/write-tests` skill
 - [x] Delete mock-based `commands_test.go` — coverage consolidated into integration tests
 
-## Phase 11: FFL Event Integration
+## Phase 11: FFL Event Integration ✅
 
 **Goal:** Wire up cross-service event flow between AFL and FFL
 
-- [ ] FFL subscribes to `AFL.PlayerMatchUpdated` → auto-calculates fantasy scores
-- [ ] FFL publishes `FFL.FantasyScoreCalculated`
-- [ ] Tests — integration (event flow end-to-end)
+- [x] Contract extended: `RoundID` added to `PlayerMatchUpdatedPayload`
+- [x] AFL publishes `AFL.PlayerMatchUpdated` after stat updates (PG LISTEN/NOTIFY)
+- [x] FFL round correlation: `afl_round_id` column + join query for player_match lookup
+- [x] FFL subscribes to `AFL.PlayerMatchUpdated` → auto-calculates fantasy scores
+- [x] FFL publishes `FFL.FantasyScoreCalculated`
+- [x] Tests — integration (event flow end-to-end, unknown player, multiple clubs)
 
 ## Phase 12: Search Service
 

--- a/services/afl/cmd/main.go
+++ b/services/afl/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	pg "xffl/services/afl/internal/infrastructure/postgres"
 	"xffl/services/afl/internal/infrastructure/postgres/sqlcgen"
 	gql "xffl/services/afl/internal/interface/graphql"
+	pgevents "xffl/shared/events/pg"
 )
 
 func main() {
@@ -48,8 +49,15 @@ func main() {
 		pg.NewPlayerSeasonRepository(q),
 	)
 
+	dispatcher := pgevents.New(pool, "xffl_events")
+	go func() {
+		if err := dispatcher.Listen(ctx); err != nil {
+			log.Printf("AFL: event listener stopped: %v", err)
+		}
+	}()
+
 	db := pg.NewDB(pool)
-	commands := application.NewCommands(db)
+	commands := application.NewCommands(db, dispatcher)
 
 	resolver := &gql.Resolver{Queries: queries, Commands: commands}
 	srv := handler.NewDefaultServer(gql.NewExecutableSchema(gql.Config{Resolvers: resolver}))

--- a/services/afl/internal/application/commands.go
+++ b/services/afl/internal/application/commands.go
@@ -2,8 +2,12 @@ package application
 
 import (
 	"context"
+	"encoding/json"
+	"log"
 
+	"xffl/contracts/events"
 	"xffl/services/afl/internal/domain"
+	sharedevents "xffl/shared/events"
 )
 
 // WriteRepos provides repository access within a transaction.
@@ -19,17 +23,19 @@ type TxManager interface {
 
 // Commands handles all write operations for the AFL service.
 type Commands struct {
-	tx TxManager
+	tx         TxManager
+	dispatcher sharedevents.Dispatcher
 }
 
-func NewCommands(tx TxManager) *Commands {
-	return &Commands{tx: tx}
+func NewCommands(tx TxManager, dispatcher sharedevents.Dispatcher) *Commands {
+	return &Commands{tx: tx, dispatcher: dispatcher}
 }
 
 // UpdatePlayerMatch upserts a player match and recalculates the club match score
-// using domain logic.
+// using domain logic. Publishes an AFL.PlayerMatchUpdated event on success.
 func (c *Commands) UpdatePlayerMatch(ctx context.Context, params domain.UpsertPlayerMatchParams) (domain.PlayerMatch, error) {
 	var result domain.PlayerMatch
+	var roundID int
 	err := c.tx.WithTx(ctx, func(repos WriteRepos) error {
 		pm, err := repos.PlayerMatches.Upsert(ctx, params)
 		if err != nil {
@@ -46,8 +52,38 @@ func (c *Commands) UpdatePlayerMatch(ctx context.Context, params domain.UpsertPl
 			return err
 		}
 
+		roundID, err = repos.ClubMatches.FindRoundID(ctx, params.ClubMatchID)
+		if err != nil {
+			return err
+		}
+
 		clubMatch.PlayerMatches = playerMatches
 		return repos.ClubMatches.UpdateScore(ctx, params.ClubMatchID, clubMatch.Score())
 	})
-	return result, err
+	if err != nil {
+		return result, err
+	}
+
+	payload, err := json.Marshal(events.PlayerMatchUpdatedPayload{
+		PlayerMatchID:  result.ID,
+		PlayerSeasonID: result.PlayerSeasonID,
+		ClubMatchID:    result.ClubMatchID,
+		RoundID:        roundID,
+		Kicks:          result.Kicks,
+		Handballs:      result.Handballs,
+		Marks:          result.Marks,
+		Hitouts:        result.Hitouts,
+		Tackles:        result.Tackles,
+		Goals:          result.Goals,
+		Behinds:        result.Behinds,
+	})
+	if err != nil {
+		log.Printf("AFL: failed to marshal PlayerMatchUpdated event: %v", err)
+		return result, nil
+	}
+	if err := c.dispatcher.Publish(ctx, events.PlayerMatchUpdated, payload); err != nil {
+		log.Printf("AFL: failed to publish PlayerMatchUpdated event: %v", err)
+	}
+
+	return result, nil
 }

--- a/services/afl/internal/domain/club_match.go
+++ b/services/afl/internal/domain/club_match.go
@@ -23,5 +23,6 @@ func (cm ClubMatch) Score() int {
 type ClubMatchRepository interface {
 	FindByMatchID(ctx context.Context, matchID int) ([]ClubMatch, error)
 	FindByID(ctx context.Context, id int) (ClubMatch, error)
+	FindRoundID(ctx context.Context, clubMatchID int) (int, error)
 	UpdateScore(ctx context.Context, id int, score int) error
 }

--- a/services/afl/internal/infrastructure/postgres/repository.go
+++ b/services/afl/internal/infrastructure/postgres/repository.go
@@ -317,6 +317,14 @@ func (r *ClubMatchRepository) FindByID(ctx context.Context, id int) (domain.Club
 	}, nil
 }
 
+func (r *ClubMatchRepository) FindRoundID(ctx context.Context, clubMatchID int) (int, error) {
+	roundID, err := r.q.FindRoundIDByClubMatchID(ctx, int32(clubMatchID))
+	if err != nil {
+		return 0, err
+	}
+	return int(roundID), nil
+}
+
 func (r *ClubMatchRepository) UpdateScore(ctx context.Context, id int, score int) error {
 	s := int32(score)
 	return r.q.UpdateClubMatchScore(ctx, sqlcgen.UpdateClubMatchScoreParams{

--- a/services/afl/internal/infrastructure/postgres/sqlc/club_match.sql
+++ b/services/afl/internal/infrastructure/postgres/sqlc/club_match.sql
@@ -13,3 +13,9 @@ UPDATE afl.club_match
 SET drv_score = $2,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND deleted_at IS NULL;
+
+-- name: FindRoundIDByClubMatchID :one
+SELECT m.round_id
+FROM afl.match m
+JOIN afl.club_match cm ON cm.match_id = m.id
+WHERE cm.id = $1 AND cm.deleted_at IS NULL AND m.deleted_at IS NULL;

--- a/services/afl/internal/infrastructure/postgres/sqlc/round.sql
+++ b/services/afl/internal/infrastructure/postgres/sqlc/round.sql
@@ -1,8 +1,10 @@
 -- name: FindRoundsBySeasonID :many
-SELECT id, name, season_id
-FROM afl.round
-WHERE season_id = $1 AND deleted_at IS NULL
-ORDER BY name;
+SELECT r.id, r.name, r.season_id
+FROM afl.round r
+LEFT JOIN afl.match m ON m.round_id = r.id AND m.deleted_at IS NULL
+WHERE r.season_id = $1 AND r.deleted_at IS NULL
+GROUP BY r.id, r.name, r.season_id
+ORDER BY MIN(m.start_dt) NULLS LAST, r.id;
 
 -- name: FindRoundByID :one
 SELECT id, name, season_id

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/club_match.sql.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/club_match.sql.go
@@ -76,6 +76,20 @@ func (q *Queries) FindClubMatchesByMatchID(ctx context.Context, matchID int32) (
 	return items, nil
 }
 
+const findRoundIDByClubMatchID = `-- name: FindRoundIDByClubMatchID :one
+SELECT m.round_id
+FROM afl.match m
+JOIN afl.club_match cm ON cm.match_id = m.id
+WHERE cm.id = $1 AND cm.deleted_at IS NULL AND m.deleted_at IS NULL
+`
+
+func (q *Queries) FindRoundIDByClubMatchID(ctx context.Context, id int32) (int32, error) {
+	row := q.db.QueryRow(ctx, findRoundIDByClubMatchID, id)
+	var round_id int32
+	err := row.Scan(&round_id)
+	return round_id, err
+}
+
 const updateClubMatchScore = `-- name: UpdateClubMatchScore :exec
 UPDATE afl.club_match
 SET drv_score = $2,

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -25,6 +25,7 @@ type Querier interface {
 	FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) ([]FindPlayerMatchesByClubMatchIDRow, error)
 	FindPlayerSeasonByID(ctx context.Context, id int32) (FindPlayerSeasonByIDRow, error)
 	FindRoundByID(ctx context.Context, id int32) (FindRoundByIDRow, error)
+	FindRoundIDByClubMatchID(ctx context.Context, id int32) (int32, error)
 	FindRoundsBySeasonID(ctx context.Context, seasonID int32) ([]FindRoundsBySeasonIDRow, error)
 	FindSeasonByID(ctx context.Context, id int32) (FindSeasonByIDRow, error)
 	SearchPlayersByName(ctx context.Context, query *string) ([]SearchPlayersByNameRow, error)

--- a/services/afl/internal/infrastructure/postgres/sqlcgen/round.sql.go
+++ b/services/afl/internal/infrastructure/postgres/sqlcgen/round.sql.go
@@ -51,10 +51,12 @@ func (q *Queries) FindRoundByID(ctx context.Context, id int32) (FindRoundByIDRow
 }
 
 const findRoundsBySeasonID = `-- name: FindRoundsBySeasonID :many
-SELECT id, name, season_id
-FROM afl.round
-WHERE season_id = $1 AND deleted_at IS NULL
-ORDER BY name
+SELECT r.id, r.name, r.season_id
+FROM afl.round r
+LEFT JOIN afl.match m ON m.round_id = r.id AND m.deleted_at IS NULL
+WHERE r.season_id = $1 AND r.deleted_at IS NULL
+GROUP BY r.id, r.name, r.season_id
+ORDER BY MIN(m.start_dt) NULLS LAST, r.id
 `
 
 type FindRoundsBySeasonIDRow struct {

--- a/services/afl/internal/interface/graphql/integration_test.go
+++ b/services/afl/internal/interface/graphql/integration_test.go
@@ -18,6 +18,7 @@ import (
 	pg "xffl/services/afl/internal/infrastructure/postgres"
 	"xffl/services/afl/internal/infrastructure/postgres/sqlcgen"
 	gql "xffl/services/afl/internal/interface/graphql"
+	memevents "xffl/shared/events/memory"
 )
 
 // db setup
@@ -44,7 +45,7 @@ func setupTestServer(t *testing.T, pool *pgxpool.Pool) *httptest.Server {
 	)
 
 	db := pg.NewDB(pool)
-	commands := application.NewCommands(db)
+	commands := application.NewCommands(db, memevents.New())
 
 	resolver := &gql.Resolver{Queries: queries, Commands: commands}
 	srv := gqlhandler.NewDefaultServer(gql.NewExecutableSchema(gql.Config{Resolvers: resolver}))

--- a/services/ffl/cmd/main.go
+++ b/services/ffl/cmd/main.go
@@ -10,10 +10,12 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 
+	contractevents "xffl/contracts/events"
 	"xffl/services/ffl/internal/application"
 	pg "xffl/services/ffl/internal/infrastructure/postgres"
 	"xffl/services/ffl/internal/infrastructure/postgres/sqlcgen"
 	gql "xffl/services/ffl/internal/interface/graphql"
+	pgevents "xffl/shared/events/pg"
 )
 
 func main() {
@@ -48,8 +50,21 @@ func main() {
 		pg.NewPlayerSeasonRepository(q),
 	)
 
+	dispatcher := pgevents.New(pool, "xffl_events")
+
 	db := pg.NewDB(pool)
-	commands := application.NewCommands(db)
+	commands := application.NewCommands(db, dispatcher, application.EventRepos{
+		Rounds:        pg.NewRoundRepository(q),
+		PlayerSeasons: pg.NewPlayerSeasonRepository(q),
+		PlayerMatches: pg.NewPlayerMatchRepository(q),
+	})
+
+	dispatcher.Subscribe(contractevents.PlayerMatchUpdated, commands.HandlePlayerMatchUpdated)
+	go func() {
+		if err := dispatcher.Listen(ctx); err != nil {
+			log.Printf("FFL: event listener stopped: %v", err)
+		}
+	}()
 
 	resolver := &gql.Resolver{Queries: queries, Commands: commands}
 	srv := handler.NewDefaultServer(gql.NewExecutableSchema(gql.Config{Resolvers: resolver}))

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -2,8 +2,13 @@ package application
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log"
 
+	"xffl/contracts/events"
 	"xffl/services/ffl/internal/domain"
+	sharedevents "xffl/shared/events"
 )
 
 // WriteRepos provides repository access within a transaction.
@@ -19,13 +24,22 @@ type TxManager interface {
 	WithTx(ctx context.Context, fn func(repos WriteRepos) error) error
 }
 
-// Commands handles all write operations for the FFL service.
-type Commands struct {
-	tx TxManager
+// EventRepos provides read-only access for event handler lookups.
+type EventRepos struct {
+	Rounds        domain.RoundRepository
+	PlayerSeasons domain.PlayerSeasonRepository
+	PlayerMatches domain.PlayerMatchRepository
 }
 
-func NewCommands(tx TxManager) *Commands {
-	return &Commands{tx: tx}
+// Commands handles all write operations for the FFL service.
+type Commands struct {
+	tx         TxManager
+	dispatcher sharedevents.Dispatcher
+	eventRepos EventRepos
+}
+
+func NewCommands(tx TxManager, dispatcher sharedevents.Dispatcher, eventRepos EventRepos) *Commands {
+	return &Commands{tx: tx, dispatcher: dispatcher, eventRepos: eventRepos}
 }
 
 // CreatePlayer creates a new player linked to an AFL player.
@@ -199,4 +213,77 @@ func (c *Commands) CalculateFantasyScore(ctx context.Context, playerMatchID int,
 		return repos.ClubMatches.UpdateScore(ctx, pm.ClubMatchID, clubMatch.Score())
 	})
 	return result, err
+}
+
+// HandlePlayerMatchUpdated processes an AFL.PlayerMatchUpdated event.
+// It finds all FFL player matches for the given AFL player in the matching round
+// and recalculates their fantasy scores.
+func (c *Commands) HandlePlayerMatchUpdated(ctx context.Context, payload []byte) error {
+	var event events.PlayerMatchUpdatedPayload
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return fmt.Errorf("unmarshal PlayerMatchUpdated: %w", err)
+	}
+
+	// Find the FFL round that corresponds to this AFL round.
+	fflRound, err := c.eventRepos.Rounds.FindByAFLRoundID(ctx, event.RoundID)
+	if err != nil {
+		log.Printf("FFL: no round for AFL round %d, skipping", event.RoundID)
+		return nil
+	}
+
+	// Find all FFL player seasons linked to this AFL player season.
+	fflPlayerSeasons, err := c.eventRepos.PlayerSeasons.FindByAFLPlayerSeasonID(ctx, event.PlayerSeasonID)
+	if err != nil {
+		return fmt.Errorf("find FFL player seasons for AFL player_season %d: %w", event.PlayerSeasonID, err)
+	}
+	if len(fflPlayerSeasons) == 0 {
+		return nil // player not in any FFL squad
+	}
+
+	stats := domain.AFLStats{
+		Goals:     event.Goals,
+		Kicks:     event.Kicks,
+		Handballs: event.Handballs,
+		Marks:     event.Marks,
+		Tackles:   event.Tackles,
+		Hitouts:   event.Hitouts,
+	}
+
+	for _, ps := range fflPlayerSeasons {
+		// Find the FFL player match for this player season in the matching round.
+		pm, err := c.eventRepos.PlayerMatches.FindByPlayerSeasonAndRound(ctx, ps.ID, fflRound.ID)
+		if err != nil {
+			log.Printf("FFL: no player_match for player_season %d in round %d, skipping", ps.ID, fflRound.ID)
+			continue
+		}
+
+		// Link to the AFL player match if not already set.
+		if pm.AFLPlayerMatchID == nil {
+			if err := c.eventRepos.PlayerMatches.UpdateAFLPlayerMatchID(ctx, pm.ID, event.PlayerMatchID); err != nil {
+				log.Printf("FFL: failed to set afl_player_match_id on player_match %d: %v", pm.ID, err)
+			}
+		}
+
+		// Calculate and store the fantasy score.
+		scored, err := c.CalculateFantasyScore(ctx, pm.ID, stats)
+		if err != nil {
+			log.Printf("FFL: failed to calculate score for player_match %d: %v", pm.ID, err)
+			continue
+		}
+
+		// Publish FFL.FantasyScoreCalculated.
+		fflPayload, err := json.Marshal(events.FantasyScoreCalculatedPayload{
+			PlayerMatchID: scored.ID,
+			Score:         scored.Score,
+		})
+		if err != nil {
+			log.Printf("FFL: failed to marshal FantasyScoreCalculated: %v", err)
+			continue
+		}
+		if err := c.dispatcher.Publish(ctx, events.FantasyScoreCalculated, fflPayload); err != nil {
+			log.Printf("FFL: failed to publish FantasyScoreCalculated: %v", err)
+		}
+	}
+
+	return nil
 }

--- a/services/ffl/internal/domain/player_match.go
+++ b/services/ffl/internal/domain/player_match.go
@@ -222,6 +222,8 @@ type PlayerMatchRepository interface {
 	DeleteByClubMatchID(ctx context.Context, clubMatchID int) error
 	FindByClubMatchID(ctx context.Context, clubMatchID int) ([]PlayerMatch, error)
 	FindByID(ctx context.Context, id int) (PlayerMatch, error)
+	FindByPlayerSeasonAndRound(ctx context.Context, playerSeasonID int, roundID int) (PlayerMatch, error)
+	UpdateAFLPlayerMatchID(ctx context.Context, id int, aflPlayerMatchID int) error
 	Upsert(ctx context.Context, params UpsertPlayerMatchParams) (PlayerMatch, error)
 }
 

--- a/services/ffl/internal/domain/player_season.go
+++ b/services/ffl/internal/domain/player_season.go
@@ -12,6 +12,7 @@ type PlayerSeason struct {
 type PlayerSeasonRepository interface {
 	FindByClubSeasonID(ctx context.Context, clubSeasonID int) ([]PlayerSeason, error)
 	FindByID(ctx context.Context, id int) (PlayerSeason, error)
+	FindByAFLPlayerSeasonID(ctx context.Context, aflPlayerSeasonID int) ([]PlayerSeason, error)
 	Create(ctx context.Context, playerID int, clubSeasonID int) (PlayerSeason, error)
 	Delete(ctx context.Context, id int) error
 }

--- a/services/ffl/internal/domain/round.go
+++ b/services/ffl/internal/domain/round.go
@@ -3,13 +3,15 @@ package domain
 import "context"
 
 type Round struct {
-	ID       int
-	Name     string
-	SeasonID int
+	ID         int
+	Name       string
+	SeasonID   int
+	AFLRoundID *int
 }
 
 type RoundRepository interface {
 	FindBySeasonID(ctx context.Context, seasonID int) ([]Round, error)
 	FindByID(ctx context.Context, id int) (Round, error)
 	FindLatest(ctx context.Context) (Round, error)
+	FindByAFLRoundID(ctx context.Context, aflRoundID int) (Round, error)
 }

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -116,6 +116,15 @@ func (r *RoundRepository) FindLatest(ctx context.Context) (domain.Round, error) 
 	return domain.Round{ID: int(row.ID), Name: row.Name, SeasonID: int(row.SeasonID)}, nil
 }
 
+func (r *RoundRepository) FindByAFLRoundID(ctx context.Context, aflRoundID int) (domain.Round, error) {
+	v := int32(aflRoundID)
+	row, err := r.q.FindRoundByAFLRoundID(ctx, &v)
+	if err != nil {
+		return domain.Round{}, err
+	}
+	return domain.Round{ID: int(row.ID), Name: row.Name, SeasonID: int(row.SeasonID), AFLRoundID: int32PtrToIntPtr(row.AflRoundID)}, nil
+}
+
 // --- Match ---
 
 type MatchRepository struct{ q *sqlcgen.Queries }
@@ -460,6 +469,26 @@ func (r *PlayerMatchRepository) FindByID(ctx context.Context, id int) (domain.Pl
 		row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.DrvScore, row.AflPlayerMatchID), nil
 }
 
+func (r *PlayerMatchRepository) FindByPlayerSeasonAndRound(ctx context.Context, playerSeasonID int, roundID int) (domain.PlayerMatch, error) {
+	row, err := r.q.FindPlayerMatchByPlayerSeasonAndRound(ctx, sqlcgen.FindPlayerMatchByPlayerSeasonAndRoundParams{
+		PlayerSeasonID: int32(playerSeasonID),
+		RoundID:        int32(roundID),
+	})
+	if err != nil {
+		return domain.PlayerMatch{}, err
+	}
+	return toPlayerMatch(row.ID, row.ClubMatchID, row.PlayerSeasonID,
+		row.Position, row.Status, row.BackupPositions, row.InterchangePosition, row.DrvScore, row.AflPlayerMatchID), nil
+}
+
+func (r *PlayerMatchRepository) UpdateAFLPlayerMatchID(ctx context.Context, id int, aflPlayerMatchID int) error {
+	v := int32(aflPlayerMatchID)
+	return r.q.UpdateAFLPlayerMatchID(ctx, sqlcgen.UpdateAFLPlayerMatchIDParams{
+		ID:               int32(id),
+		AflPlayerMatchID: &v,
+	})
+}
+
 func posToStringPtr(p *domain.Position) *string {
 	if p == nil {
 		return nil
@@ -503,6 +532,19 @@ func NewPlayerSeasonRepository(q *sqlcgen.Queries) *PlayerSeasonRepository {
 
 func (r *PlayerSeasonRepository) FindByClubSeasonID(ctx context.Context, clubSeasonID int) ([]domain.PlayerSeason, error) {
 	rows, err := r.q.FindPlayerSeasonsByClubSeasonID(ctx, int32(clubSeasonID))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.PlayerSeason, len(rows))
+	for i, row := range rows {
+		out[i] = domain.PlayerSeason{ID: int(row.ID), PlayerID: int(row.PlayerID), ClubSeasonID: int(row.ClubSeasonID), AFLPlayerSeasonID: int32PtrToIntPtr(row.AflPlayerSeasonID)}
+	}
+	return out, nil
+}
+
+func (r *PlayerSeasonRepository) FindByAFLPlayerSeasonID(ctx context.Context, aflPlayerSeasonID int) ([]domain.PlayerSeason, error) {
+	v := int32(aflPlayerSeasonID)
+	rows, err := r.q.FindPlayerSeasonsByAFLPlayerSeasonID(ctx, &v)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
@@ -14,6 +14,19 @@ WHERE id = $1 AND deleted_at IS NULL;
 DELETE FROM ffl.player_match
 WHERE club_match_id = $1;
 
+-- name: FindPlayerMatchByPlayerSeasonAndRound :one
+SELECT pm.id, pm.club_match_id, pm.player_season_id,
+       pm.position, pm.status, pm.backup_positions, pm.interchange_position, pm.drv_score, pm.afl_player_match_id
+FROM ffl.player_match pm
+JOIN ffl.club_match cm ON pm.club_match_id = cm.id
+JOIN ffl.match m ON cm.match_id = m.id
+WHERE pm.player_season_id = $1 AND m.round_id = $2 AND pm.deleted_at IS NULL;
+
+-- name: UpdateAFLPlayerMatchID :exec
+UPDATE ffl.player_match
+SET afl_player_match_id = $2, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND deleted_at IS NULL;
+
 -- name: UpsertPlayerMatch :one
 INSERT INTO ffl.player_match (club_match_id, player_season_id, position, status, backup_positions, interchange_position, drv_score)
 VALUES ($1, $2, $3, $4, $5, $6, $7)

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player_season.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player_season.sql
@@ -8,6 +8,11 @@ SELECT id, player_id, club_season_id, afl_player_season_id
 FROM ffl.player_season
 WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: FindPlayerSeasonsByAFLPlayerSeasonID :many
+SELECT id, player_id, club_season_id, afl_player_season_id
+FROM ffl.player_season
+WHERE afl_player_season_id = $1 AND deleted_at IS NULL;
+
 -- name: CreatePlayerSeason :one
 INSERT INTO ffl.player_season (player_id, club_season_id)
 VALUES ($1, $2)

--- a/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
@@ -16,3 +16,8 @@ JOIN ffl.season s ON s.id = r.season_id AND s.deleted_at IS NULL
 WHERE r.deleted_at IS NULL
 ORDER BY s.id DESC, r.id DESC
 LIMIT 1;
+
+-- name: FindRoundByAFLRoundID :one
+SELECT id, name, season_id, afl_round_id
+FROM ffl.round
+WHERE afl_round_id = $1 AND deleted_at IS NULL;

--- a/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
@@ -1,8 +1,10 @@
 -- name: FindRoundsBySeasonID :many
-SELECT id, name, season_id
-FROM ffl.round
-WHERE season_id = $1 AND deleted_at IS NULL
-ORDER BY id;
+SELECT r.id, r.name, r.season_id
+FROM ffl.round r
+LEFT JOIN ffl.match m ON m.round_id = r.id AND m.deleted_at IS NULL
+WHERE r.season_id = $1 AND r.deleted_at IS NULL
+GROUP BY r.id, r.name, r.season_id
+ORDER BY MIN(m.start_dt) NULLS LAST, r.id;
 
 -- name: FindRoundByID :one
 SELECT id, name, season_id

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/models.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/models.go
@@ -104,12 +104,13 @@ type FflPlayerSeason struct {
 }
 
 type FflRound struct {
-	ID        int32
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-	DeletedAt pgtype.Timestamptz
-	SeasonID  int32
-	Name      string
+	ID         int32
+	CreatedAt  pgtype.Timestamptz
+	UpdatedAt  pgtype.Timestamptz
+	DeletedAt  pgtype.Timestamptz
+	SeasonID   int32
+	Name       string
+	AflRoundID *int32
 }
 
 type FflSeason struct {

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
@@ -9,6 +9,16 @@ import (
 	"context"
 )
 
+const deletePlayerMatchesByClubMatchID = `-- name: DeletePlayerMatchesByClubMatchID :exec
+DELETE FROM ffl.player_match
+WHERE club_match_id = $1
+`
+
+func (q *Queries) DeletePlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) error {
+	_, err := q.db.Exec(ctx, deletePlayerMatchesByClubMatchID, clubMatchID)
+	return err
+}
+
 const findPlayerMatchByID = `-- name: FindPlayerMatchByID :one
 SELECT id, club_match_id, player_season_id,
        position, status, backup_positions, interchange_position, drv_score, afl_player_match_id
@@ -31,6 +41,49 @@ type FindPlayerMatchByIDRow struct {
 func (q *Queries) FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayerMatchByIDRow, error) {
 	row := q.db.QueryRow(ctx, findPlayerMatchByID, id)
 	var i FindPlayerMatchByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.ClubMatchID,
+		&i.PlayerSeasonID,
+		&i.Position,
+		&i.Status,
+		&i.BackupPositions,
+		&i.InterchangePosition,
+		&i.DrvScore,
+		&i.AflPlayerMatchID,
+	)
+	return i, err
+}
+
+const findPlayerMatchByPlayerSeasonAndRound = `-- name: FindPlayerMatchByPlayerSeasonAndRound :one
+SELECT pm.id, pm.club_match_id, pm.player_season_id,
+       pm.position, pm.status, pm.backup_positions, pm.interchange_position, pm.drv_score, pm.afl_player_match_id
+FROM ffl.player_match pm
+JOIN ffl.club_match cm ON pm.club_match_id = cm.id
+JOIN ffl.match m ON cm.match_id = m.id
+WHERE pm.player_season_id = $1 AND m.round_id = $2 AND pm.deleted_at IS NULL
+`
+
+type FindPlayerMatchByPlayerSeasonAndRoundParams struct {
+	PlayerSeasonID int32
+	RoundID        int32
+}
+
+type FindPlayerMatchByPlayerSeasonAndRoundRow struct {
+	ID                  int32
+	ClubMatchID         int32
+	PlayerSeasonID      int32
+	Position            *string
+	Status              *string
+	BackupPositions     *string
+	InterchangePosition *string
+	DrvScore            *int32
+	AflPlayerMatchID    *int32
+}
+
+func (q *Queries) FindPlayerMatchByPlayerSeasonAndRound(ctx context.Context, arg FindPlayerMatchByPlayerSeasonAndRoundParams) (FindPlayerMatchByPlayerSeasonAndRoundRow, error) {
+	row := q.db.QueryRow(ctx, findPlayerMatchByPlayerSeasonAndRound, arg.PlayerSeasonID, arg.RoundID)
+	var i FindPlayerMatchByPlayerSeasonAndRoundRow
 	err := row.Scan(
 		&i.ID,
 		&i.ClubMatchID,
@@ -94,13 +147,19 @@ func (q *Queries) FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchI
 	return items, nil
 }
 
-const deletePlayerMatchesByClubMatchID = `-- name: DeletePlayerMatchesByClubMatchID :exec
-DELETE FROM ffl.player_match
-WHERE club_match_id = $1
+const updateAFLPlayerMatchID = `-- name: UpdateAFLPlayerMatchID :exec
+UPDATE ffl.player_match
+SET afl_player_match_id = $2, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND deleted_at IS NULL
 `
 
-func (q *Queries) DeletePlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) error {
-	_, err := q.db.Exec(ctx, deletePlayerMatchesByClubMatchID, clubMatchID)
+type UpdateAFLPlayerMatchIDParams struct {
+	ID               int32
+	AflPlayerMatchID *int32
+}
+
+func (q *Queries) UpdateAFLPlayerMatchID(ctx context.Context, arg UpdateAFLPlayerMatchIDParams) error {
+	_, err := q.db.Exec(ctx, updateAFLPlayerMatchID, arg.ID, arg.AflPlayerMatchID)
 	return err
 }
 

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player_season.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player_season.sql.go
@@ -76,6 +76,44 @@ func (q *Queries) FindPlayerSeasonByID(ctx context.Context, id int32) (FindPlaye
 	return i, err
 }
 
+const findPlayerSeasonsByAFLPlayerSeasonID = `-- name: FindPlayerSeasonsByAFLPlayerSeasonID :many
+SELECT id, player_id, club_season_id, afl_player_season_id
+FROM ffl.player_season
+WHERE afl_player_season_id = $1 AND deleted_at IS NULL
+`
+
+type FindPlayerSeasonsByAFLPlayerSeasonIDRow struct {
+	ID                int32
+	PlayerID          int32
+	ClubSeasonID      int32
+	AflPlayerSeasonID *int32
+}
+
+func (q *Queries) FindPlayerSeasonsByAFLPlayerSeasonID(ctx context.Context, aflPlayerSeasonID *int32) ([]FindPlayerSeasonsByAFLPlayerSeasonIDRow, error) {
+	rows, err := q.db.Query(ctx, findPlayerSeasonsByAFLPlayerSeasonID, aflPlayerSeasonID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindPlayerSeasonsByAFLPlayerSeasonIDRow{}
+	for rows.Next() {
+		var i FindPlayerSeasonsByAFLPlayerSeasonIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.PlayerID,
+			&i.ClubSeasonID,
+			&i.AflPlayerSeasonID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findPlayerSeasonsByClubSeasonID = `-- name: FindPlayerSeasonsByClubSeasonID :many
 SELECT id, player_id, club_season_id, afl_player_season_id
 FROM ffl.player_season

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -29,12 +29,16 @@ type Querier interface {
 	FindPlayerByAFLPlayerID(ctx context.Context, aflPlayerID int32) (FindPlayerByAFLPlayerIDRow, error)
 	FindPlayerByID(ctx context.Context, id int32) (FindPlayerByIDRow, error)
 	FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayerMatchByIDRow, error)
+	FindPlayerMatchByPlayerSeasonAndRound(ctx context.Context, arg FindPlayerMatchByPlayerSeasonAndRoundParams) (FindPlayerMatchByPlayerSeasonAndRoundRow, error)
 	FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) ([]FindPlayerMatchesByClubMatchIDRow, error)
 	FindPlayerSeasonByID(ctx context.Context, id int32) (FindPlayerSeasonByIDRow, error)
+	FindPlayerSeasonsByAFLPlayerSeasonID(ctx context.Context, aflPlayerSeasonID *int32) ([]FindPlayerSeasonsByAFLPlayerSeasonIDRow, error)
 	FindPlayerSeasonsByClubSeasonID(ctx context.Context, clubSeasonID int32) ([]FindPlayerSeasonsByClubSeasonIDRow, error)
+	FindRoundByAFLRoundID(ctx context.Context, aflRoundID *int32) (FindRoundByAFLRoundIDRow, error)
 	FindRoundByID(ctx context.Context, id int32) (FindRoundByIDRow, error)
 	FindRoundsBySeasonID(ctx context.Context, seasonID int32) ([]FindRoundsBySeasonIDRow, error)
 	FindSeasonByID(ctx context.Context, id int32) (FindSeasonByIDRow, error)
+	UpdateAFLPlayerMatchID(ctx context.Context, arg UpdateAFLPlayerMatchIDParams) error
 	UpdateClubMatchScore(ctx context.Context, arg UpdateClubMatchScoreParams) error
 	UpdatePlayer(ctx context.Context, arg UpdatePlayerParams) (UpdatePlayerRow, error)
 	UpsertPlayerMatch(ctx context.Context, arg UpsertPlayerMatchParams) (UpsertPlayerMatchRow, error)

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
@@ -76,10 +76,12 @@ func (q *Queries) FindRoundByID(ctx context.Context, id int32) (FindRoundByIDRow
 }
 
 const findRoundsBySeasonID = `-- name: FindRoundsBySeasonID :many
-SELECT id, name, season_id
-FROM ffl.round
-WHERE season_id = $1 AND deleted_at IS NULL
-ORDER BY id
+SELECT r.id, r.name, r.season_id
+FROM ffl.round r
+LEFT JOIN ffl.match m ON m.round_id = r.id AND m.deleted_at IS NULL
+WHERE r.season_id = $1 AND r.deleted_at IS NULL
+GROUP BY r.id, r.name, r.season_id
+ORDER BY MIN(m.start_dt) NULLS LAST, r.id
 `
 
 type FindRoundsBySeasonIDRow struct {

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
@@ -31,6 +31,31 @@ func (q *Queries) FindLatestRound(ctx context.Context) (FindLatestRoundRow, erro
 	return i, err
 }
 
+const findRoundByAFLRoundID = `-- name: FindRoundByAFLRoundID :one
+SELECT id, name, season_id, afl_round_id
+FROM ffl.round
+WHERE afl_round_id = $1 AND deleted_at IS NULL
+`
+
+type FindRoundByAFLRoundIDRow struct {
+	ID         int32
+	Name       string
+	SeasonID   int32
+	AflRoundID *int32
+}
+
+func (q *Queries) FindRoundByAFLRoundID(ctx context.Context, aflRoundID *int32) (FindRoundByAFLRoundIDRow, error) {
+	row := q.db.QueryRow(ctx, findRoundByAFLRoundID, aflRoundID)
+	var i FindRoundByAFLRoundIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.SeasonID,
+		&i.AflRoundID,
+	)
+	return i, err
+}
+
 const findRoundByID = `-- name: FindRoundByID :one
 SELECT id, name, season_id
 FROM ffl.round

--- a/services/ffl/internal/interface/graphql/event_integration_test.go
+++ b/services/ffl/internal/interface/graphql/event_integration_test.go
@@ -1,0 +1,295 @@
+package graphql_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contractevents "xffl/contracts/events"
+	"xffl/services/ffl/internal/application"
+	pg "xffl/services/ffl/internal/infrastructure/postgres"
+	"xffl/services/ffl/internal/infrastructure/postgres/sqlcgen"
+	memevents "xffl/shared/events/memory"
+)
+
+// eventTestIDs holds IDs of rows inserted by seedEventTestData.
+type eventTestIDs struct {
+	aflRoundID        int
+	aflPlayerSeasonID int
+	aflClubMatchID    int
+	fflRoundID        int
+	fflClubMatchID    int
+	fflPlayerSeasonID int
+	fflClubSeasonID   int
+}
+
+func seedEventTestData(t *testing.T, pool *pgxpool.Pool) eventTestIDs {
+	t.Helper()
+	ctx := context.Background()
+	var ids eventTestIDs
+
+	cleanupEventTestData(ctx, t, pool)
+
+	// AFL side: league → season → round → club → club_season → match → club_match → player → player_season
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.league (name) VALUES ('Event Test AFL') RETURNING id").Scan(new(int)))
+
+	var aflSeasonID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.season (name, league_id) VALUES ('Event AFL 2026', (SELECT id FROM afl.league WHERE name = 'Event Test AFL')) RETURNING id",
+	).Scan(&aflSeasonID))
+
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.round (name, season_id) VALUES ('Round 1', $1) RETURNING id",
+		aflSeasonID).Scan(&ids.aflRoundID))
+
+	var aflClubID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.club (name) VALUES ('Event Test Club') RETURNING id").Scan(&aflClubID))
+
+	var aflClubSeasonID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.club_season (club_id, season_id) VALUES ($1, $2) RETURNING id",
+		aflClubID, aflSeasonID).Scan(&aflClubSeasonID))
+
+	var aflMatchID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.match (round_id, venue) VALUES ($1, 'Test Ground') RETURNING id",
+		ids.aflRoundID).Scan(&aflMatchID))
+
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.club_match (match_id, club_season_id) VALUES ($1, $2) RETURNING id",
+		aflMatchID, aflClubSeasonID).Scan(&ids.aflClubMatchID))
+
+	var aflPlayerID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.player (name) VALUES ('Event Test Player') RETURNING id").Scan(&aflPlayerID))
+
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO afl.player_season (player_id, club_season_id) VALUES ($1, $2) RETURNING id",
+		aflPlayerID, aflClubSeasonID).Scan(&ids.aflPlayerSeasonID))
+
+	// FFL side: league → season → round (linked to AFL round) → club → club_season → match → club_match → player → player_season
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.league (name) VALUES ('Event Test FFL') RETURNING id").Scan(new(int)))
+
+	var fflSeasonID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.season (name, league_id) VALUES ('Event FFL 2026', (SELECT id FROM ffl.league WHERE name = 'Event Test FFL')) RETURNING id",
+	).Scan(&fflSeasonID))
+
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.round (name, season_id, afl_round_id) VALUES ('1', $1, $2) RETURNING id",
+		fflSeasonID, ids.aflRoundID).Scan(&ids.fflRoundID))
+
+	var fflClubID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.club (name) VALUES ('Event Test Eagles') RETURNING id").Scan(&fflClubID))
+
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.club_season (club_id, season_id) VALUES ($1, $2) RETURNING id",
+		fflClubID, fflSeasonID).Scan(&ids.fflClubSeasonID))
+
+	var fflMatchID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.match (round_id, match_style, venue) VALUES ($1, 'versus', 'Test Ground') RETURNING id",
+		ids.fflRoundID).Scan(&fflMatchID))
+
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.club_match (match_id, club_season_id) VALUES ($1, $2) RETURNING id",
+		fflMatchID, ids.fflClubSeasonID).Scan(&ids.fflClubMatchID))
+
+	// FFL player linked to AFL player
+	var fflPlayerID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.player (drv_name, afl_player_id) VALUES ('Event Test Player', $1) RETURNING id",
+		aflPlayerID).Scan(&fflPlayerID))
+
+	// FFL player season linked to AFL player season
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.player_season (player_id, club_season_id, afl_player_season_id) VALUES ($1, $2, $3) RETURNING id",
+		fflPlayerID, ids.fflClubSeasonID, ids.aflPlayerSeasonID).Scan(&ids.fflPlayerSeasonID))
+
+	// FFL player match: assigned to kicks position for this round
+	_, err := pool.Exec(ctx,
+		`INSERT INTO ffl.player_match (club_match_id, player_season_id, position, status)
+		 VALUES ($1, $2, 'kicks', 'named')`,
+		ids.fflClubMatchID, ids.fflPlayerSeasonID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { cleanupEventTestData(context.Background(), t, pool) })
+	return ids
+}
+
+func cleanupEventTestData(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	// FFL tables first (depend on AFL player)
+	fflTables := []string{
+		"ffl.player_match", "ffl.player_season", "ffl.player",
+		"ffl.club_match", "ffl.match", "ffl.club_season",
+		"ffl.club", "ffl.round", "ffl.season", "ffl.league",
+	}
+	for _, table := range fflTables {
+		pool.Exec(ctx, "TRUNCATE "+table+" CASCADE")
+	}
+	aflTables := []string{
+		"afl.player_match", "afl.player_season", "afl.player",
+		"afl.club_match", "afl.match", "afl.club_season",
+		"afl.club", "afl.round", "afl.season", "afl.league",
+	}
+	for _, table := range aflTables {
+		pool.Exec(ctx, "TRUNCATE "+table+" CASCADE")
+	}
+}
+
+func setupCommandsWithDispatcher(t *testing.T, pool *pgxpool.Pool) (*application.Commands, *memevents.Dispatcher) {
+	t.Helper()
+	q := sqlcgen.New(pool)
+	db := pg.NewDB(pool)
+	dispatcher := memevents.New()
+	commands := application.NewCommands(db, dispatcher, application.EventRepos{
+		Rounds:        pg.NewRoundRepository(q),
+		PlayerSeasons: pg.NewPlayerSeasonRepository(q),
+		PlayerMatches: pg.NewPlayerMatchRepository(q),
+	})
+	return commands, dispatcher
+}
+
+func TestHandlePlayerMatchUpdated_scores_ffl_player_match(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedEventTestData(t, pool)
+	commands, _ := setupCommandsWithDispatcher(t, pool)
+	ctx := context.Background()
+
+	// Simulate AFL publishing a PlayerMatchUpdated event.
+	payload, err := json.Marshal(contractevents.PlayerMatchUpdatedPayload{
+		PlayerMatchID:  999, // AFL player_match ID (arbitrary, used for linking)
+		PlayerSeasonID: ids.aflPlayerSeasonID,
+		ClubMatchID:    ids.aflClubMatchID,
+		RoundID:        ids.aflRoundID,
+		Kicks:          20,
+		Handballs:      10,
+		Marks:          5,
+		Hitouts:        0,
+		Tackles:        3,
+		Goals:          2,
+		Behinds:        1,
+	})
+	require.NoError(t, err)
+
+	// Handle the event.
+	err = commands.HandlePlayerMatchUpdated(ctx, payload)
+	require.NoError(t, err)
+
+	// Verify the FFL player match was scored.
+	// Position is "kicks", so score = kicks * 1 = 20.
+	var score int
+	err = pool.QueryRow(ctx,
+		"SELECT drv_score FROM ffl.player_match WHERE player_season_id = $1 AND club_match_id = $2",
+		ids.fflPlayerSeasonID, ids.fflClubMatchID).Scan(&score)
+	require.NoError(t, err)
+	assert.Equal(t, 20, score)
+
+	// Verify afl_player_match_id was linked.
+	var aflPMID *int
+	err = pool.QueryRow(ctx,
+		"SELECT afl_player_match_id FROM ffl.player_match WHERE player_season_id = $1 AND club_match_id = $2",
+		ids.fflPlayerSeasonID, ids.fflClubMatchID).Scan(&aflPMID)
+	require.NoError(t, err)
+	require.NotNil(t, aflPMID)
+	assert.Equal(t, 999, *aflPMID)
+}
+
+func TestHandlePlayerMatchUpdated_ignores_unknown_player(t *testing.T) {
+	pool := connectDB(t)
+	seedEventTestData(t, pool)
+	commands, _ := setupCommandsWithDispatcher(t, pool)
+	ctx := context.Background()
+
+	// Event for an AFL player_season not in any FFL squad.
+	payload, err := json.Marshal(contractevents.PlayerMatchUpdatedPayload{
+		PlayerMatchID:  1000,
+		PlayerSeasonID: 99999, // does not exist in FFL
+		ClubMatchID:    1,
+		RoundID:        1,
+		Kicks:          10,
+	})
+	require.NoError(t, err)
+
+	err = commands.HandlePlayerMatchUpdated(ctx, payload)
+	assert.NoError(t, err) // should not error, just skip
+}
+
+func TestHandlePlayerMatchUpdated_multiple_ffl_clubs(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedEventTestData(t, pool)
+	commands, _ := setupCommandsWithDispatcher(t, pool)
+	ctx := context.Background()
+
+	// Add a second FFL club with the same AFL player.
+	var secondClubSeasonID, secondClubMatchID, secondPlayerSeasonID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.club (name) VALUES ('Event Second Club') RETURNING id").Scan(new(int)))
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.club_season (club_id, season_id) VALUES ((SELECT id FROM ffl.club WHERE name = 'Event Second Club'), (SELECT season_id FROM ffl.round WHERE id = $1)) RETURNING id",
+		ids.fflRoundID).Scan(&secondClubSeasonID))
+
+	var secondMatchID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.match (round_id, match_style, venue) VALUES ($1, 'versus', 'Other Ground') RETURNING id",
+		ids.fflRoundID).Scan(&secondMatchID))
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.club_match (match_id, club_season_id) VALUES ($1, $2) RETURNING id",
+		secondMatchID, secondClubSeasonID).Scan(&secondClubMatchID))
+
+	// Second FFL player for the same AFL player
+	var secondPlayerID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT id FROM ffl.player WHERE drv_name = 'Event Test Player'").Scan(&secondPlayerID))
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.player_season (player_id, club_season_id, afl_player_season_id) VALUES ($1, $2, $3) RETURNING id",
+		secondPlayerID, secondClubSeasonID, ids.aflPlayerSeasonID).Scan(&secondPlayerSeasonID))
+
+	// Assign to goals position in second club.
+	_, err := pool.Exec(ctx,
+		`INSERT INTO ffl.player_match (club_match_id, player_season_id, position, status) VALUES ($1, $2, 'goals', 'named')`,
+		secondClubMatchID, secondPlayerSeasonID)
+	require.NoError(t, err)
+
+	// Fire event.
+	payload, err := json.Marshal(contractevents.PlayerMatchUpdatedPayload{
+		PlayerMatchID:  888,
+		PlayerSeasonID: ids.aflPlayerSeasonID,
+		ClubMatchID:    ids.aflClubMatchID,
+		RoundID:        ids.aflRoundID,
+		Kicks:          15,
+		Handballs:      8,
+		Marks:          4,
+		Hitouts:        0,
+		Tackles:        6,
+		Goals:          3,
+		Behinds:        2,
+	})
+	require.NoError(t, err)
+
+	err = commands.HandlePlayerMatchUpdated(ctx, payload)
+	require.NoError(t, err)
+
+	// First club: kicks position → score = kicks * 1 = 15.
+	var score1 int
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT drv_score FROM ffl.player_match WHERE player_season_id = $1 AND club_match_id = $2",
+		ids.fflPlayerSeasonID, ids.fflClubMatchID).Scan(&score1))
+	assert.Equal(t, 15, score1)
+
+	// Second club: goals position → score = goals * 5 = 15.
+	var score2 int
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT drv_score FROM ffl.player_match WHERE player_season_id = $1 AND club_match_id = $2",
+		secondPlayerSeasonID, secondClubMatchID).Scan(&score2))
+	assert.Equal(t, 15, score2)
+}

--- a/services/ffl/internal/interface/graphql/integration_test.go
+++ b/services/ffl/internal/interface/graphql/integration_test.go
@@ -19,6 +19,7 @@ import (
 	pg "xffl/services/ffl/internal/infrastructure/postgres"
 	"xffl/services/ffl/internal/infrastructure/postgres/sqlcgen"
 	gql "xffl/services/ffl/internal/interface/graphql"
+	memevents "xffl/shared/events/memory"
 )
 
 // db setup
@@ -45,7 +46,11 @@ func setupTestServer(t *testing.T, pool *pgxpool.Pool) *httptest.Server {
 	)
 
 	db := pg.NewDB(pool)
-	commands := application.NewCommands(db)
+	commands := application.NewCommands(db, memevents.New(), application.EventRepos{
+		Rounds:        pg.NewRoundRepository(q),
+		PlayerSeasons: pg.NewPlayerSeasonRepository(q),
+		PlayerMatches: pg.NewPlayerMatchRepository(q),
+	})
 
 	resolver := &gql.Resolver{Queries: queries, Commands: commands}
 	srv := gqlhandler.NewDefaultServer(gql.NewExecutableSchema(gql.Config{Resolvers: resolver}))


### PR DESCRIPTION
  Summary

  - AFL service publishes AFL.PlayerMatchUpdated via PG LISTEN/NOTIFY after stat updates
  - FFL subscribes, finds matching FFL player matches via afl_round_id + afl_player_season_id, auto-calculates fantasy scores, and publishes FFL.FantasyScoreCalculated
  - Round correlation: afl_round_id column added to ffl.round; join query finds player_match by (player_season_id, round_id)
  - Seed data updated with afl_round_id and afl_player_season_id for dev

  Test plan

  - 3 new integration tests (score calculation, unknown player skip, multi-club scoring)
  - All existing AFL + FFL Go tests pass
  - Playwright e2e tests (not run — no UI changes)