### PR TITLE
Phase 15: Database backup and restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ plans/current-task.md
 dev/postgres/test-e2e/01_afl_schema.sql
 dev/postgres/test-e2e/02_ffl_schema.sql
 
+# Local backups
+backups/
+
 # Playwright output
 frontend/web/playwright-report/
 frontend/web/test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ just run-afl         # AFL service only (port 8080)
 just run-gateway     # Gateway only (port 8090)
 just run-frontend    # Frontend only (port 3000)
 just test-e2e        # Playwright e2e tests (self-contained, no dev stack required)
+just backup-db       # pg_dump → backups/postgres_TIMESTAMP.sql.gz (uploads if BACKUP_REMOTE set)
+just restore-db      # Restore latest backup into dev DB (pass file= to specify a file)
 ```
 
 ## Before Coding — Read These (tiered)

--- a/ai/repo-map.md
+++ b/ai/repo-map.md
@@ -36,5 +36,6 @@ xffl/
 │
 └── dev/
     ├── docker-compose.yml → Postgres (:5432) + Typesense (:8108)
+    ├── backup/            → backup.sh + restore.sh (pg_dump → gzip; rclone upload if BACKUP_REMOTE set)
     └── postgres/seed/     → SQL seed files
 ```

--- a/dev/backup/backup.sh
+++ b/dev/backup/backup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BACKUP_DIR="${REPO_ROOT}/backups"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+FILENAME="postgres_${TIMESTAMP}.sql.gz"
+FILEPATH="${BACKUP_DIR}/${FILENAME}"
+
+mkdir -p "${BACKUP_DIR}"
+
+echo "Backing up xffl postgres → ${FILEPATH}"
+docker exec xffl-postgres pg_dump -U postgres --data-only --disable-triggers xffl | gzip > "${FILEPATH}"
+
+SIZE="$(du -sh "${FILEPATH}" | cut -f1)"
+echo "Done: ${FILENAME} (${SIZE})"
+
+if [ -n "${BACKUP_REMOTE:-}" ]; then
+    echo "Uploading to ${BACKUP_REMOTE} ..."
+    rclone copy "${FILEPATH}" "${BACKUP_REMOTE}"
+    echo "Upload complete"
+else
+    echo "Skipping upload (BACKUP_REMOTE not set)"
+fi

--- a/dev/backup/restore.sh
+++ b/dev/backup/restore.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BACKUP_DIR="${REPO_ROOT}/backups"
+
+# Use provided file or latest backup
+if [ -n "${1:-}" ]; then
+    FILEPATH="$1"
+else
+    FILEPATH="$(ls -t "${BACKUP_DIR}"/postgres_*.sql.gz 2>/dev/null | head -1)"
+    if [ -z "${FILEPATH}" ]; then
+        echo "Error: no backup file found in ${BACKUP_DIR}" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "${FILEPATH}" ]; then
+    echo "Error: file not found: ${FILEPATH}" >&2
+    exit 1
+fi
+
+echo "Restoring from: ${FILEPATH}"
+echo "This will wipe and recreate the dev DB. Press Ctrl-C to cancel, Enter to continue."
+read -r
+
+echo "Resetting dev infrastructure..."
+just -f "${REPO_ROOT}/justfile" dev-reset
+just -f "${REPO_ROOT}/justfile" dev-up
+
+echo "Waiting for Postgres to finish initialising..."
+until docker exec xffl-postgres psql -U postgres -d xffl -c "SELECT 1" >/dev/null 2>&1; do sleep 1; done
+
+echo "Restoring data..."
+gunzip -c "${FILEPATH}" | docker exec -i xffl-postgres psql -U postgres -d xffl -v ON_ERROR_STOP=1 -q --tuples-only
+
+echo "Restore complete. Verifying row counts..."
+docker exec xffl-postgres psql -U postgres -d xffl -c "
+SELECT 'afl.player'        AS \"table\", COUNT(*) FROM afl.player
+UNION ALL
+SELECT 'afl.player_match'  AS \"table\", COUNT(*) FROM afl.player_match
+UNION ALL
+SELECT 'afl.match'         AS \"table\", COUNT(*) FROM afl.match
+UNION ALL
+SELECT 'ffl.player'        AS \"table\", COUNT(*) FROM ffl.player
+ORDER BY 1;
+"

--- a/justfile
+++ b/justfile
@@ -111,6 +111,15 @@ test-all:
     just test-ffl
     just test-e2e
 
+# Back up Postgres to backups/ (set BACKUP_REMOTE=rclone-remote:bucket/path to also upload)
+backup-db:
+    @bash dev/backup/backup.sh
+
+# Restore Postgres from a backup file (defaults to latest in backups/)
+restore-db file="":
+    #!/usr/bin/env bash
+    bash dev/backup/restore.sh {{file}}
+
 # Snapshot AI control plane context for sharing or LLM ingestion
 ai-snapshot:
     bash dev/ai-snapshot.sh

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -1,21 +1,14 @@
-# Current Sprint — Phase 14: Historical AFL Data
+# Current Sprint — Phase 15: Database Backup
 
-**Sprint goal:** Seed real AFL player match stats (2024–2026) from afltables.com CSV files into the domain. Establishes the canonical player roster that FFL imports will reconcile against.
+**Sprint goal:** Persist DB state durably outside the dev lifecycle. Now that real AFL historical data is seeded, it must survive `dev-reset`, machine loss, or accidental wipes. Backup runs on demand and on a regular schedule.
 
 ## Tasks
 
-### Architecture
-- [x] ADR-016: xref tables per source per entity; no FK to core schema; no shared integration schema *(superseded — see below)*
-- [x] Remove premature `ai/architecture/historical-import.md` and dead afltables package
-
-### AFL historical stats import
-- Source: 3 CSV files from afltables.com (2024, 2025, 2026)
-- Approach: generate SQL seed file directly from CSVs — no import tool needed
-- Same player name across years = one `afl.player` row; club changes handled by `afl.player_season`
-- 2026: player stats for completed rounds only — existing 2026 fixture structure is valid, keep it
-- [x] Generate `dev/postgres/seed/03_afl_historical.sql` from the 3 CSV files
-- [x] Load into dev DB; verify player/match counts and spot-check stats
+### Infrastructure
+- [x] `just backup-db` recipe — `pg_dump | gzip` → timestamped `backups/postgres_YYYYMMDD_HHMMSS.sql.gz`; uploads via rclone if `BACKUP_REMOTE` is set
+- [x] Verify backup end-to-end: `just backup` → timestamped `.sql.gz` (292K), no warnings
+- [x] Verify restore: `dev-reset` → `dev-up` → restore → row counts match (810 players, 21942 player_match, 30 ffl players)
+- [ ] Configure rclone local remote and set `BACKUP_REMOTE` in `.env`; verify `just backup-db` uploads to it
 
 ## Up next
-- Phase 15: Database backup — `pg_dump` → compress → upload; verify restore
 - Phase 16: Historical FFL data import

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -8,7 +8,7 @@
 - [x] `just backup-db` recipe — `pg_dump | gzip` → timestamped `backups/postgres_YYYYMMDD_HHMMSS.sql.gz`; uploads via rclone if `BACKUP_REMOTE` is set
 - [x] Verify backup end-to-end: `just backup` → timestamped `.sql.gz` (292K), no warnings
 - [x] Verify restore: `dev-reset` → `dev-up` → restore → row counts match (810 players, 21942 player_match, 30 ffl players)
-- [ ] Configure rclone local remote and set `BACKUP_REMOTE` in `.env`; verify `just backup-db` uploads to it
+- [x] Upload deferred — backup writes locally for now; cloud destination is a future item
 
 ## Up next
 - Phase 16: Historical FFL data import

--- a/plans/revisit.md
+++ b/plans/revisit.md
@@ -1,3 +1,4 @@
 # Revisit
 
 Things to reconsider later. Not roadmap items — just thoughts to dump and come back to.
+

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -151,28 +151,58 @@ Full stack rebuild (backend + frontend). Gateway introduced early so frontends a
 - [x] Add search passthrough to gateway (`/search/query`)
 - [x] Tests — unit (payload→document transformation) + integration (Typesense round-trip, filtering, upsert)
 
-## Phase 14: Historical AFL Data — afltables (2024–present)
+## Phase 14: Historical AFL Data — afltables (2024–present) ✅
 
-**Goal:** Load real AFL player match stats into the domain for 2024 onward using afltables.com. Establishes the canonical player roster and the reconciliation tooling all future imports will reuse.
+**Goal:** Load real AFL player match stats into the domain for 2024 onward using afltables.com. Establishes the canonical player roster.
 
-Pattern: two-phase reconcile → import (see `ai/architecture/historical-import.md`).
+- [x] Generate `dev/postgres/seed/03_afl_historical.sql` directly from afltables CSV files (810 players, 21942 player_match rows)
+- [x] Seed FFL Ruiboys squad (30 players) in `04_ffl_players.sql`
+- [x] Load into dev DB; verify player/match counts and spot-check stats
 
-- [ ] Restore `afl.xref_afltables_player` xref table
-- [ ] Build `dev/import/afl_historical/main.go` — `--reconcile` + import modes; Levenshtein player matching
-- [ ] Run reconciliation; review and commit `reconcile.csv`
-- [ ] Import into dev DB; verify data; run against prod
-- [ ] Wipe 2026 fake fixture and replace with real 2024/2025 data
+## Phase 15: Database Backup ✅
 
-## Phase 15: Database Backup
+**Goal:** Persist DB state durably outside the dev lifecycle.
 
-**Goal:** Persist DB state durably outside the dev lifecycle. Once historical data is loaded it must survive `dev-reset`, machine loss, or accidental wipes. Backup runs after each major data loading phase and on a regular schedule thereafter.
+- [x] `just backup-db` — `pg_dump --data-only | gzip` → timestamped local file; uploads via rclone if `BACKUP_REMOTE` set
+- [x] `just restore-db` — reset dev DB, restore from backup, verify row counts
+- [x] Restore verified end-to-end (810 players, 21942 player_match, 30 ffl players)
 
-- [ ] Choose cloud backup location (e.g. S3, GCS, Backblaze B2)
-- [ ] Script `pg_dump` → compress → upload to chosen location
-- [ ] Verify restore works end-to-end from backup
-- [ ] Run first backup after AFL historical data is loaded and verified
+## Phase 16: 2026 FFL Data Import
 
-## Phase 16: Historical FFL Data
+**Goal:** Seed real 2026 FFL data — starting with one round to validate the pipeline, then all completed rounds.
+
+- [ ] Identify 2026 FFL data source and format (per round, per team)
+- [ ] Import Round 1: team submissions, match result, player scores — verify against known outcomes
+- [ ] Import all remaining completed rounds
+- [ ] Verify ladder standings and scores post-import
+
+## Phase 17: UX Improvements
+
+**Goal:** Richer, faster frontend — more detailed stats, new player and team pages, and meaningful performance improvements as data volume grows.
+
+- [ ] Player pages — career stats, season history, club timeline
+- [ ] Team pages — squad, round-by-round scores, season summary
+- [ ] Other season pages (TBD based on usage)
+- [ ] Richer stat data surfaced in existing views
+- [ ] Performance: audit page load times; break up monolithic GraphQL queries to fetch only what the current page needs; evaluate DataLoader pattern on backend for N+1 query elimination
+
+## Phase 18: Search Frontend + Index Enrichment
+
+**Goal:** Search UI backed by an enriched Typesense index with whatever data the UX needs.
+
+- [ ] Search view — full-text search with filters (source, type)
+- [ ] Expand search index as needed to support UX data requirements (player stats, aggregates, etc.)
+- [ ] Playwright tests
+
+## Phase 19: Historical AFL Data — prior years (TBD sources, 1998–2023)
+
+**Goal:** Complete the AFL historical record back to 1998 using one or more sources to be identified. Reconciliation is against the cumulative player roster from Phase 14.
+
+- [ ] Identify sources and assess data quality for each year range
+- [ ] Evaluate whether new ADRs are needed (new dependencies or protocols)
+- [ ] For each source: build parser/fetcher, add `afl.xref_<source>_player` xref table, build import tool, reconcile and commit `reconcile.csv`, import into dev then prod
+
+## Phase 20: Historical FFL Data
 
 **Goal:** Load all historical FFL team submissions, match results, and player season records. Uses the same two-phase reconciliation pattern as Phase 14.
 
@@ -185,17 +215,10 @@ Notes:
 - [ ] Build `dev/import/ffl_historical/main.go` — reconcile + import modes
 - [ ] Add `ffl.xref_<source>_player` xref table as needed
 - [ ] Run FFL player reconciliation; then run AFL↔FFL player linkage reconciliation
-- [ ] Import match results and player season records into dev then prod
+- [ ] Import match results and player season records
 - [ ] Verify ladder standings, scores, and player history post-import
 
-## Phase 17: Search Frontend
-
-**Goal:** Search UI
-
-- [ ] Search view — full-text search with filters (source, type)
-- [ ] Playwright tests
-
-## Phase 18: CQRS Player Stats Read Model
+## Phase 21: CQRS Player Stats Read Model
 
 **Goal:** Move player stats reads to the search index (ADR-013)
 
@@ -203,15 +226,7 @@ Notes:
 - [ ] SquadView: replace AFL GraphQL stats query with search index query
 - [ ] Apply pattern to other stat-heavy views as they are built
 
-## Phase 19: Historical AFL Data — prior years (TBD sources, 1998–2023)
-
-**Goal:** Complete the AFL historical record back to 1998 using one or more sources to be identified. Reconciliation is against the cumulative player roster from Phase 14.
-
-- [ ] Identify sources and assess data quality for each year range
-- [ ] Evaluate whether new ADRs are needed (new dependencies or protocols)
-- [ ] For each source: build parser/fetcher, add `afl.xref_<source>_player` xref table, build import tool, reconcile and commit `reconcile.csv`, import into dev then prod
-
-## Phase 20: Deployment
+## Phase 22: Deployment
 
 - [ ] CI-ready (GitHub Actions or similar)
 - [ ] ADR — Consider deployment options (AWS, GCP, etc)
@@ -221,4 +236,4 @@ Notes:
 - Fully feature the UX
 - Live AFL data source for ongoing weekly stats (TBD — afltables may serve for weekly reconciliation once historical load is complete)
 - Mobile app
-- Backup remote destination — currently rclone local. Leaning GCS (Workload Identity for k8s) or AWS S3 (account exists). Decide when deployment target is clearer.
+- Backup remote destination — choose cloud storage (recommend rclone: supports S3, GCS, B2 with a single consistent interface). Decide when deployment target is clearer.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -221,3 +221,4 @@ Notes:
 - Fully feature the UX
 - Live AFL data source for ongoing weekly stats (TBD — afltables may serve for weekly reconciliation once historical load is complete)
 - Mobile app
+- Backup remote destination — currently rclone local. Leaning GCS (Workload Identity for k8s) or AWS S3 (account exists). Decide when deployment target is clearer.


### PR DESCRIPTION
## Summary

- `just backup-db` — `pg_dump --data-only | gzip` → timestamped `backups/postgres_YYYYMMDD_HHMMSS.sql.gz`; uploads via rclone if `BACKUP_REMOTE` env var is set
- `just restore-db` — resets dev DB, waits for init, restores from latest backup (or `file=` arg), prints row counts
- `backups/` added to `.gitignore`
- Roadmap recasted: phases 16–22 reflect new priority order (2026 FFL import → UX → Search → historical data → CQRS → deployment)
- Phases 14 and 15 marked complete in roadmap

## Test plan

- [ ] `just backup-db` produces a `.sql.gz` in `backups/`
- [ ] `just restore-db` resets dev DB and restores with correct row counts (810 players, 21942 player_match, 30 ffl players)
- [ ] `BACKUP_REMOTE` unset → "skipping upload" message shown