### PR TITLE
Enrichment sprint: breadcrumbs, squad links, Team Builder UX, AFL round links

### DIFF
--- a/dev/postgres/seed/02_ffl_seed.sql
+++ b/dev/postgres/seed/02_ffl_seed.sql
@@ -46,7 +46,7 @@ SELECT ap.id, ap.name FROM afl.player ap WHERE ap.name IN (
 
 -- Round 1 (afl_round_id references the AFL round for the same week)
 INSERT INTO ffl.round (name, season_id, afl_round_id) VALUES
-    ('1', (SELECT id FROM ffl.season WHERE name = 'FFL 2026'),
+    ('Round 1', (SELECT id FROM ffl.season WHERE name = 'FFL 2026'),
      (SELECT r.id FROM afl.round r JOIN afl.season s ON r.season_id = s.id WHERE r.name = 'Round 1' AND s.name = 'AFL 2026'));
 
 -- Player seasons — Ruiboys (afl_player_season_id links to the AFL player's season entry)
@@ -57,7 +57,7 @@ FROM ffl.player p
 JOIN afl.player ap ON p.afl_player_id = ap.id
 JOIN ffl.club_season cs ON cs.club_id = (SELECT id FROM ffl.club WHERE name = 'Ruiboys')
 JOIN ffl.round r ON r.season_id = cs.season_id
-WHERE r.name = '1' AND ap.name IN ('Jordan Dawson', 'Wayne Milera');
+WHERE r.name = 'Round 1' AND ap.name IN ('Jordan Dawson', 'Wayne Milera');
 
 -- Player seasons — The Howling Cows (Henry Smith + Hugh McCluggage assigned to positions;
 -- remaining 6 are squad-only with no player_match, available in the team builder)
@@ -68,7 +68,7 @@ FROM ffl.player p
 JOIN afl.player ap ON p.afl_player_id = ap.id
 JOIN ffl.club_season cs ON cs.club_id = (SELECT id FROM ffl.club WHERE name = 'The Howling Cows')
 JOIN ffl.round r ON r.season_id = cs.season_id
-WHERE r.name = '1' AND ap.name IN (
+WHERE r.name = 'Round 1' AND ap.name IN (
     'Henry Smith', 'Hugh McCluggage'
 );
 
@@ -89,7 +89,7 @@ BEGIN
     -- Insert rounds 2–23 in order (19 = SUPERBYE, 23 = no matches yet)
     -- afl_round_id links each FFL round to its corresponding AFL round
     INSERT INTO ffl.round (name, season_id, afl_round_id)
-    SELECT n::text, v_season_id,
+    SELECT 'Round ' || n::text, v_season_id,
            (SELECT ar.id FROM afl.round ar JOIN afl.season s ON ar.season_id = s.id
             WHERE ar.name = 'Round ' || n::text AND s.name = 'AFL 2026')
     FROM generate_series(2, 23) AS n;
@@ -99,46 +99,46 @@ BEGIN
     -- Insert all matches (rounds 19 and 23 have none)
     FOR rec IN
         SELECT * FROM (VALUES
-            ('2',  '2026-03-19 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
-            ('2',  '2026-03-19 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
-            ('3',  '2026-03-26 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
-            ('3',  '2026-03-26 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
-            ('4',  '2026-04-02 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
-            ('4',  '2026-04-02 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
-            ('5',  '2026-04-09 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
-            ('5',  '2026-04-09 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
-            ('6',  '2026-04-16 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Ruiboys'),
-            ('6',  '2026-04-16 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Slashers'),
-            ('7',  '2026-04-23 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'The Howling Cows'),
-            ('7',  '2026-04-23 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Ruiboys'),
-            ('8',  '2026-04-30 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
-            ('8',  '2026-04-30 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
-            ('9',  '2026-05-07 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
-            ('9',  '2026-05-07 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
-            ('10', '2026-05-14 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
-            ('10', '2026-05-14 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
-            ('11', '2026-05-21 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
-            ('11', '2026-05-21 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
-            ('12', '2026-05-28 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Ruiboys'),
-            ('12', '2026-05-28 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Slashers'),
-            ('13', '2026-06-04 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'The Howling Cows'),
-            ('13', '2026-06-04 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Ruiboys'),
-            ('14', '2026-06-11 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
-            ('14', '2026-06-11 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
-            ('15', '2026-06-18 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
-            ('15', '2026-06-18 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
-            ('16', '2026-06-25 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
-            ('16', '2026-06-25 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
-            ('17', '2026-07-02 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
-            ('17', '2026-07-02 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
-            ('18', '2026-07-09 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
-            ('18', '2026-07-09 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
-            ('20', '2026-07-23 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
-            ('20', '2026-07-23 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
-            ('21', '2026-07-30 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
-            ('21', '2026-07-30 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
-            ('22', '2026-08-06 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Ruiboys'),
-            ('22', '2026-08-06 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Slashers')
+            ('Round 2',  '2026-03-19 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
+            ('Round 2',  '2026-03-19 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
+            ('Round 3',  '2026-03-26 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
+            ('Round 3',  '2026-03-26 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
+            ('Round 4',  '2026-04-02 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
+            ('Round 4',  '2026-04-02 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
+            ('Round 5',  '2026-04-09 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
+            ('Round 5',  '2026-04-09 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
+            ('Round 6',  '2026-04-16 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Ruiboys'),
+            ('Round 6',  '2026-04-16 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Slashers'),
+            ('Round 7',  '2026-04-23 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'The Howling Cows'),
+            ('Round 7',  '2026-04-23 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Ruiboys'),
+            ('Round 8',  '2026-04-30 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
+            ('Round 8',  '2026-04-30 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
+            ('Round 9',  '2026-05-07 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
+            ('Round 9',  '2026-05-07 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
+            ('Round 10', '2026-05-14 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
+            ('Round 10', '2026-05-14 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
+            ('Round 11', '2026-05-21 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
+            ('Round 11', '2026-05-21 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
+            ('Round 12', '2026-05-28 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Ruiboys'),
+            ('Round 12', '2026-05-28 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Slashers'),
+            ('Round 13', '2026-06-04 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'The Howling Cows'),
+            ('Round 13', '2026-06-04 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Ruiboys'),
+            ('Round 14', '2026-06-11 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Cheetahs'),
+            ('Round 14', '2026-06-11 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Slashers'),
+            ('Round 15', '2026-06-18 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
+            ('Round 15', '2026-06-18 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
+            ('Round 16', '2026-06-25 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
+            ('Round 17', '2026-07-02 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'Cheetahs'),
+            ('Round 18', '2026-07-09 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'The Howling Cows'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Rui Dome',      'Ruiboys',          'Slashers'),
+            ('Round 20', '2026-07-23 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Cheetahs'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'The Slash Pit', 'Slashers',         'The Howling Cows'),
+            ('Round 21', '2026-07-30 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Ruiboys'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Moo Meadow',    'The Howling Cows', 'Ruiboys'),
+            ('Round 22', '2026-08-06 00:00:00+00'::timestamptz, 'Savanna Park',  'Cheetahs',         'Slashers')
         ) AS t(round_name, start_dt, venue, home_club, away_club)
     LOOP
         INSERT INTO ffl.match (round_id, match_style, venue, start_dt)

--- a/frontend/web/e2e/admin-match-view.spec.ts
+++ b/frontend/web/e2e/admin-match-view.spec.ts
@@ -12,13 +12,14 @@ test.describe('Admin match view', () => {
     await page.goto(adminHref)
   })
 
-  test('displays admin label', async ({ page }) => {
-    await expect(page.getByText('Admin')).toBeVisible()
-  })
-
   test('displays match header with teams', async ({ page }) => {
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Adelaide Crows')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Brisbane Lions')
+  })
+
+  test('shows breadcrumb with AFL, season and round', async ({ page }) => {
+    await expect(page.locator('main').getByRole('link', { name: 'AFL 2026' })).toBeVisible()
+    await expect(page.locator('main').getByRole('link', { name: 'Round 1' })).toBeVisible()
   })
 
   test('stats are editable (has input fields)', async ({ page }) => {

--- a/frontend/web/e2e/ffl-home.spec.ts
+++ b/frontend/web/e2e/ffl-home.spec.ts
@@ -16,6 +16,16 @@ test.describe('FFL Home', () => {
     await expect(page.getByRole('cell', { name: 'The Howling Cows' })).toBeVisible()
   })
 
+  test('shows FFL breadcrumb on home page', async ({ page }) => {
+    await expect(page.locator('main').getByText('FFL', { exact: true })).toBeVisible()
+  })
+
+  test('club name in ladder links to squad page', async ({ page }) => {
+    await page.getByRole('link', { name: 'Ruiboys' }).first().click()
+    await page.waitForURL(/\/ffl\/seasons\/.*\/clubs\/.*\/squad/)
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Ruiboys')
+  })
+
   test('displays ladder with percentage column', async ({ page }) => {
     await expect(page.getByRole('columnheader', { name: '%' })).toBeVisible()
   })
@@ -25,14 +35,14 @@ test.describe('FFL Home', () => {
   })
 
   test('displays round selector with ladder icon and round circles', async ({ page }) => {
-    const roundNav = page.locator('main nav')
+    const roundNav = page.locator('main nav').last()
     await expect(roundNav).toBeVisible()
     await expect(roundNav.getByTitle('Ladder')).toBeVisible()
     await expect(roundNav.getByRole('link', { name: '1', exact: true })).toBeVisible()
   })
 
   test('round circle navigates to round page', async ({ page }) => {
-    await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
+    await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
     await page.waitForURL(/\/ffl\/seasons\/.*\/rounds\//)
     await page.waitForLoadState('networkidle')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
@@ -53,7 +63,7 @@ test.describe('FFL Home', () => {
   })
 
   test('round 3 has the open live-round ring indicator', async ({ page }) => {
-    const round3 = page.locator('main nav').getByRole('link', { name: '3', exact: true })
+    const round3 = page.locator('main nav').last().getByRole('link', { name: '3', exact: true })
     await expect(round3).toHaveClass(/ring-active/)
   })
 })

--- a/frontend/web/e2e/ffl-match.spec.ts
+++ b/frontend/web/e2e/ffl-match.spec.ts
@@ -2,10 +2,11 @@ import { test, expect } from '@playwright/test'
 
 test.describe('FFL Match', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate: FFL Home → Round 1 → match
+    // Navigate: FFL Home → Round 1 → match (match card is a div, not a link)
     await page.goto('/ffl')
     await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
-    await page.getByRole('link', { name: /Ruiboys.+v.+The Howling Cows/ }).click()
+    await page.locator('.cursor-pointer').filter({ hasText: 'Ruiboys' }).filter({ hasText: 'The Howling Cows' }).click()
+    await page.waitForURL(/\/ffl\/seasons\/.*\/matches\//)
   })
 
   test('displays match header with teams', async ({ page }) => {
@@ -40,13 +41,24 @@ test.describe('FFL Match', () => {
     await expect(page.getByText('Total').first()).toBeVisible()
   })
 
-  test('shows Build Team link in selected club column only', async ({ page }) => {
-    // Selected club is The Howling Cows — link should appear once (in their column)
-    await expect(page.getByRole('link', { name: 'Build Team →' })).toHaveCount(1)
+  test('shows Team Builder button in selected club column only', async ({ page }) => {
+    // Selected club is The Howling Cows — button should appear once (in their column)
+    await expect(page.getByTitle('Team Builder')).toHaveCount(1)
   })
 
-  test('Build Team link navigates to team builder', async ({ page }) => {
-    await page.getByRole('link', { name: 'Build Team →' }).click()
+  test('Team Builder button navigates to team builder', async ({ page }) => {
+    await page.getByTitle('Team Builder').click()
     await expect(page).toHaveURL(/\/ffl\/.*\/team-builder/)
+  })
+
+  test('shows breadcrumb with FFL, season and round', async ({ page }) => {
+    await expect(page.locator('main').getByRole('link', { name: 'FFL 2026' })).toBeVisible()
+    await expect(page.locator('main').getByRole('link', { name: 'Round 1' })).toBeVisible()
+  })
+
+  test('club name links to squad page', async ({ page }) => {
+    await page.locator('main').getByRole('link', { name: 'Ruiboys' }).first().click()
+    await page.waitForURL(/\/ffl\/seasons\/.*\/clubs\/.*\/squad/)
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Ruiboys')
   })
 })

--- a/frontend/web/e2e/ffl-round.spec.ts
+++ b/frontend/web/e2e/ffl-round.spec.ts
@@ -4,31 +4,33 @@ test.describe('FFL Round', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
     // Click round circle "1" in the round selector (main nav)
-    await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
+    await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
   })
 
-  test('displays round and season name inline in heading', async ({ page }) => {
-    const heading = page.getByRole('heading', { level: 1 })
-    await expect(heading).toContainText('Round 1')
-    await expect(heading).toContainText('FFL 2026')
+  test('displays round name in heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
+  })
+
+  test('displays season name in breadcrumb', async ({ page }) => {
+    await expect(page.locator('main').getByRole('link', { name: 'FFL 2026' })).toBeVisible()
   })
 
   test('displays round selector above matches', async ({ page }) => {
-    const roundNav = page.locator('main nav')
+    const roundNav = page.locator('main nav').last()
     await expect(roundNav).toBeVisible()
     await expect(roundNav.getByTitle('Ladder')).toBeVisible()
     await expect(roundNav.getByRole('link', { name: '1', exact: true })).toBeVisible()
   })
 
   test('ladder icon navigates back to home', async ({ page }) => {
-    await page.locator('main nav').getByTitle('Ladder').click()
+    await page.locator('main nav').last().getByTitle('Ladder').click()
     await expect(page).toHaveURL('/ffl')
   })
 
   test('displays match summaries', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Matches' })).toBeVisible()
-    const matchLink = page.getByRole('link', { name: /Ruiboys.+v.+The Howling Cows/ })
-    await expect(matchLink).toBeVisible()
+    const matchCard = page.locator('.cursor-pointer').filter({ hasText: 'Ruiboys' }).filter({ hasText: 'The Howling Cows' })
+    await expect(matchCard).toBeVisible()
   })
 
   test('displays top fantasy scorers', async ({ page }) => {
@@ -37,17 +39,17 @@ test.describe('FFL Round', () => {
     await expect(page.getByRole('columnheader', { name: 'Score' })).toBeVisible()
   })
 
-  test('shows Build Team link for selected club match', async ({ page }) => {
-    await expect(page.getByRole('link', { name: 'Build Team →' })).toBeVisible()
+  test('shows Team Builder button for selected club match', async ({ page }) => {
+    await expect(page.getByTitle('Team Builder')).toBeVisible()
   })
 
-  test('Build Team link navigates to team builder', async ({ page }) => {
-    await page.getByRole('link', { name: 'Build Team →' }).click()
+  test('Team Builder button navigates to team builder', async ({ page }) => {
+    await page.getByTitle('Team Builder').click()
     await expect(page).toHaveURL(/\/ffl\/.*\/team-builder/)
   })
 
   test('rounds display in numeric order', async ({ page }) => {
-    const roundLinks = await page.locator('main nav').getByRole('link').allTextContents()
+    const roundLinks = await page.locator('main nav').last().getByRole('link').allTextContents()
     const roundNumbers = roundLinks.map(t => parseInt(t.trim())).filter(n => !isNaN(n))
     expect(roundNumbers).toEqual([...roundNumbers].sort((a, b) => a - b))
   })

--- a/frontend/web/e2e/ffl-squad.spec.ts
+++ b/frontend/web/e2e/ffl-squad.spec.ts
@@ -5,7 +5,7 @@ test.describe('FFL Squad', () => {
   test.beforeEach(async ({ page }) => {
     await setupFflSession(page)
     await page.getByRole('link', { name: 'Squad' }).click()
-    await page.waitForURL(/\/ffl\/seasons\/.*\/squad/)
+    await page.waitForURL(/\/ffl\/seasons\/.*\/clubs\/.*\/squad/)
     await page.waitForLoadState('networkidle')
   })
 
@@ -13,8 +13,9 @@ test.describe('FFL Squad', () => {
     await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
   })
 
-  test('displays season name in subheading', async ({ page }) => {
-    await expect(page.getByText(/FFL 2026 Squad/)).toBeVisible()
+  test('shows breadcrumb with FFL, season and club name', async ({ page }) => {
+    await expect(page.locator('main').getByRole('link', { name: 'FFL 2026' })).toBeVisible()
+    await expect(page.locator('main').getByText('The Howling Cows', { exact: true }).first()).toBeVisible()
   })
 
   test('displays player list', async ({ page }) => {
@@ -58,7 +59,7 @@ test.describe('FFL Squad', () => {
     await expect(page.getByText('Jordan Dawson')).toBeVisible()
   })
 
-  test('switching club exits manage mode', async ({ page }) => {
+  test('switching to a different club hides Manage button', async ({ page }) => {
     await page.getByRole('button', { name: 'Manage' }).click()
     await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
 
@@ -66,7 +67,17 @@ test.describe('FFL Squad', () => {
     await page.getByRole('button', { name: /The Howling Cows|Ruiboys/ }).click()
     await page.getByRole('button', { name: /Ruiboys/ }).click()
 
-    await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+    // Page still shows The Howling Cows squad, but Manage is hidden (not the selected club)
+    await expect(page.getByRole('button', { name: 'Manage' })).not.toBeVisible()
     await expect(page.getByRole('button', { name: 'Done' })).not.toBeVisible()
+  })
+
+  test('Manage button hidden when viewing another club squad', async ({ page }) => {
+    // Navigate to Ruiboys squad while The Howling Cows is selected
+    await page.goto('/ffl')
+    await page.locator('main').getByRole('link', { name: 'Ruiboys' }).first().click()
+    await page.waitForURL(/\/ffl\/seasons\/.*\/clubs\/.*\/squad/)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('button', { name: 'Manage' })).not.toBeVisible()
   })
 })

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -3,8 +3,8 @@ import { test, expect } from '@playwright/test'
 // Helpers
 async function goToTeamBuilder(page: import('@playwright/test').Page) {
   await page.goto('/ffl')
-  await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
-  await page.getByRole('link', { name: 'Build Team →' }).click()
+  await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+  await page.getByTitle('Team Builder').click()
   await page.waitForURL(/\/ffl\/.*\/team-builder/)
 }
 
@@ -311,12 +311,16 @@ test.describe('FFL Team Builder', () => {
       await goToTeamBuilder(page)
     })
 
-    test('shows round name in heading', async ({ page }) => {
-      await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
-    })
-
     test('shows club name in heading', async ({ page }) => {
       await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
+    })
+
+    test('shows round name in breadcrumb', async ({ page }) => {
+      await expect(page.locator('main').getByRole('link', { name: 'Round 1' })).toBeVisible()
+    })
+
+    test('shows season name in breadcrumb', async ({ page }) => {
+      await expect(page.locator('main').getByRole('link', { name: 'FFL 2026' })).toBeVisible()
     })
   })
 

--- a/frontend/web/e2e/home-view.spec.ts
+++ b/frontend/web/e2e/home-view.spec.ts
@@ -20,14 +20,14 @@ test.describe('AFL Home view', () => {
   })
 
   test('displays round selector with ladder icon and round circles', async ({ page }) => {
-    const roundNav = page.locator('main nav')
+    const roundNav = page.locator('main nav').last()
     await expect(roundNav).toBeVisible()
     await expect(roundNav.getByTitle('Ladder')).toBeVisible()
     await expect(roundNav.getByRole('link', { name: '1', exact: true })).toBeVisible()
   })
 
   test('round circle navigates to round page', async ({ page }) => {
-    await page.locator('main nav').getByRole('link', { name: '1', exact: true }).click()
+    await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Round 1')
   })
 
@@ -42,7 +42,7 @@ test.describe('AFL Home view', () => {
   })
 
   test('round 3 has the open live-round ring indicator', async ({ page }) => {
-    const round3 = page.locator('main nav').getByRole('link', { name: '3', exact: true })
+    const round3 = page.locator('main nav').last().getByRole('link', { name: '3', exact: true })
     await expect(round3).toHaveClass(/ring-active/)
   })
 })

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -18,9 +18,9 @@
           <!-- Squad + Team Builder (always visible on FFL pages once season is known) -->
           <template v-if="isFfl">
             <router-link
-              :to="liveSeasonId ? { name: 'ffl-squad', params: { seasonId: liveSeasonId } } : '/ffl'"
+              :to="liveSeasonId && selectedClubId ? { name: 'ffl-squad', params: { seasonId: liveSeasonId, clubId: selectedClubId } } : '/ffl'"
               class="text-sm transition-colors"
-              :class="liveSeasonId ? 'text-text-muted hover:text-text' : 'text-text-faint pointer-events-none'"
+              :class="liveSeasonId && selectedClubId ? 'text-text-muted hover:text-text' : 'text-text-faint pointer-events-none'"
             >
               Squad
             </router-link>

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -28,7 +28,7 @@ const router = createRouter({
       props: true,
     },
     {
-      path: '/ffl/seasons/:seasonId/squad',
+      path: '/ffl/seasons/:seasonId/clubs/:clubId/squad',
       name: 'ffl-squad',
       component: () => import('@/features/ffl/views/SquadView.vue'),
       props: true,

--- a/frontend/web/src/features/afl/api/queries.ts
+++ b/frontend/web/src/features/afl/api/queries.ts
@@ -119,6 +119,7 @@ export const GET_MATCH = gql`
   query GetMatch($seasonId: ID!) {
     aflSeason(id: $seasonId) {
       id
+      name
       rounds {
         id
         name

--- a/frontend/web/src/features/afl/components/Breadcrumb.vue
+++ b/frontend/web/src/features/afl/components/Breadcrumb.vue
@@ -1,0 +1,24 @@
+<template>
+  <nav class="flex items-center gap-1.5 text-sm mb-1">
+    <template v-for="(item, i) in items" :key="i">
+      <span v-if="i > 0" class="text-text-faint select-none">›</span>
+      <router-link
+        v-if="item.to"
+        :to="item.to"
+        class="text-text-muted hover:text-text transition-colors"
+      >{{ item.label }}</router-link>
+      <span v-else-if="i === items.length - 1 && items.length > 1" class="font-semibold text-text">
+        {{ item.label }}<span v-if="item.sub" class="font-normal text-text-faint"> · {{ item.sub }}</span>
+      </span>
+      <span v-else class="text-text-muted">{{ item.label }}</span>
+    </template>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
+
+defineProps<{
+  items: Array<{ label: string; to?: RouteLocationRaw; sub?: string }>
+}>()
+</script>

--- a/frontend/web/src/features/afl/views/AdminMatchView.vue
+++ b/frontend/web/src/features/afl/views/AdminMatchView.vue
@@ -4,15 +4,7 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="match">
       <div class="mb-6">
-        <div v-if="matchData" class="mb-2">
-          <router-link
-            :to="{ name: 'afl-round', params: { seasonId: props.seasonId, roundId: matchData.roundId } }"
-            class="text-sm text-text-muted hover:text-text transition-colors"
-          >
-            ← Back to round
-          </router-link>
-        </div>
-        <p class="text-sm text-text-muted mb-1">Admin</p>
+        <Breadcrumb v-if="matchData" :items="breadcrumbs" />
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
           {{ match.homeClubMatch?.club.name ?? '—' }}
@@ -44,6 +36,7 @@ import { computed } from 'vue'
 import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_MATCH } from '../api/queries'
 import { UPDATE_PLAYER_MATCH } from '../api/mutations'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import PlayerStatsTable from '../components/PlayerStatsTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
 
@@ -56,9 +49,18 @@ const matchData = computed(() => {
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return { match: found, roundId: round.id as string }
+    if (found) return { match: found, roundId: round.id as string, roundName: round.name as string, seasonName: season.name as string }
   }
   return null
+})
+
+const breadcrumbs = computed(() => {
+  if (!matchData.value) return []
+  return [
+    { label: 'AFL' },
+    { label: matchData.value.seasonName, to: { name: 'afl-home' } },
+    { label: matchData.value.roundName, to: { name: 'afl-round', params: { seasonId: props.seasonId, roundId: matchData.value.roundId } } },
+  ]
 })
 
 const match = computed(() => matchData.value?.match ?? null)

--- a/frontend/web/src/features/afl/views/HomeView.vue
+++ b/frontend/web/src/features/afl/views/HomeView.vue
@@ -3,7 +3,8 @@
     <div v-if="loading" class="text-text-faint">Loading…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
-      <h1 class="text-2xl font-bold mb-4">Home<span class="font-normal text-text-muted"> · {{ data.season.name }}</span></h1>
+      <Breadcrumb :items="[{ label: 'AFL' }]" />
+      <h1 class="text-2xl font-bold mb-6">{{ data.season.name }}</h1>
 
       <RoundNav
         class="mb-8"
@@ -25,6 +26,7 @@ import { computed, watch } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_AFL_LIVE_ROUND } from '../api/queries'
 import { useAflState } from '../composables/useAflState'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import LadderTable from '../components/LadderTable.vue'
 import RoundNav from '../components/RoundNav.vue'
 

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -4,14 +4,7 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="match">
       <div class="mb-6">
-        <div v-if="matchData" class="mb-2">
-          <router-link
-            :to="{ name: 'afl-round', params: { seasonId: props.seasonId, roundId: matchData.roundId } }"
-            class="text-sm text-text-muted hover:text-text transition-colors"
-          >
-            ← Back to round
-          </router-link>
-        </div>
+        <Breadcrumb v-if="matchData" :items="breadcrumbs" />
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
           {{ match.homeClubMatch?.club.name ?? '—' }}
@@ -55,6 +48,7 @@ import { ref, computed } from 'vue'
 import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_MATCH } from '../api/queries'
 import { UPDATE_PLAYER_MATCH } from '../api/mutations'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import PlayerStatsTable from '../components/PlayerStatsTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
 
@@ -69,9 +63,18 @@ const matchData = computed(() => {
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return { match: found, roundId: round.id as string }
+    if (found) return { match: found, roundId: round.id as string, roundName: round.name as string, seasonName: season.name as string }
   }
   return null
+})
+
+const breadcrumbs = computed(() => {
+  if (!matchData.value) return []
+  return [
+    { label: 'AFL' },
+    { label: matchData.value.seasonName, to: { name: 'afl-home' } },
+    { label: matchData.value.roundName, to: { name: 'afl-round', params: { seasonId: props.seasonId, roundId: matchData.value.roundId } } },
+  ]
 })
 
 const match = computed(() => matchData.value?.match ?? null)

--- a/frontend/web/src/features/afl/views/RoundView.vue
+++ b/frontend/web/src/features/afl/views/RoundView.vue
@@ -3,8 +3,9 @@
     <div v-if="loading" class="text-text-faint">Loading…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
-      <h1 class="text-2xl font-bold mb-4">
-        {{ data.round.name }}<span class="font-normal text-text-muted"> · {{ data.season.name }}</span>
+      <Breadcrumb :items="[{ label: 'AFL' }, { label: data.season.name, to: { name: 'afl-home' } }]" />
+      <h1 class="text-2xl font-bold mb-6">
+        {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
       </h1>
 
       <RoundNav
@@ -47,6 +48,7 @@ import { computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_ROUND } from '../api/queries'
 import { useAflState } from '../composables/useAflState'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import RoundNav from '../components/RoundNav.vue'
 import TopPlayers from '../components/TopPlayers.vue'
@@ -93,6 +95,20 @@ interface Match {
   homeClubMatch?: ClubMatch | null
   awayClubMatch?: ClubMatch | null
 }
+
+const roundStartDate = computed(() => {
+  if (!data.value) return null
+  const times = data.value.round.matches
+    .map((m: { startTime?: string | null }) => m.startTime)
+    .filter((t): t is string => !!t)
+    .map(t => new Date(t))
+  if (!times.length) return null
+  const earliest = new Date(Math.min(...times.map(t => t.getTime())))
+  const day = earliest.getDate()
+  const month = earliest.toLocaleDateString('en-AU', { month: 'short' })
+  const year = String(earliest.getFullYear()).slice(-2)
+  return `${day} ${month} '${year}`
+})
 
 const topPlayerStats = computed(() => {
   if (!data.value) return []

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -158,6 +158,7 @@ export const GET_FFL_SEASON = gql`
       rounds {
         id
         name
+        aflRoundId
         matches {
           id
           venue

--- a/frontend/web/src/features/ffl/components/Breadcrumb.vue
+++ b/frontend/web/src/features/ffl/components/Breadcrumb.vue
@@ -1,0 +1,24 @@
+<template>
+  <nav class="flex items-center gap-1.5 text-sm mb-1">
+    <template v-for="(item, i) in items" :key="i">
+      <span v-if="i > 0" class="text-text-faint select-none">›</span>
+      <router-link
+        v-if="item.to"
+        :to="item.to"
+        class="text-text-muted hover:text-text transition-colors"
+      >{{ item.label }}</router-link>
+      <span v-else-if="i === items.length - 1 && items.length > 1" class="font-semibold text-text">
+        {{ item.label }}<span v-if="item.sub" class="font-normal text-text-faint"> · {{ item.sub }}</span>
+      </span>
+      <span v-else class="text-text-muted">{{ item.label }}</span>
+    </template>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
+
+defineProps<{
+  items: Array<{ label: string; to?: RouteLocationRaw; sub?: string }>
+}>()
+</script>

--- a/frontend/web/src/features/ffl/components/LadderTable.vue
+++ b/frontend/web/src/features/ffl/components/LadderTable.vue
@@ -22,10 +22,13 @@
         >
           <td class="py-2 pr-4 tabular-nums text-text-faint">{{ index + 1 }}</td>
           <td class="py-2 pr-4 font-medium">
-            <div class="flex items-center gap-2">
+            <router-link
+              :to="{ name: 'ffl-squad', params: { seasonId, clubId: entry.club.id } }"
+              class="flex items-center gap-2 hover:text-active transition-colors"
+            >
               <img :src="clubLogoUrl(entry.club.name)" :alt="entry.club.name" class="w-6 h-6 object-contain" />
               {{ entry.club.name }}
-            </div>
+            </router-link>
           </td>
           <td class="py-2 px-2 text-right tabular-nums">{{ entry.played }}</td>
           <td class="py-2 px-2 text-right tabular-nums">{{ entry.won }}</td>
@@ -55,5 +58,5 @@ interface LadderEntry {
   percentage: number
 }
 
-defineProps<{ ladder: LadderEntry[] }>()
+defineProps<{ ladder: LadderEntry[]; seasonId: string }>()
 </script>

--- a/frontend/web/src/features/ffl/components/MatchSummary.vue
+++ b/frontend/web/src/features/ffl/components/MatchSummary.vue
@@ -1,27 +1,45 @@
 <template>
-  <router-link
-    :to="to"
-    class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-3 hover:border-border-strong transition-colors"
+  <div
+    class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-3 hover:border-border-strong transition-colors cursor-pointer"
+    @click="router.push(to)"
   >
     <div class="flex items-center gap-3 font-medium">
       <img v-if="homeLogo" :src="homeLogo" :alt="match.homeClubMatch?.club.name" class="w-8 h-8 object-contain" />
-      <span :class="{ 'font-bold': winner === 'home' }">
-        {{ match.homeClubMatch?.club.name ?? '—' }}
-      </span>
+      <span :class="{ 'font-bold': winner === 'home' }">{{ match.homeClubMatch?.club.name ?? '—' }}</span>
+      <button
+        v-if="buildTeamTo && myClubSide === 'home'"
+        @click.stop="router.push(buildTeamTo)"
+        title="Team Builder"
+        class="rounded p-1 text-active hover:bg-active/10 transition-colors"
+      >
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z"/>
+        </svg>
+      </button>
       <span class="text-text-faint">v</span>
       <img v-if="awayLogo" :src="awayLogo" :alt="match.awayClubMatch?.club.name" class="w-8 h-8 object-contain" />
-      <span :class="{ 'font-bold': winner === 'away' }">
-        {{ match.awayClubMatch?.club.name ?? '—' }}
-      </span>
+      <span :class="{ 'font-bold': winner === 'away' }">{{ match.awayClubMatch?.club.name ?? '—' }}</span>
+      <button
+        v-if="buildTeamTo && myClubSide === 'away'"
+        @click.stop="router.push(buildTeamTo)"
+        title="Team Builder"
+        class="rounded p-1 text-active hover:bg-active/10 transition-colors"
+      >
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z"/>
+        </svg>
+      </button>
     </div>
     <span v-if="match.result" class="text-sm tabular-nums text-text-muted font-semibold">
       {{ match.homeClubMatch?.score }} – {{ match.awayClubMatch?.score }}
     </span>
-  </router-link>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
 import { clubLogoUrl } from '../utils/clubLogos'
 
 interface ClubMatch {
@@ -39,8 +57,12 @@ interface Match {
 
 const props = defineProps<{
   match: Match
-  to: { name: string; params: Record<string, string> }
+  to: RouteLocationRaw
+  myClubId?: string
+  buildTeamTo?: RouteLocationRaw
 }>()
+
+const router = useRouter()
 
 const homeLogo = computed(() => props.match.homeClubMatch ? clubLogoUrl(props.match.homeClubMatch.club.name) : '')
 const awayLogo = computed(() => props.match.awayClubMatch ? clubLogoUrl(props.match.awayClubMatch.club.name) : '')
@@ -49,6 +71,13 @@ const winner = computed(() => {
   if (!props.match.result) return null
   if (props.match.result === 'home_win') return 'home'
   if (props.match.result === 'away_win') return 'away'
+  return null
+})
+
+const myClubSide = computed(() => {
+  if (!props.myClubId) return null
+  if (props.match.homeClubMatch?.club.id === props.myClubId) return 'home'
+  if (props.match.awayClubMatch?.club.id === props.myClubId) return 'away'
   return null
 })
 </script>

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -19,7 +19,7 @@
 
       <section>
         <h2 class="text-lg font-semibold text-text-heading mb-3">Ladder</h2>
-        <LadderTable :ladder="fflRound.season.ladder" />
+        <LadderTable :ladder="fflRound.season.ladder" :season-id="fflRound.season.id" />
       </section>
     </template>
   </div>

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -7,7 +7,8 @@
       Cannot determine round to display. Consult your admin.
     </div>
     <template v-else-if="fflRound">
-      <h1 class="text-2xl font-bold mb-4">Home<span class="font-normal text-text-muted"> · {{ fflRound.season.name }}</span></h1>
+      <Breadcrumb :items="[{ label: 'FFL' }]" />
+      <h1 class="text-2xl font-bold mb-6">{{ fflRound.season.name }}</h1>
 
       <RoundNav
         class="mb-8"
@@ -29,6 +30,7 @@ import { computed, watch } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_AFL_LIVE_ROUND, GET_FFL_ROUND_BY_AFL_ROUND } from '../api/queries'
 import { useFflState } from '../composables/useFflState'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import LadderTable from '../components/LadderTable.vue'
 import RoundNav from '../components/RoundNav.vue'
 

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -22,7 +22,14 @@
         <div v-for="side in sides" :key="side.label">
           <div class="flex items-center gap-2 mb-1">
             <img v-if="side.clubMatch" :src="clubLogoUrl(side.clubMatch.club.name)" :alt="side.clubMatch.club.name" class="w-8 h-8 object-contain" />
-            <h2 class="text-lg font-semibold">{{ side.label }}</h2>
+            <h2 class="text-lg font-semibold">
+              <router-link
+                v-if="side.clubMatch"
+                :to="{ name: 'ffl-squad', params: { seasonId: props.seasonId, clubId: side.clubMatch.club.id } }"
+                class="hover:text-active transition-colors"
+              >{{ side.label }}</router-link>
+              <span v-else>{{ side.label }}</span>
+            </h2>
             <router-link
               v-if="isMyClubMatch && side.clubMatch?.club.id === selectedClubId"
               :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: matchData!.roundId } }"

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -47,6 +47,12 @@
           <SquadTable v-if="side.clubMatch" :player-matches="side.clubMatch.playerMatches" />
         </div>
       </div>
+
+      <div v-if="aflRoundTo" class="mt-8">
+        <router-link :to="aflRoundTo" class="text-sm text-text-muted hover:text-text transition-colors">
+          AFL Round ↗
+        </router-link>
+      </div>
     </template>
   </div>
 </template>
@@ -59,10 +65,12 @@ import Breadcrumb from '../components/Breadcrumb.vue'
 import SquadTable from '../components/SquadTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
 import { useFflState } from '../composables/useFflState'
+import { useAflState } from '../../afl/composables/useAflState'
 
 const props = defineProps<{ seasonId: string; matchId: string }>()
 
 const { selectedClubId } = useFflState()
+const { liveSeasonId: aflSeasonId } = useAflState()
 const { result, loading, error } = useQuery(GET_FFL_SEASON, () => ({ id: props.seasonId }))
 
 const matchData = computed(() => {
@@ -70,7 +78,7 @@ const matchData = computed(() => {
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return { match: found, roundId: round.id as string, roundName: round.name as string, seasonName: season.name as string }
+    if (found) return { match: found, roundId: round.id as string, roundName: round.name as string, seasonName: season.name as string, aflRoundId: round.aflRoundId as string | null }
   }
   return null
 })
@@ -90,6 +98,12 @@ const isMyClubMatch = computed(() => {
   if (!match.value || !selectedClubId.value) return false
   return match.value.homeClubMatch?.club.id === selectedClubId.value ||
     match.value.awayClubMatch?.club.id === selectedClubId.value
+})
+
+const aflRoundTo = computed(() => {
+  const aflRoundId = matchData.value?.aflRoundId
+  if (!aflRoundId || !aflSeasonId.value) return null
+  return { name: 'afl-round', params: { seasonId: aflSeasonId.value, roundId: aflRoundId } }
 })
 
 const sides = computed(() => {

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -4,14 +4,7 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="match">
       <div class="mb-6">
-        <div v-if="matchData" class="mb-2">
-          <router-link
-            :to="{ name: 'ffl-round', params: { seasonId: props.seasonId, roundId: matchData.roundId } }"
-            class="text-sm text-text-muted hover:text-text transition-colors"
-          >
-            ← Back to round
-          </router-link>
-        </div>
+        <Breadcrumb v-if="matchData" :items="breadcrumbs" />
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
           {{ match.homeClubMatch?.club.name ?? '—' }}
@@ -51,6 +44,7 @@
 import { computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON } from '../api/queries'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import SquadTable from '../components/SquadTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
 import { useFflState } from '../composables/useFflState'
@@ -65,9 +59,18 @@ const matchData = computed(() => {
   if (!season) return null
   for (const round of season.rounds) {
     const found = round.matches.find((m: { id: string }) => m.id === props.matchId)
-    if (found) return { match: found, roundId: round.id as string }
+    if (found) return { match: found, roundId: round.id as string, roundName: round.name as string, seasonName: season.name as string }
   }
   return null
+})
+
+const breadcrumbs = computed(() => {
+  if (!matchData.value) return []
+  return [
+    { label: 'FFL' },
+    { label: matchData.value.seasonName, to: { name: 'home' } },
+    { label: matchData.value.roundName, to: { name: 'ffl-round', params: { seasonId: props.seasonId, roundId: matchData.value.roundId } } },
+  ]
 })
 
 const match = computed(() => matchData.value?.match ?? null)

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -20,14 +20,18 @@
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div v-for="side in sides" :key="side.label">
-          <div class="flex items-center justify-between mb-1">
+          <div class="flex items-center gap-2 mb-1">
+            <img v-if="side.clubMatch" :src="clubLogoUrl(side.clubMatch.club.name)" :alt="side.clubMatch.club.name" class="w-8 h-8 object-contain" />
             <h2 class="text-lg font-semibold">{{ side.label }}</h2>
             <router-link
               v-if="isMyClubMatch && side.clubMatch?.club.id === selectedClubId"
               :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: matchData!.roundId } }"
-              class="text-xs text-active hover:text-active-hover transition-colors"
+              title="Team Builder"
+              class="rounded p-1 text-active hover:bg-active/10 transition-colors"
             >
-              Build Team →
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z"/>
+              </svg>
             </router-link>
           </div>
           <p class="text-sm text-text-muted mb-3">

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -3,8 +3,10 @@
     <div v-if="loading" class="text-text-faint">Loading…</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
-      <h1 class="text-2xl font-bold mb-4">
-        {{ data.round.name }}<span class="font-normal text-text-muted"> · {{ data.season.name }}</span>
+      <Breadcrumb :items="breadcrumbs" />
+
+      <h1 class="text-2xl font-bold mb-6">
+        Round {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
       </h1>
 
       <RoundNav
@@ -72,6 +74,7 @@ import { computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON } from '../api/queries'
 import { useFflState } from '../composables/useFflState'
+import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import RoundNav from '../components/RoundNav.vue'
 
@@ -86,6 +89,28 @@ const data = computed(() => {
   const round = season.rounds.find((r: { id: string }) => r.id === props.roundId)
   if (!round) return null
   return { season, round }
+})
+
+const roundStartDate = computed(() => {
+  if (!data.value) return null
+  const times = data.value.round.matches
+    .map((m: { startTime?: string | null }) => m.startTime)
+    .filter((t): t is string => !!t)
+    .map(t => new Date(t))
+  if (!times.length) return null
+  const earliest = new Date(Math.min(...times.map(t => t.getTime())))
+  const day = earliest.getDate()
+  const month = earliest.toLocaleDateString('en-AU', { month: 'short' })
+  const year = String(earliest.getFullYear()).slice(-2)
+  return `${day} ${month} '${year}`
+})
+
+const breadcrumbs = computed(() => {
+  if (!data.value) return []
+  return [
+    { label: 'FFL' },
+    { label: data.value.season.name, to: { name: 'home' } },
+  ]
 })
 
 const myMatch = computed(() => {

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -6,7 +6,7 @@
       <Breadcrumb :items="breadcrumbs" />
 
       <h1 class="text-2xl font-bold mb-6">
-        Round {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
+        {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
       </h1>
 
       <RoundNav

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -19,19 +19,14 @@
       <section class="mb-8">
         <h2 class="text-lg font-semibold text-text-heading mb-3">Matches</h2>
         <div class="space-y-2">
-          <div v-for="match in data.round.matches" :key="match.id">
-            <MatchSummary
-              :match="match"
-              :to="{ name: 'ffl-match', params: { seasonId: props.seasonId, matchId: match.id } }"
-            />
-            <router-link
-              v-if="myMatch?.id === match.id"
-              :to="{ name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: props.roundId } }"
-              class="mt-1 flex items-center justify-end text-xs text-active hover:text-active-hover transition-colors"
-            >
-              Build Team →
-            </router-link>
-          </div>
+          <MatchSummary
+            v-for="match in data.round.matches"
+            :key="match.id"
+            :match="match"
+            :to="{ name: 'ffl-match', params: { seasonId: props.seasonId, matchId: match.id } }"
+            :my-club-id="selectedClubId ?? undefined"
+            :build-team-to="myMatch?.id === match.id ? { name: 'ffl-team-builder', params: { seasonId: props.seasonId, roundId: props.roundId } } : undefined"
+          />
         </div>
       </section>
 
@@ -93,12 +88,12 @@ const data = computed(() => {
 
 const roundStartDate = computed(() => {
   if (!data.value) return null
-  const times = data.value.round.matches
-    .map((m: { startTime?: string | null }) => m.startTime)
+  const times = (data.value.round.matches as Array<{ startTime?: string | null }>)
+    .map(m => m.startTime)
     .filter((t): t is string => !!t)
-    .map(t => new Date(t))
+    .map((t: string) => new Date(t))
   if (!times.length) return null
-  const earliest = new Date(Math.min(...times.map(t => t.getTime())))
+  const earliest = new Date(Math.min(...times.map((t: Date) => t.getTime())))
   const day = earliest.getDate()
   const month = earliest.toLocaleDateString('en-AU', { month: 'short' })
   const year = String(earliest.getFullYear()).slice(-2)

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -60,6 +60,12 @@
         </div>
       </section>
 
+      <div v-if="aflRoundTo" class="mt-8">
+        <router-link :to="aflRoundTo" class="text-sm text-text-muted hover:text-text transition-colors">
+          AFL Round ↗
+        </router-link>
+      </div>
+
     </template>
   </div>
 </template>
@@ -69,6 +75,7 @@ import { computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON } from '../api/queries'
 import { useFflState } from '../composables/useFflState'
+import { useAflState } from '../../afl/composables/useAflState'
 import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import RoundNav from '../components/RoundNav.vue'
@@ -76,6 +83,7 @@ import RoundNav from '../components/RoundNav.vue'
 const props = defineProps<{ seasonId: string; roundId: string }>()
 
 const { liveRoundId, selectedClubId } = useFflState()
+const { liveSeasonId: aflSeasonId } = useAflState()
 const { result, loading, error } = useQuery(GET_FFL_SEASON, () => ({ id: props.seasonId }))
 
 const data = computed(() => {
@@ -98,6 +106,12 @@ const roundStartDate = computed(() => {
   const month = earliest.toLocaleDateString('en-AU', { month: 'short' })
   const year = String(earliest.getFullYear()).slice(-2)
   return `${day} ${month} '${year}`
+})
+
+const aflRoundTo = computed(() => {
+  const aflRoundId = data.value?.round.aflRoundId
+  if (!aflRoundId || !aflSeasonId.value) return null
+  return { name: 'afl-round', params: { seasonId: aflSeasonId.value, roundId: aflRoundId } }
 })
 
 const breadcrumbs = computed(() => {

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -1,12 +1,15 @@
 <template>
   <div>
+    <Breadcrumb v-if="clubSeason" :items="breadcrumbs" />
     <div class="mb-6">
-      <h1 class="text-2xl font-bold mb-1">{{ clubSeason?.club.name ?? '' }}</h1>
-      <p class="text-text-muted">{{ clubSeason?.season.name ? clubSeason.season.name + ' Squad' : 'Squad' }}</p>
+      <h1 class="text-2xl font-bold mb-1 flex items-center gap-3">
+        <img v-if="clubSeason" :src="clubLogoUrl(clubSeason.club.name)" :alt="clubSeason.club.name" class="w-10 h-10 object-contain" />
+        {{ clubSeason?.club.name ?? '' }}
+      </h1>
     </div>
 
-    <!-- Manage toggle -->
-    <div class="mb-6 flex items-center gap-4">
+    <!-- Manage toggle — only for the selected club -->
+    <div v-if="isMyClub" class="mb-6 flex items-center gap-4">
       <button
         @click="managing = !managing"
         class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
@@ -14,7 +17,12 @@
           ? 'border-active bg-active text-active-text'
           : 'border-border bg-surface text-text hover:bg-surface-hover'"
       >
-        {{ managing ? 'Done' : 'Manage' }}
+        <span class="flex items-center gap-1.5">
+          <svg v-if="!managing" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+          </svg>
+          {{ managing ? 'Done' : 'Manage' }}
+        </span>
       </button>
       <span v-if="saveMessage" class="text-sm text-green-500">{{ saveMessage }}</span>
     </div>
@@ -30,7 +38,7 @@
               <thead>
                 <tr class="border-b border-border text-left text-text-muted">
                   <th class="py-2 pr-4 font-medium">Player</th>
-                  <th v-if="managing" class="py-2 px-2 font-medium text-right"></th>
+                  <th v-if="isMyClub && managing" class="py-2 px-2 font-medium text-right"></th>
                 </tr>
               </thead>
               <tbody>
@@ -40,7 +48,7 @@
                   class="border-b border-border-subtle hover:bg-surface-hover"
                 >
                   <td class="py-2 pr-4 font-medium">{{ row.player.name }}</td>
-                  <td v-if="managing" class="py-2 px-2 text-right">
+                  <td v-if="isMyClub && managing" class="py-2 px-2 text-right">
                     <button
                       @click="removePlayer(row.id)"
                       aria-label="Remove"
@@ -60,7 +68,7 @@
         </div>
 
         <!-- Add player search (manage mode only) -->
-        <div v-if="managing" class="w-72 shrink-0">
+        <div v-if="isMyClub && managing" class="w-72 shrink-0">
           <h2 class="text-lg font-semibold mb-2">Add Player</h2>
           <input
             v-model="searchQuery"
@@ -100,21 +108,33 @@ import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_FFL_CLUB_SEASON, SEARCH_AFL_PLAYERS } from '../api/queries'
 import { REMOVE_FFL_PLAYER_FROM_SEASON, ADD_FFL_SQUAD_PLAYER } from '../api/mutations'
 import { useFflState } from '../composables/useFflState'
+import Breadcrumb from '../components/Breadcrumb.vue'
+import { clubLogoUrl } from '../utils/clubLogos'
 
-const props = defineProps<{ seasonId: string }>()
+const props = defineProps<{ seasonId: string; clubId: string }>()
 
 const { selectedClubId } = useFflState()
 const managing = ref(false)
 
-// Squad query — driven by global club selection
+const isMyClub = computed(() => !!selectedClubId.value && props.clubId === selectedClubId.value)
+
+// Squad query — driven by route clubId
 const { result: squadResult, loading: squadLoading, error: squadError, refetch: refetchSquad } = useQuery(
   GET_FFL_CLUB_SEASON,
-  () => ({ seasonId: props.seasonId, clubId: selectedClubId.value }),
-  () => ({ enabled: !!selectedClubId.value })
+  () => ({ seasonId: props.seasonId, clubId: props.clubId }),
 )
 
 const clubSeason = computed(() => squadResult.value?.fflClubSeason ?? null)
 const clubSeasonId = computed(() => clubSeason.value?.id ?? '')
+
+const breadcrumbs = computed(() => {
+  if (!clubSeason.value) return []
+  return [
+    { label: 'FFL' },
+    { label: clubSeason.value.season.name, to: { name: 'home' } },
+    { label: clubSeason.value.club.name },
+  ]
+})
 
 const players = computed(() => {
   const nodes = clubSeason.value?.players?.nodes ?? []
@@ -214,7 +234,7 @@ watch(managing, (val) => {
   }
 })
 
-watch(selectedClubId, () => {
-  managing.value = false
+watch(isMyClub, (val) => {
+  if (!val) managing.value = false
 })
 </script>

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -52,7 +52,12 @@
             @click="managing = true"
             class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
           >
-            Manage
+            <span class="flex items-center gap-1.5">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+              </svg>
+              Manage
+            </span>
           </button>
           <span v-if="benchValidationError" class="text-sm text-red-400">{{ benchValidationError }}</span>
           <span v-else-if="submitMessage" class="text-sm text-green-500">{{ submitMessage }}</span>

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -4,14 +4,12 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="season">
       <div class="mb-6">
-        <!-- Breadcrumb + round nav -->
-        <div v-if="currentRound" class="flex items-center gap-3 mb-2">
-          <router-link
-            :to="{ name: 'ffl-round', params: { seasonId: props.seasonId, roundId: props.roundId } }"
-            class="text-sm text-text-muted hover:text-text transition-colors"
-          >
-            ← Back to round
-          </router-link>
+        <Breadcrumb v-if="currentRound" :items="breadcrumbs" />
+        <div class="flex items-center">
+          <h1 class="text-2xl font-bold flex items-center gap-3">
+            <img v-if="selectedClubSeason" :src="clubLogoUrl(selectedClubSeason.club.name)" :alt="selectedClubSeason.club.name" class="w-10 h-10 object-contain" />
+            {{ selectedClubSeason?.club.name ?? '' }}<span class="font-normal text-text-muted"> · Team Builder</span>
+          </h1>
           <div class="flex items-center gap-1 ml-auto">
             <router-link
               v-if="prevRound"
@@ -29,9 +27,6 @@
             <span v-else class="w-6 h-6 flex items-center justify-center text-text-faint text-sm opacity-30">›</span>
           </div>
         </div>
-        <h1 class="text-2xl font-bold">
-          {{ selectedClubSeason?.club.name ?? '' }}<span v-if="currentRound" class="font-normal text-text-muted"> · {{ currentRound.name }}</span>
-        </h1>
       </div>
 
       <template v-if="selectedClubSeason && clubMatch">
@@ -262,6 +257,8 @@ import { ref, computed, watch } from 'vue'
 import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_FFL_TEAM_BUILDER } from '../api/queries'
 import { SET_FFL_TEAM } from '../api/mutations'
+import Breadcrumb from '../components/Breadcrumb.vue'
+import { clubLogoUrl } from '../utils/clubLogos'
 import { useFflState } from '../composables/useFflState'
 
 const props = defineProps<{ seasonId: string; roundId: string }>()
@@ -315,6 +312,21 @@ const currentRound = computed(() =>
   season.value?.rounds.find((r: { id: string }) => r.id === props.roundId) ?? null
 )
 
+const breadcrumbs = computed(() => {
+  if (!season.value || !currentRound.value) return []
+  const crumbs: { label: string; to?: object }[] = [
+    { label: 'FFL' },
+    { label: season.value.name, to: { name: 'home' } },
+    { label: currentRound.value.name, to: { name: 'ffl-round', params: { seasonId: props.seasonId, roundId: props.roundId } } },
+  ]
+  if (currentMatch.value) {
+    const home = currentMatch.value.homeClubMatch?.club.name ?? '?'
+    const away = currentMatch.value.awayClubMatch?.club.name ?? '?'
+    crumbs.push({ label: `${home} v ${away}`, to: { name: 'ffl-match', params: { seasonId: props.seasonId, matchId: currentMatch.value.id } } })
+  }
+  return crumbs
+})
+
 const prevRound = computed(() => {
   const rounds = season.value?.rounds ?? []
   const idx = rounds.findIndex((r: { id: string }) => r.id === props.roundId)
@@ -327,15 +339,22 @@ const nextRound = computed(() => {
   return idx >= 0 && idx < rounds.length - 1 ? rounds[idx + 1] : null
 })
 
-const clubMatch = computed(() => {
+const currentMatch = computed(() => {
   if (!season.value || !selectedClubSeason.value) return null
   const round = season.value.rounds.find((r: { id: string }) => r.id === props.roundId)
   if (!round) return null
   const clubId = selectedClubSeason.value.club.id
-  for (const match of round.matches) {
-    if (match.homeClubMatch?.club.id === clubId) return match.homeClubMatch
-    if (match.awayClubMatch?.club.id === clubId) return match.awayClubMatch
-  }
+  return round.matches.find((m: { homeClubMatch?: { club: { id: string } } | null; awayClubMatch?: { club: { id: string } } | null }) =>
+    m.homeClubMatch?.club.id === clubId || m.awayClubMatch?.club.id === clubId
+  ) ?? null
+})
+
+const clubMatch = computed(() => {
+  if (!currentMatch.value || !selectedClubSeason.value) return null
+  const clubId = selectedClubSeason.value.club.id
+  const m = currentMatch.value
+  if (m.homeClubMatch?.club.id === clubId) return m.homeClubMatch
+  if (m.awayClubMatch?.club.id === clubId) return m.awayClubMatch
   return null
 })
 

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -1,79 +1,12 @@
-# Current Sprint — Phase 13: Search Service
+# Current Sprint — Enrichment
 
-**Sprint goal:** Build a standalone Search service that subscribes to AFL and FFL events, indexes documents into Typesense, and exposes a GraphQL API for full-text search with source/type filtering.
-
-> **Pivot notes (2026-04-16):**
-> - ADR-015 replaced ZincSearch with Typesense. Tasks 1-3 unaffected. Task 4 redone.
-> - ADR-002 updated: Search now exposes GraphQL (like AFL/FFL) instead of REST, keeping the frontend on a single protocol (Apollo). Task 5 redone.
-
-## Design decisions
-
-- **GraphQL, not REST** (ADR-002 updated) — `search(q, source, type)` query via gqlgen, consistent with AFL/FFL. Frontend stays 100% Apollo.
-- **Single Typesense collection** (`documents`) — all documents in one collection with `source` and `type` fields for filtering. Simpler than per-type collections; supports the cross-source search the frontend will need.
-- **Document ID** — `"{source}_{type}_{id}"` (e.g. `"afl_player_match_42"`). Deterministic so re-indexing is idempotent (Typesense upserts by `id`).
-- **Event subscriptions** — same pattern as FFL: `dispatcher.Subscribe(...)` then `go dispatcher.Listen(ctx)`. Subscribes to both `AFL.PlayerMatchUpdated` and `FFL.FantasyScoreCalculated`.
-- **No DB** — Search service has no PostgreSQL schema. Typesense is its only persistence.
-- **Typesense auth** — API key set via `TYPESENSE_API_KEY` env var (default `xyz` for local dev, matching docker-compose).
-- **Testing** — unit tests for payload→document transformation; integration tests against a real Typesense instance via testcontainers.
-- **Gateway passthrough** — `/search/query` proxied to Search service (same pattern as `/afl/query`, `/ffl/query`).
-
-## Document shapes
-
-### AFL player match (from `AFL.PlayerMatchUpdated`)
-```
-source: "afl"
-type:   "player_match"
-id:     player_match_id
-fields: player_match_id, player_season_id, club_match_id, round_id,
-        kicks, handballs, marks, hitouts, tackles, goals, behinds
-```
-
-### FFL fantasy score (from `FFL.FantasyScoreCalculated`)
-```
-source: "ffl"
-type:   "fantasy_score"
-id:     player_match_id (FFL)
-fields: player_match_id, score, afl_player_match_id
-```
+**Sprint goal:** Minor UX polish across AFL and FFL views, then pull in real data.
 
 ## Tasks
 
-### 1. Scaffold
-- [x] Create `services/search/` directory structure: `cmd/`, `internal/domain/`, `internal/application/`, `internal/infrastructure/zinc/`, `internal/interface/rest/`
-- [x] `services/search/go.mod` — module `xffl/services/search`; import `xffl/contracts/events`, `xffl/shared/events`
-- [x] Add `./services/search` to `go.work`
+### UX polish
+- [x] Show round start date on AFL and FFL round pages (format: 23 Feb '26)
+- [ ] More changes TBD
 
-### 2. Domain layer
-- [x] `internal/domain/document.go` — `SearchDocument{ID, Source, Type, Data map[string]any}` struct; `Source` and `Type` string constants (`SourceAFL`, `SourceFFL`, `TypePlayerMatch`, `TypeFantasyScore`)
-- [x] `internal/domain/query.go` — `SearchQuery{Q, Source, Type string}` and `SearchResult{Total int, Documents []SearchDocument}` structs
-- [x] `internal/domain/repository.go` — `DocumentRepository` interface: `Index(ctx, doc) error` and `Search(ctx, query) (SearchResult, error)`
-
-### 3. Application layer
-- [x] `internal/application/index.go` — `IndexDocument` use case: takes a `SearchDocument`, delegates to `DocumentRepository.Index`
-- [x] `internal/application/search.go` — `Search` use case: takes a `SearchQuery`, delegates to `DocumentRepository.Search`; returns `SearchResult`
-- [x] `internal/application/handlers.go` — `HandlePlayerMatchUpdated(ctx, payload []byte) error` and `HandleFantasyScoreCalculated(ctx, payload []byte) error`; each unmarshal contract payload, build `SearchDocument`, call `IndexDocument`
-- [x] Unit tests for handler payload→document transformation (table-driven: valid payload, malformed JSON, zero values)
-
-### 4. Infrastructure: Typesense client *(redo — was Zinc, see ADR-015)*
-- [x] `internal/infrastructure/typesense/client.go` — `Client{apiURL, apiKey, collection, httpClient}`; `EnsureCollection(ctx) error` creates the `documents` collection with schema (`source`/`type` as string facets, `.*` auto for data fields); `upsertDoc(ctx, doc) error`; `search(ctx, q, queryBy, filterBy) (*searchResponse, error)`
-- [x] `internal/infrastructure/typesense/repository.go` — wraps `Client`, implements `domain.DocumentRepository`; maps Typesense response to `SearchResult`; uses native `filter_by` (no post-filtering needed)
-- [x] Integration tests — use testcontainers (Typesense image: `typesense/typesense:27.1`) to start Typesense; test `Index` then `Search` round-trip; test source/type filtering; test idempotent re-index via upsert
-- [x] Remove `internal/infrastructure/zinc/` directory
-
-### 5. Interface: GraphQL *(redo — was REST, see ADR-002 update)*
-- [x] `api/graphql/schema.graphqls` — `search(q: String, source: String, type: String): SearchResult!` query; `SearchResult{total, documents}` and `SearchDocument{id, source, type, data: JSON}` types
-- [x] `gqlgen.yml` + `go generate` — generated resolver scaffold, models, executor
-- [x] `internal/interface/graphql/resolver.go` — `Resolver{Repo domain.DocumentRepository}`; wire search query to repo
-- [x] Unit tests for resolver (stub repo, verify query mapping and response shape)
-- [x] Remove `internal/interface/rest/` (replaced by GraphQL)
-
-### 6. Service entrypoint *(update for GraphQL)*
-- [x] `cmd/main.go` — wire `TypesenseClient → TypesenseRepository → IndexDocument + Handlers + GraphQL server`; read `TYPESENSE_HOST` (default `localhost`), `TYPESENSE_PORT` (default `8108`), `TYPESENSE_API_KEY` (default `xyz`); call `EnsureCollection` on startup; subscribe to both events via pgevents; serve `/query` (GraphQL) + `/` (playground) + `/health`; port 8082
-
-### 7. Gateway: search passthrough
-- [x] `services/gateway/cmd/main.go` — add `SEARCH_SERVICE_URL` env (default `http://localhost:8082`); add `/search/query` route (same pattern as `/afl/query`, `/ffl/query`)
-
-### 8. justfile + docker-compose + go.work
-- [x] `dev/docker-compose.yml` — removed `zinc` service, added `typesense` service (image `typesense/typesense:27.1`, port 8108, API key `xyz`, data volume)
-- [x] `justfile` — updated comments/echo to reference Typesense; added `run-search` to `run-all` and port 8082 to `stop-all`
-- [x] `go.work` — already has `./services/search` from task 1
+### Real data
+- [ ] TBD

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -97,7 +97,7 @@ func (r *RoundRepository) FindBySeasonID(ctx context.Context, seasonID int) ([]d
 	}
 	out := make([]domain.Round, len(rows))
 	for i, row := range rows {
-		out[i] = domain.Round{ID: int(row.ID), Name: row.Name, SeasonID: int(row.SeasonID)}
+		out[i] = domain.Round{ID: int(row.ID), Name: row.Name, SeasonID: int(row.SeasonID), AFLRoundID: int32PtrToIntPtr(row.AflRoundID)}
 	}
 	return out, nil
 }
@@ -107,7 +107,7 @@ func (r *RoundRepository) FindByID(ctx context.Context, id int) (domain.Round, e
 	if err != nil {
 		return domain.Round{}, err
 	}
-	return domain.Round{ID: int(row.ID), Name: row.Name, SeasonID: int(row.SeasonID)}, nil
+	return domain.Round{ID: int(row.ID), Name: row.Name, SeasonID: int(row.SeasonID), AFLRoundID: int32PtrToIntPtr(row.AflRoundID)}, nil
 }
 
 func (r *RoundRepository) FindByAFLRoundID(ctx context.Context, aflRoundID int) (domain.Round, error) {

--- a/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/round.sql
@@ -1,13 +1,13 @@
 -- name: FindRoundsBySeasonID :many
-SELECT r.id, r.name, r.season_id
+SELECT r.id, r.name, r.season_id, r.afl_round_id
 FROM ffl.round r
 LEFT JOIN ffl.match m ON m.round_id = r.id AND m.deleted_at IS NULL
 WHERE r.season_id = $1 AND r.deleted_at IS NULL
-GROUP BY r.id, r.name, r.season_id
+GROUP BY r.id, r.name, r.season_id, r.afl_round_id
 ORDER BY MIN(m.start_dt) NULLS LAST, r.id;
 
 -- name: FindRoundByID :one
-SELECT id, name, season_id
+SELECT id, name, season_id, afl_round_id
 FROM ffl.round
 WHERE id = $1 AND deleted_at IS NULL;
 

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/round.sql.go
@@ -35,37 +35,39 @@ func (q *Queries) FindRoundByAFLRoundID(ctx context.Context, aflRoundID *int32) 
 }
 
 const findRoundByID = `-- name: FindRoundByID :one
-SELECT id, name, season_id
+SELECT id, name, season_id, afl_round_id
 FROM ffl.round
 WHERE id = $1 AND deleted_at IS NULL
 `
 
 type FindRoundByIDRow struct {
-	ID       int32
-	Name     string
-	SeasonID int32
+	ID         int32
+	Name       string
+	SeasonID   int32
+	AflRoundID *int32
 }
 
 func (q *Queries) FindRoundByID(ctx context.Context, id int32) (FindRoundByIDRow, error) {
 	row := q.db.QueryRow(ctx, findRoundByID, id)
 	var i FindRoundByIDRow
-	err := row.Scan(&i.ID, &i.Name, &i.SeasonID)
+	err := row.Scan(&i.ID, &i.Name, &i.SeasonID, &i.AflRoundID)
 	return i, err
 }
 
 const findRoundsBySeasonID = `-- name: FindRoundsBySeasonID :many
-SELECT r.id, r.name, r.season_id
+SELECT r.id, r.name, r.season_id, r.afl_round_id
 FROM ffl.round r
 LEFT JOIN ffl.match m ON m.round_id = r.id AND m.deleted_at IS NULL
 WHERE r.season_id = $1 AND r.deleted_at IS NULL
-GROUP BY r.id, r.name, r.season_id
+GROUP BY r.id, r.name, r.season_id, r.afl_round_id
 ORDER BY MIN(m.start_dt) NULLS LAST, r.id
 `
 
 type FindRoundsBySeasonIDRow struct {
-	ID       int32
-	Name     string
-	SeasonID int32
+	ID         int32
+	Name       string
+	SeasonID   int32
+	AflRoundID *int32
 }
 
 func (q *Queries) FindRoundsBySeasonID(ctx context.Context, seasonID int32) ([]FindRoundsBySeasonIDRow, error) {
@@ -77,7 +79,7 @@ func (q *Queries) FindRoundsBySeasonID(ctx context.Context, seasonID int32) ([]F
 	items := []FindRoundsBySeasonIDRow{}
 	for rows.Next() {
 		var i FindRoundsBySeasonIDRow
-		if err := rows.Scan(&i.ID, &i.Name, &i.SeasonID); err != nil {
+		if err := rows.Scan(&i.ID, &i.Name, &i.SeasonID, &i.AflRoundID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
## Summary

- **Breadcrumbs** on all AFL and FFL pages (home, round, match, squad, team builder, admin match) following the pattern league › season › round › match
- **Round start date** shown in round page headings (derived client-side from match start times)
- **Club names** in ladder and match pages link to their squad pages
- **Squad page** scoped per club (`/seasons/:id/clubs/:clubId/squad`); Manage button only shown for the selected club; club logo in heading; pencil icon on Manage button
- **Team Builder button** replaced with icon-only wrench-screwdriver with "Team Builder" tooltip, placed inline next to the user's team name in round and match views; pencil icon on Manage button
- **FFL seed rounds** renamed from bare numbers to "Round N" format (aligns with e2e seed and AFL convention)
- **AFL Round ↗ link** at bottom of FFL round and match pages, linking to the corresponding AFL round (requires `aflRoundId` now returned from `FindRoundsBySeasonID` and `FindRoundByID` SQL queries)
- **e2e tests** updated for all UX changes

## Test plan

- [ ] Run `just test-e2e` — all 93 tests pass
- [ ] Verify breadcrumbs appear and navigate correctly on each page
- [ ] Verify club names in ladder and match pages link to squad pages
- [ ] Verify Squad page shows Manage button only for the selected club
- [ ] Verify AFL Round ↗ link appears on FFL round/match pages and navigates correctly