### PR TITLE
Bootstrap live round IDs from any page on 24h cookie expiry

### DIFF
--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -80,9 +80,11 @@ import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON_CLUBS } from '@/features/ffl/api/queries'
 import { useFflState } from '@/features/ffl/composables/useFflState'
 import ClubSelector from '@/features/ffl/components/ClubSelector.vue'
+import { useLiveRoundBootstrap } from '@/app/useLiveRoundBootstrap'
 
 const route = useRoute()
 const { selectedClubId, liveSeasonId, setClub } = useFflState()
+useLiveRoundBootstrap()
 
 const isFfl = computed(() => route.path.startsWith('/ffl'))
 

--- a/frontend/web/src/app/apollo.ts
+++ b/frontend/web/src/app/apollo.ts
@@ -10,6 +10,7 @@ const FFL_OPERATIONS = new Set([
   'GetFFLSeasonClubs',
   'GetFFLClubSeason',
   'GetFFLRoundByAflRound',
+  'GetFFLRoundIdsByAflRound',
   'GetFFLSeason',
   'AddFFLPlayerToSeason',
   'RemoveFFLPlayerFromSeason',

--- a/frontend/web/src/app/useLiveRoundBootstrap.ts
+++ b/frontend/web/src/app/useLiveRoundBootstrap.ts
@@ -1,0 +1,48 @@
+import { computed, watch } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_AFL_LIVE_ROUND_IDS } from '@/features/afl/api/queries'
+import { GET_FFL_ROUND_IDS_BY_AFL_ROUND } from '@/features/ffl/api/queries'
+import { useAflState } from '@/features/afl/composables/useAflState'
+import { useFflState } from '@/features/ffl/composables/useFflState'
+
+/**
+ * Fires live round queries when the cached state is absent (cookie expired or
+ * first visit). Runs from App.vue so any deep-linked page triggers the
+ * bootstrap rather than only the home views.
+ */
+export function useLiveRoundBootstrap() {
+  const { liveRoundId: aflRoundId, setLiveRound: setAflLiveRound } = useAflState()
+  const { liveRoundId: fflRoundId, setLiveRound: setFflLiveRound } = useFflState()
+
+  const aflStale = computed(() => !aflRoundId.value)
+  const fflStale = computed(() => !fflRoundId.value)
+
+  // Step 1: resolve the live AFL round IDs when stale
+  const { result: aflResult } = useQuery(
+    GET_AFL_LIVE_ROUND_IDS,
+    undefined,
+    () => ({ enabled: aflStale.value }),
+  )
+
+  watch(aflResult, (result) => {
+    if (!result?.aflLiveRound) return
+    const { round, startDate } = result.aflLiveRound
+    setAflLiveRound(round.season.id, round.id, startDate)
+  })
+
+  const bootstrapAflRoundId = computed(() => aflResult.value?.aflLiveRound?.round?.id ?? null)
+
+  // Step 2: resolve the corresponding FFL round IDs when stale
+  const { result: fflResult } = useQuery(
+    GET_FFL_ROUND_IDS_BY_AFL_ROUND,
+    () => ({ aflRoundId: bootstrapAflRoundId.value }),
+    () => ({ enabled: !!bootstrapAflRoundId.value && fflStale.value }),
+  )
+
+  watch(fflResult, (result) => {
+    if (!result?.fflRoundByAflRound || !aflResult.value) return
+    const round = result.fflRoundByAflRound
+    const { startDate } = aflResult.value.aflLiveRound
+    setFflLiveRound(round.season.id, round.id, startDate)
+  })
+}

--- a/frontend/web/src/features/afl/api/queries.ts
+++ b/frontend/web/src/features/afl/api/queries.ts
@@ -1,5 +1,14 @@
 import gql from 'graphql-tag'
 
+export const GET_AFL_LIVE_ROUND_IDS = gql`
+  query GetAFLLiveRoundIds {
+    aflLiveRound {
+      round { id season { id } }
+      startDate
+    }
+  }
+`
+
 export const GET_AFL_LIVE_ROUND = gql`
   query GetAFLLiveRound {
     aflLiveRound {

--- a/frontend/web/src/features/afl/composables/useAflState.ts
+++ b/frontend/web/src/features/afl/composables/useAflState.ts
@@ -30,7 +30,7 @@ function readCookie(): AflState {
 
 function writeCookie(state: AflState) {
   const expires = new Date()
-  expires.setDate(expires.getDate() + 30)
+  expires.setHours(expires.getHours() + 24)
   document.cookie = `${COOKIE_NAME}=${encodeURIComponent(JSON.stringify(state))};expires=${expires.toUTCString()};path=/`
 }
 

--- a/frontend/web/src/features/afl/composables/useAflState.ts
+++ b/frontend/web/src/features/afl/composables/useAflState.ts
@@ -30,7 +30,7 @@ function readCookie(): AflState {
 
 function writeCookie(state: AflState) {
   const expires = new Date()
-  expires.setHours(expires.getHours() + 24)
+  expires.setHours(24, 0, 0, 0)
   document.cookie = `${COOKIE_NAME}=${encodeURIComponent(JSON.stringify(state))};expires=${expires.toUTCString()};path=/`
 }
 

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -93,6 +93,15 @@ export const SEARCH_AFL_PLAYERS = gql`
 `
 
 
+export const GET_FFL_ROUND_IDS_BY_AFL_ROUND = gql`
+  query GetFFLRoundIdsByAflRound($aflRoundId: ID!) {
+    fflRoundByAflRound(aflRoundId: $aflRoundId) {
+      id
+      season { id }
+    }
+  }
+`
+
 export const GET_FFL_ROUND_BY_AFL_ROUND = gql`
   query GetFFLRoundByAflRound($aflRoundId: ID!) {
     fflRoundByAflRound(aflRoundId: $aflRoundId) {

--- a/frontend/web/src/features/ffl/composables/useFflState.ts
+++ b/frontend/web/src/features/ffl/composables/useFflState.ts
@@ -15,7 +15,7 @@ function getCookie(name: string): string {
 
 function setCookie(name: string, value: string) {
   const expires = new Date()
-  expires.setHours(expires.getHours() + 24)
+  expires.setHours(24, 0, 0, 0)
   document.cookie = `${name}=${encodeURIComponent(value)};expires=${expires.toUTCString()};path=/`
 }
 

--- a/frontend/web/src/features/ffl/composables/useFflState.ts
+++ b/frontend/web/src/features/ffl/composables/useFflState.ts
@@ -15,7 +15,7 @@ function getCookie(name: string): string {
 
 function setCookie(name: string, value: string) {
   const expires = new Date()
-  expires.setDate(expires.getDate() + 30)
+  expires.setHours(expires.getHours() + 24)
   document.cookie = `${name}=${encodeURIComponent(value)};expires=${expires.toUTCString()};path=/`
 }
 


### PR DESCRIPTION
## Summary
- Reduces `xffl_afl` and `xffl_ffl` cookie TTL from 30 days to midnight local time (browser timezone) so live round state is recalculated each new calendar day
- Adds `useLiveRoundBootstrap` composable (called from `App.vue`) that fires lightweight ID-only queries when cookies are absent — covers any deep-linked page, not just the home views
- Adds `GetAFLLiveRoundIds` and `GetFFLRoundIdsByAflRound` minimal queries that fetch only `seasonId`/`roundId`/`startDate`, keeping the bootstrap payload small
- Registers `GetFFLRoundIdsByAflRound` in the Apollo routing table so it routes to the FFL service

## Test plan
- [ ] Visit /ffl or /afl with fresh cookies — live round resolves as before
- [ ] Deep-link to a round/squad/match page with expired cookies — bootstrap queries fire and populate state (Squad nav link activates, round nav highlights live round)
- [ ] Confirm only the two minimal ID queries fire on a deep-linked page (not full ladder/match data)
- [ ] Confirm cookies expire at midnight local time and live round is recalculated on next page load