### PR TITLE
Structured logging and back-to-round nav

### DIFF
--- a/frontend/web/src/features/afl/views/AdminMatchView.vue
+++ b/frontend/web/src/features/afl/views/AdminMatchView.vue
@@ -3,8 +3,16 @@
     <div v-if="loading" class="text-text-faint">Loading match…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="match">
-      <div class="mb-8">
-        <p class="text-sm text-text-muted mb-2">Admin</p>
+      <div class="mb-6">
+        <div v-if="matchData" class="mb-2">
+          <router-link
+            :to="{ name: 'afl-round', params: { seasonId: props.seasonId, roundId: matchData.roundId } }"
+            class="text-sm text-text-muted hover:text-text transition-colors"
+          >
+            ← Back to round
+          </router-link>
+        </div>
+        <p class="text-sm text-text-muted mb-1">Admin</p>
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
           {{ match.homeClubMatch?.club.name ?? '—' }}
@@ -43,15 +51,17 @@ const props = defineProps<{ seasonId: string; matchId: string }>()
 
 const { result, loading, error } = useQuery(GET_MATCH, () => ({ seasonId: props.seasonId }))
 
-const match = computed(() => {
+const matchData = computed(() => {
   const season = result.value?.aflSeason
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return found
+    if (found) return { match: found, roundId: round.id as string }
   }
   return null
 })
+
+const match = computed(() => matchData.value?.match ?? null)
 
 const sides = computed(() => {
   if (!match.value) return []

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -3,7 +3,15 @@
     <div v-if="loading" class="text-text-faint">Loading match…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="match">
-      <div class="mb-8">
+      <div class="mb-6">
+        <div v-if="matchData" class="mb-2">
+          <router-link
+            :to="{ name: 'afl-round', params: { seasonId: props.seasonId, roundId: matchData.roundId } }"
+            class="text-sm text-text-muted hover:text-text transition-colors"
+          >
+            ← Back to round
+          </router-link>
+        </div>
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
           {{ match.homeClubMatch?.club.name ?? '—' }}
@@ -56,15 +64,17 @@ const managing = ref(false)
 
 const { result, loading, error } = useQuery(GET_MATCH, () => ({ seasonId: props.seasonId }))
 
-const match = computed(() => {
+const matchData = computed(() => {
   const season = result.value?.aflSeason
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return found
+    if (found) return { match: found, roundId: round.id as string }
   }
   return null
 })
+
+const match = computed(() => matchData.value?.match ?? null)
 
 const sides = computed(() => {
   if (!match.value) return []

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -3,7 +3,15 @@
     <div v-if="loading" class="text-text-faint">Loading match…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="match">
-      <div class="mb-8">
+      <div class="mb-6">
+        <div v-if="matchData" class="mb-2">
+          <router-link
+            :to="{ name: 'ffl-round', params: { seasonId: props.seasonId, roundId: matchData.roundId } }"
+            class="text-sm text-text-muted hover:text-text transition-colors"
+          >
+            ← Back to round
+          </router-link>
+        </div>
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
           {{ match.homeClubMatch?.club.name ?? '—' }}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 set dotenv-load := true
 
+log_level := env_var_or_default("LOG_LEVEL", "debug")
+
 # List available recipes
 default:
     @just --list
@@ -32,11 +34,11 @@ dev-logs:
 
 # Run AFL service (port 8080)
 run-afl:
-    cd services/afl && go run ./cmd/main.go
+    cd services/afl && LOG_LEVEL={{log_level}} go run ./cmd/main.go
 
 # Run FFL service (port 8081)
 run-ffl:
-    cd services/ffl && go run ./cmd/main.go
+    cd services/ffl && LOG_LEVEL={{log_level}} go run ./cmd/main.go
 
 # Run Search service (port 8082)
 run-search:
@@ -44,7 +46,7 @@ run-search:
 
 # Run Gateway (port 8090)
 run-gateway:
-    cd services/gateway && go run ./cmd/main.go
+    cd services/gateway && LOG_LEVEL={{log_level}} go run ./cmd/main.go
 
 # Install frontend dependencies (run once before first run-all)
 install-frontend:

--- a/services/afl/cmd/main.go
+++ b/services/afl/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -20,6 +20,10 @@ import (
 )
 
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevelFromEnv(),
+	})))
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
@@ -33,13 +37,14 @@ func main() {
 	ctx := context.Background()
 	pool, err := pg.NewPool(ctx, dbURL)
 	if err != nil {
-		log.Fatalf("unable to connect to database: %v", err)
+		slog.ErrorContext(ctx, "unable to connect to database", slog.Any("error", err))
+		os.Exit(1)
 	}
 	defer pool.Close()
 
 	q := sqlcgen.New(pool)
 
-	clk := clockFromEnv()
+	clk := clockFromEnv(ctx)
 
 	queries := application.NewQueries(
 		clk,
@@ -57,7 +62,7 @@ func main() {
 	dispatcher := pgevents.New(pool, "xffl_events")
 	go func() {
 		if err := dispatcher.Listen(ctx); err != nil {
-			log.Printf("AFL: event listener stopped: %v", err)
+			slog.ErrorContext(ctx, "AFL event listener stopped", slog.Any("error", err))
 		}
 	}()
 
@@ -75,21 +80,31 @@ func main() {
 	mux.Handle("/", playground.Handler("AFL", "/query"))
 	mux.Handle("/query", srv)
 
-	log.Printf("AFL service starting on :%s", port)
+	slog.InfoContext(ctx, "AFL service starting", slog.String("port", port))
 	if err := http.ListenAndServe(":"+port, mux); err != nil {
-		log.Fatal(err)
+		slog.ErrorContext(ctx, "AFL service failed", slog.Any("error", err))
+		os.Exit(1)
 	}
+}
+
+// logLevelFromEnv returns slog.LevelDebug if LOG_LEVEL=debug, otherwise LevelInfo.
+func logLevelFromEnv() slog.Level {
+	if os.Getenv("LOG_LEVEL") == "debug" {
+		return slog.LevelDebug
+	}
+	return slog.LevelInfo
 }
 
 // clockFromEnv returns a FixedClock if CLOCK_OVERRIDE is set (for e2e tests),
 // otherwise a RealClock.
-func clockFromEnv() clock.Clock {
+func clockFromEnv(ctx context.Context) clock.Clock {
 	if override := os.Getenv("CLOCK_OVERRIDE"); override != "" {
 		t, err := time.Parse(time.RFC3339, override)
 		if err != nil {
-			log.Fatalf("invalid CLOCK_OVERRIDE %q: %v", override, err)
+			slog.ErrorContext(ctx, "invalid CLOCK_OVERRIDE", slog.String("value", override), slog.Any("error", err))
+			os.Exit(1)
 		}
-		log.Printf("AFL: clock overridden to %s", t.Format(time.RFC3339))
+		slog.InfoContext(ctx, "AFL clock overridden", slog.String("time", t.Format(time.RFC3339)))
 		return clock.FixedClock{T: t}
 	}
 	return clock.RealClock{}

--- a/services/afl/internal/application/commands.go
+++ b/services/afl/internal/application/commands.go
@@ -3,7 +3,7 @@ package application
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 
 	"xffl/contracts/events"
 	"xffl/services/afl/internal/domain"
@@ -78,11 +78,11 @@ func (c *Commands) UpdatePlayerMatch(ctx context.Context, params domain.UpsertPl
 		Behinds:        result.Behinds,
 	})
 	if err != nil {
-		log.Printf("AFL: failed to marshal PlayerMatchUpdated event: %v", err)
+		slog.ErrorContext(ctx, "failed to marshal PlayerMatchUpdated event", slog.Any("error", err))
 		return result, nil
 	}
 	if err := c.dispatcher.Publish(ctx, events.PlayerMatchUpdated, payload); err != nil {
-		log.Printf("AFL: failed to publish PlayerMatchUpdated event: %v", err)
+		slog.ErrorContext(ctx, "failed to publish PlayerMatchUpdated event", slog.Any("error", err))
 	}
 
 	return result, nil

--- a/services/ffl/cmd/main.go
+++ b/services/ffl/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 
@@ -18,7 +18,19 @@ import (
 	pgevents "xffl/shared/events/pg"
 )
 
+// logLevelFromEnv returns slog.LevelDebug if LOG_LEVEL=debug, otherwise LevelInfo.
+func logLevelFromEnv() slog.Level {
+	if os.Getenv("LOG_LEVEL") == "debug" {
+		return slog.LevelDebug
+	}
+	return slog.LevelInfo
+}
+
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevelFromEnv(),
+	})))
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8081"
@@ -32,7 +44,8 @@ func main() {
 	ctx := context.Background()
 	pool, err := pg.NewPool(ctx, dbURL)
 	if err != nil {
-		log.Fatalf("unable to connect to database: %v", err)
+		slog.ErrorContext(ctx, "unable to connect to database", slog.Any("error", err))
+		os.Exit(1)
 	}
 	defer pool.Close()
 
@@ -62,7 +75,7 @@ func main() {
 	dispatcher.Subscribe(contractevents.PlayerMatchUpdated, commands.HandlePlayerMatchUpdated)
 	go func() {
 		if err := dispatcher.Listen(ctx); err != nil {
-			log.Printf("FFL: event listener stopped: %v", err)
+			slog.ErrorContext(ctx, "FFL event listener stopped", slog.Any("error", err))
 		}
 	}()
 
@@ -77,8 +90,9 @@ func main() {
 	mux.Handle("/", playground.Handler("FFL", "/query"))
 	mux.Handle("/query", srv)
 
-	log.Printf("FFL service starting on :%s", port)
+	slog.InfoContext(ctx, "FFL service starting", slog.String("port", port))
 	if err := http.ListenAndServe(":"+port, mux); err != nil {
-		log.Fatal(err)
+		slog.ErrorContext(ctx, "FFL service failed", slog.Any("error", err))
+		os.Exit(1)
 	}
 }

--- a/services/ffl/internal/application/commands.go
+++ b/services/ffl/internal/application/commands.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"xffl/contracts/events"
 	"xffl/services/ffl/internal/domain"
@@ -224,10 +224,16 @@ func (c *Commands) HandlePlayerMatchUpdated(ctx context.Context, payload []byte)
 		return fmt.Errorf("unmarshal PlayerMatchUpdated: %w", err)
 	}
 
+	slog.DebugContext(ctx, "event received",
+		slog.String("event_type", events.PlayerMatchUpdated),
+		slog.Int("player_match_id", event.PlayerMatchID),
+		slog.Int("player_season_id", event.PlayerSeasonID),
+		slog.Int("round_id", event.RoundID),
+	)
+
 	// Find the FFL round that corresponds to this AFL round.
 	fflRound, err := c.eventRepos.Rounds.FindByAFLRoundID(ctx, event.RoundID)
 	if err != nil {
-		log.Printf("FFL: no round for AFL round %d, skipping", event.RoundID)
 		return nil
 	}
 
@@ -253,21 +259,21 @@ func (c *Commands) HandlePlayerMatchUpdated(ctx context.Context, payload []byte)
 		// Find the FFL player match for this player season in the matching round.
 		pm, err := c.eventRepos.PlayerMatches.FindByPlayerSeasonAndRound(ctx, ps.ID, fflRound.ID)
 		if err != nil {
-			log.Printf("FFL: no player_match for player_season %d in round %d, skipping", ps.ID, fflRound.ID)
+			slog.DebugContext(ctx, "no player_match for player_season in round, skipping", slog.Int("player_season_id", ps.ID), slog.Int("round_id", fflRound.ID))
 			continue
 		}
 
 		// Link to the AFL player match if not already set.
 		if pm.AFLPlayerMatchID == nil {
 			if err := c.eventRepos.PlayerMatches.UpdateAFLPlayerMatchID(ctx, pm.ID, event.PlayerMatchID); err != nil {
-				log.Printf("FFL: failed to set afl_player_match_id on player_match %d: %v", pm.ID, err)
+				slog.ErrorContext(ctx, "failed to set afl_player_match_id on player_match", slog.Int("player_match_id", pm.ID), slog.Any("error", err))
 			}
 		}
 
 		// Calculate and store the fantasy score.
 		scored, err := c.CalculateFantasyScore(ctx, pm.ID, stats)
 		if err != nil {
-			log.Printf("FFL: failed to calculate score for player_match %d: %v", pm.ID, err)
+			slog.ErrorContext(ctx, "failed to calculate score for player_match", slog.Int("player_match_id", pm.ID), slog.Any("error", err))
 			continue
 		}
 
@@ -277,11 +283,11 @@ func (c *Commands) HandlePlayerMatchUpdated(ctx context.Context, payload []byte)
 			Score:         scored.Score,
 		})
 		if err != nil {
-			log.Printf("FFL: failed to marshal FantasyScoreCalculated: %v", err)
+			slog.ErrorContext(ctx, "failed to marshal FantasyScoreCalculated event", slog.Any("error", err))
 			continue
 		}
 		if err := c.dispatcher.Publish(ctx, events.FantasyScoreCalculated, fflPayload); err != nil {
-			log.Printf("FFL: failed to publish FantasyScoreCalculated: %v", err)
+			slog.ErrorContext(ctx, "failed to publish FantasyScoreCalculated event", slog.Any("error", err))
 		}
 	}
 

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -1,15 +1,28 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 )
 
+// logLevelFromEnv returns slog.LevelDebug if LOG_LEVEL=debug, otherwise LevelInfo.
+func logLevelFromEnv() slog.Level {
+	if os.Getenv("LOG_LEVEL") == "debug" {
+		return slog.LevelDebug
+	}
+	return slog.LevelInfo
+}
+
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevelFromEnv(),
+	})))
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8090"
@@ -30,15 +43,18 @@ func main() {
 		corsOrigin = "http://localhost:3000"
 	}
 
+	ctx := context.Background()
 	aflTarget, err := url.Parse(aflURL)
 	if err != nil {
-		log.Fatalf("invalid AFL_SERVICE_URL: %v", err)
+		slog.ErrorContext(ctx, "invalid AFL_SERVICE_URL", slog.Any("error", err))
+		os.Exit(1)
 	}
 	aflProxy := httputil.NewSingleHostReverseProxy(aflTarget)
 
 	fflTarget, err := url.Parse(fflURL)
 	if err != nil {
-		log.Fatalf("invalid FFL_SERVICE_URL: %v", err)
+		slog.ErrorContext(ctx, "invalid FFL_SERVICE_URL", slog.Any("error", err))
+		os.Exit(1)
 	}
 	fflProxy := httputil.NewSingleHostReverseProxy(fflTarget)
 
@@ -74,8 +90,9 @@ func main() {
 		fflProxy.ServeHTTP(w, r)
 	}))
 
-	log.Printf("Gateway starting on :%s (AFL→%s, FFL→%s)", port, aflURL, fflURL)
+	slog.InfoContext(ctx, "gateway starting", slog.String("port", port), slog.String("afl_url", aflURL), slog.String("ffl_url", fflURL))
 	if err := http.ListenAndServe(":"+port, mux); err != nil {
-		log.Fatal(err)
+		slog.ErrorContext(ctx, "gateway failed", slog.Any("error", err))
+		os.Exit(1)
 	}
 }

--- a/shared/events/pg/dispatcher.go
+++ b/shared/events/pg/dispatcher.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -52,6 +52,8 @@ func (d *Dispatcher) Publish(ctx context.Context, eventType string, payload []by
 	if err != nil {
 		return fmt.Errorf("pg dispatch notify: %w", err)
 	}
+
+	slog.DebugContext(ctx, "event published", slog.String("event_type", eventType))
 	return nil
 }
 
@@ -88,7 +90,7 @@ func (d *Dispatcher) Listen(ctx context.Context) error {
 
 		var msg message
 		if err := json.Unmarshal([]byte(notification.Payload), &msg); err != nil {
-			log.Printf("pg dispatch: invalid message: %v", err)
+			slog.ErrorContext(ctx, "pg dispatch: invalid message", slog.Any("error", err))
 			continue
 		}
 
@@ -98,7 +100,7 @@ func (d *Dispatcher) Listen(ctx context.Context) error {
 
 		for _, h := range handlers {
 			if err := h(ctx, msg.Payload); err != nil {
-				log.Printf("pg dispatch: handler error for %s: %v", msg.Type, err)
+				slog.ErrorContext(ctx, "pg dispatch: handler error", slog.String("event_type", msg.Type), slog.Any("error", err))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Replace stdlib `log` with `log/slog` (structured JSON) across AFL, FFL, gateway services and shared pg dispatcher
- `LOG_LEVEL` defaults to `debug` when running via `just run-*`; overridable via env or `.env`
- Add `← Back to round` link to AFL `MatchView`, AFL `AdminMatchView`, and FFL `MatchView`, consistent with team builder layout

## Test plan

- [ ] `just run-all` — confirm JSON log output in each terminal, debug messages visible
- [ ] Update a player match stat — confirm `event published` debug log in AFL, `event received` debug log in FFL
- [ ] Navigate to an AFL or FFL match — confirm "← Back to round" link appears and navigates correctly
- [ ] `LOG_LEVEL=info just run-afl` — confirm debug messages suppressed