### PR TITLE
FFL player season page and display ordering

### DIFF
--- a/dev/router/supergraph.graphql
+++ b/dev/router/supergraph.graphql
@@ -316,6 +316,7 @@ type FFLPlayerSeason
 {
   id: ID!
   player: FFLPlayer!
+  club: FFLClub!
   clubSeasonId: ID!
   aflPlayerSeasonId: ID
   aflPlayerSeason: AFLPlayerSeason
@@ -323,6 +324,7 @@ type FFLPlayerSeason
   toRoundId: ID
   notes: String
   costCents: Int
+  playerMatches: [FFLPlayerMatch!]!
 }
 
 type FFLPlayerSeasonConnection
@@ -560,6 +562,7 @@ type Query
   fflPlayer(id: ID!): FFLPlayer! @join__field(graph: FFL)
   fflRoundByAflRound(aflRoundId: ID!): FFLRound @join__field(graph: FFL)
   fflClubMatch(id: ID!): FFLClubMatch @join__field(graph: FFL)
+  fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: ID!): [FFLPlayerSeason!]! @join__field(graph: FFL)
 }
 
 input RemoveFFLPlayerFromSeasonInput

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -40,6 +40,12 @@ const router = createRouter({
       props: true,
     },
     {
+      path: '/ffl/afl/player-seasons/:aflPlayerSeasonId',
+      name: 'ffl-afl-player-season',
+      component: () => import('@/features/ffl/views/AFLPlayerSeasonView.vue'),
+      props: true,
+    },
+    {
       path: '/ffl/data-ops',
       name: 'ffl-data-ops',
       component: () => import('@/features/data-ops/views/DataOpsView.vue'),

--- a/frontend/web/src/features/afl/components/PlayerStatsTable.vue
+++ b/frontend/web/src/features/afl/components/PlayerStatsTable.vue
@@ -17,7 +17,12 @@
           :key="pm.id"
           class="border-b border-border-subtle hover:bg-surface-hover"
         >
-          <td class="py-2 pr-4 font-medium">{{ pm.player.name }}</td>
+          <td class="py-2 pr-4 font-medium">
+            <router-link
+              :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pm.playerSeasonId } }"
+              class="hover:underline hover:text-active transition-colors"
+            >{{ pm.player.name }}</router-link>
+          </td>
           <td v-for="col in statColumns" :key="col.key" class="py-1 px-1 text-right">
             <input
               v-if="!readonly"

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -24,6 +24,7 @@ export const GET_FFL_CLUB_SEASON = gql`
           id
           player { id aflPlayerId aflPlayer { id name } }
           aflPlayerSeason {
+            id
             clubSeason {
               club { id name }
             }
@@ -397,6 +398,67 @@ export const GET_AFL_SEASON_CLUB_SEASONS = gql`
         ladder {
           id
           club { name }
+        }
+      }
+    }
+  }
+`
+
+export const GET_AFL_PLAYER_SEASON_STATS = gql`
+  query GetAFLPlayerSeasonStats($id: ID!) {
+    aflPlayerSeason(id: $id) {
+      id
+      player { id name }
+      clubSeason {
+        club { id name }
+        season { id name }
+      }
+      matches {
+        id
+        status
+        kicks
+        handballs
+        marks
+        tackles
+        hitouts
+        goals
+        behinds
+        score
+        clubMatch {
+          club { id name }
+          match {
+            round { id name }
+            homeClubMatch { club { id name } }
+            awayClubMatch { club { id name } }
+          }
+        }
+      }
+    }
+  }
+`
+
+export const GET_FFL_PLAYER_STINTS = gql`
+  query GetFFLPlayerStints($aflPlayerSeasonId: ID!) {
+    fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: $aflPlayerSeasonId) {
+      id
+      club { id name }
+      fromRoundId
+      toRoundId
+      playerMatches {
+        id
+        position
+        status
+        aflStatus
+        score
+        aflPlayerMatch {
+          id
+          clubMatch {
+            match {
+              round { id name }
+              homeClubMatch { club { id name } }
+              awayClubMatch { club { id name } }
+            }
+          }
         }
       }
     }

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -1,0 +1,292 @@
+<template>
+  <div>
+    <Breadcrumb v-if="playerSeason" :items="breadcrumbs" />
+
+    <div v-if="loading" class="text-text-faint">Loading...</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else-if="playerSeason">
+
+      <!-- Header -->
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-text">{{ playerSeason.player.name }}</h1>
+        <p class="text-sm text-text-muted mt-0.5">{{ playerSeason.clubSeason.club.name }} · {{ playerSeason.clubSeason.season.name }}</p>
+      </div>
+
+      <!-- Averages bar -->
+      <div v-if="playedMatches.length > 0" class="mb-6 flex flex-wrap gap-4">
+        <div v-for="col in statCols" :key="col.key" class="flex flex-col items-center gap-0.5">
+          <span class="text-[10px] uppercase tracking-wide text-text-faint font-medium">{{ col.label }}</span>
+          <span class="text-lg font-semibold tabular-nums text-text">{{ avg(col.key) }}</span>
+        </div>
+        <div class="flex flex-col items-center gap-0.5">
+          <span class="text-[10px] uppercase tracking-wide text-text-faint font-medium">*</span>
+          <span class="text-lg font-semibold tabular-nums text-active">{{ avg('score') }}</span>
+        </div>
+        <div class="flex flex-col items-center gap-0.5 ml-2 pl-2 border-l border-border">
+          <span class="text-[10px] uppercase tracking-wide text-text-faint font-medium">Games</span>
+          <span class="text-lg font-semibold tabular-nums text-text">{{ playedMatches.length }}</span>
+        </div>
+      </div>
+
+      <!-- AFL stats table -->
+      <section class="mb-8">
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">AFL Stats</h2>
+        <div v-if="sortedMatches.length === 0" class="text-text-faint text-sm">No matches recorded.</div>
+        <div v-else class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border text-left text-text-muted">
+                <th class="py-2 pr-3 font-medium">Round</th>
+                <th class="py-2 pr-4 font-medium">Vs</th>
+                <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right w-10">{{ col.label }}</th>
+                <th class="py-2 px-2 font-medium text-right w-10">*</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="m in sortedMatches"
+                :key="m.id"
+                class="border-b border-border-subtle"
+                :class="m.status === 'dnp' ? 'opacity-40' : 'hover:bg-surface-hover'"
+              >
+                <td class="py-2 pr-3 tabular-nums text-text-muted text-xs">{{ m.clubMatch.match.round.name }}</td>
+                <td class="py-2 pr-4 text-sm">{{ opponent(m) }}</td>
+                <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums">
+                  <span v-if="m.status !== 'dnp'">{{ m[col.key] }}</span>
+                  <span v-else class="text-text-faint">—</span>
+                </td>
+                <td class="py-2 px-2 text-right tabular-nums font-medium text-active">
+                  <span v-if="m.status !== 'dnp'">{{ m.score }}</span>
+                  <span v-else class="text-text-faint">—</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- FFL history -->
+      <section>
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">FFL History</h2>
+        <div v-if="stintsLoading" class="text-text-faint text-sm">Loading...</div>
+        <div v-else-if="stints.length === 0" class="text-text-faint text-sm">Not in any FFL squad this season.</div>
+        <div v-else class="flex flex-col gap-6">
+          <div v-for="stint in stints" :key="stint.id">
+            <div class="flex items-center gap-2 mb-2">
+              <span class="font-semibold text-text">{{ stint.club.name }}</span>
+              <span v-if="stintRoundRange(stint)" class="text-xs text-text-muted">{{ stintRoundRange(stint) }}</span>
+            </div>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="border-b border-border text-left text-text-muted">
+                    <th class="py-1.5 pr-3 font-medium">Round</th>
+                    <th class="py-1.5 px-2 font-medium">Pos</th>
+                    <th class="py-1.5 px-2 font-medium text-right">*</th>
+                    <th class="py-1.5 px-2 font-medium text-text-faint text-xs">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="pm in sortedStintMatches(stint)"
+                    :key="pm.id"
+                    class="border-b border-border-subtle"
+                    :class="pm.aflStatus === 'dnp' ? 'opacity-40' : 'hover:bg-surface-hover'"
+                  >
+                    <td class="py-1.5 pr-3 text-xs text-text-muted tabular-nums">{{ fflMatchRound(pm) }}</td>
+                    <td class="py-1.5 px-2">
+                      <span v-if="pm.position" :class="positionColor(pm.position)" class="font-medium text-xs">
+                        {{ positionLetter(pm.position) }}
+                      </span>
+                      <span v-else class="text-text-faint">—</span>
+                    </td>
+                    <td class="py-1.5 px-2 text-right tabular-nums font-medium text-active">
+                      <span v-if="pm.aflStatus !== 'dnp'">{{ pm.score }}</span>
+                      <span v-else class="text-text-faint">—</span>
+                    </td>
+                    <td class="py-1.5 px-2 text-xs text-text-faint">{{ pm.aflStatus ?? pm.status ?? '—' }}</td>
+                  </tr>
+                </tbody>
+                <tfoot v-if="stintPlayedCount(stint) > 0">
+                  <tr class="border-t border-border text-text-muted text-xs">
+                    <td class="py-1.5 pr-3" colspan="2">avg</td>
+                    <td class="py-1.5 px-2 text-right tabular-nums font-medium text-active">{{ stintAvg(stint) }}</td>
+                    <td></td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_AFL_PLAYER_SEASON_STATS, GET_FFL_PLAYER_STINTS } from '../api/queries'
+import Breadcrumb from '../components/Breadcrumb.vue'
+import { POSITION_LETTERS, POSITION_COLORS } from '../utils/position'
+
+const props = defineProps<{ aflPlayerSeasonId: string }>()
+
+// --- AFL stats query ---
+
+const { result: aflResult, loading, error } = useQuery(
+  GET_AFL_PLAYER_SEASON_STATS,
+  () => ({ id: props.aflPlayerSeasonId }),
+)
+
+const playerSeason = computed(() => aflResult.value?.aflPlayerSeason ?? null)
+
+// --- FFL stints query ---
+
+const { result: fflResult, loading: stintsLoading } = useQuery(
+  GET_FFL_PLAYER_STINTS,
+  () => ({ aflPlayerSeasonId: props.aflPlayerSeasonId }),
+)
+
+const stints = computed(() => fflResult.value?.fflPlayerSeasonsByAflPlayerSeason ?? [])
+
+// --- Breadcrumb ---
+
+const breadcrumbs = computed(() => {
+  if (!playerSeason.value) return []
+  return [
+    { label: 'FFL', to: { name: 'home' } },
+    { label: playerSeason.value.clubSeason.season.name },
+    { label: playerSeason.value.player.name },
+  ]
+})
+
+// --- AFL stats ---
+
+interface AFLPlayerMatch {
+  id: string
+  status: string
+  kicks: number
+  handballs: number
+  marks: number
+  tackles: number
+  hitouts: number
+  goals: number
+  behinds: number
+  score: number
+  clubMatch: {
+    club: { id: string; name: string }
+    match: {
+      round: { id: string; name: string }
+      homeClubMatch: { club: { id: string; name: string } }
+      awayClubMatch: { club: { id: string; name: string } }
+    }
+  }
+}
+
+const statCols = [
+  { key: 'kicks' as const,    label: 'K' },
+  { key: 'handballs' as const, label: 'HB' },
+  { key: 'marks' as const,    label: 'M' },
+  { key: 'hitouts' as const,  label: 'HO' },
+  { key: 'tackles' as const,  label: 'T' },
+  { key: 'goals' as const,    label: 'G' },
+  { key: 'behinds' as const,  label: 'B' },
+]
+
+type StatKey = typeof statCols[number]['key'] | 'score'
+
+const sortedMatches = computed((): AFLPlayerMatch[] => {
+  const ms = playerSeason.value?.matches ?? []
+  return [...ms].sort((a, b) => parseInt(a.clubMatch.match.round.id) - parseInt(b.clubMatch.match.round.id))
+})
+
+const playedMatches = computed(() =>
+  sortedMatches.value.filter(m => m.status === 'played' || m.status === 'playing'),
+)
+
+function avg(key: StatKey): string {
+  const n = playedMatches.value.length
+  if (n === 0) return '—'
+  const sum = playedMatches.value.reduce((s, m) => s + m[key], 0)
+  return (sum / n).toFixed(1)
+}
+
+function opponent(m: AFLPlayerMatch): string {
+  const myId = playerSeason.value?.clubSeason.club.id
+  const home = m.clubMatch.match.homeClubMatch.club
+  const away = m.clubMatch.match.awayClubMatch.club
+  return home.id === myId ? away.name : home.name
+}
+
+// --- FFL stints ---
+
+interface FFLPlayerMatchData {
+  id: string
+  position: string | null
+  status: string | null
+  aflStatus: string | null
+  score: number
+  aflPlayerMatch: {
+    id: string
+    clubMatch: {
+      match: {
+        round: { id: string; name: string }
+      }
+    }
+  } | null
+}
+
+interface FFLStint {
+  id: string
+  club: { id: string; name: string }
+  fromRoundId: string | null
+  toRoundId: string | null
+  playerMatches: FFLPlayerMatchData[]
+}
+
+function fflMatchRound(pm: FFLPlayerMatchData): string {
+  if (pm.aflPlayerMatch) return pm.aflPlayerMatch.clubMatch.match.round.name
+  if (pm.aflStatus === 'bye') return 'Bye'
+  return '—'
+}
+
+function fflMatchRoundId(pm: FFLPlayerMatchData): number {
+  if (pm.aflPlayerMatch) return parseInt(pm.aflPlayerMatch.clubMatch.match.round.id)
+  return 0
+}
+
+function sortedStintMatches(stint: FFLStint): FFLPlayerMatchData[] {
+  return [...stint.playerMatches].sort((a, b) => fflMatchRoundId(a) - fflMatchRoundId(b))
+}
+
+function stintRoundRange(stint: FFLStint): string {
+  const sorted = sortedStintMatches(stint)
+  const first = sorted.find(pm => fflMatchRound(pm) !== '—')
+  const last = [...sorted].reverse().find(pm => fflMatchRound(pm) !== '—')
+  if (!first) return ''
+  const from = fflMatchRound(first)
+  const to = last ? fflMatchRound(last) : from
+  return from === to ? from : `${from} – ${to}`
+}
+
+function stintPlayedCount(stint: FFLStint): number {
+  return stint.playerMatches.filter(pm => pm.aflStatus !== 'dnp').length
+}
+
+function stintAvg(stint: FFLStint): string {
+  const played = stint.playerMatches.filter(pm => pm.aflStatus !== 'dnp')
+  if (played.length === 0) return '—'
+  const sum = played.reduce((s, pm) => s + pm.score, 0)
+  return (sum / played.length).toFixed(1)
+}
+
+function positionLetter(pos: string): string {
+  return POSITION_LETTERS[pos] ?? pos
+}
+
+function positionColor(pos: string): string {
+  return POSITION_COLORS[pos] ?? 'text-text'
+}
+</script>

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -72,7 +72,15 @@
                   ]"
                   @click="managing && toggleRow(row)"
                 >
-                  <td class="py-2 pr-4 font-medium">{{ row.player.aflPlayer.name }}</td>
+                  <td class="py-2 pr-4 font-medium">
+                    <router-link
+                      v-if="row.aflPlayerSeason?.id"
+                      :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }"
+                      class="hover:underline hover:text-active transition-colors"
+                      @click.stop
+                    >{{ row.player.aflPlayer.name }}</router-link>
+                    <span v-else>{{ row.player.aflPlayer.name }}</span>
+                  </td>
                   <td class="py-2 pr-4 text-xs text-text-muted">{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</td>
                   <td class="py-2">
                     <div class="flex gap-0.5">
@@ -142,7 +150,15 @@
                   ]"
                   @click="managing && toggleRow(row)"
                 >
-                  <td class="py-2 pr-4 font-medium">{{ row.player.aflPlayer.name }}</td>
+                  <td class="py-2 pr-4 font-medium">
+                    <router-link
+                      v-if="row.aflPlayerSeason?.id"
+                      :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }"
+                      class="hover:underline hover:text-active transition-colors"
+                      @click.stop
+                    >{{ row.player.aflPlayer.name }}</router-link>
+                    <span v-else>{{ row.player.aflPlayer.name }}</span>
+                  </td>
                   <td class="py-2 pr-4 text-xs text-text-muted">{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</td>
                   <td class="py-2">
                     <div class="flex gap-0.5">
@@ -430,7 +446,7 @@ async function onPlayerAdded() {
 interface PlayerSeasonRow {
   id: string
   player: { id: string; aflPlayerId: string; aflPlayer: { id: string; name: string } }
-  aflPlayerSeason?: { clubSeason?: { club?: { name: string } } } | null
+  aflPlayerSeason?: { id: string; clubSeason?: { club?: { name: string } } } | null
   fromRoundId?: string | null
   toRoundId?: string | null
   notes?: string | null

--- a/plans/player-club-pages.md
+++ b/plans/player-club-pages.md
@@ -1,0 +1,124 @@
+# Player & Club Pages — Design
+
+Planning doc. Will be folded into roadmap (likely expanding Phase 22) once prioritised.
+
+---
+
+## Decisions
+
+- **No pure AFL pages (A1/A2).** The AFL section stays as-is (home / rounds / matches). AFL ladder club links and AFL match player links point to their FFL-lens equivalents.
+- **URL scheme:** `/ffl/afl/` sub-namespace for FFL's view of AFL entities.
+- **Future all-time pages** (`/ffl/afl/clubs/:id`, `/ffl/afl/players/:id`) follow the same namespace naturally.
+
+---
+
+## Pages
+
+### Player pages
+
+| URL | Key | What it shows |
+|---|---|---|
+| `/ffl/afl/player-seasons/:aflPlayerSeasonId` | `afl.player_season.id` | FFL league view — all FFL ownership stints across the season (incl. unowned gaps), per-round k/h/m/t/r/g + * score + FFL position |
+| `/ffl/player-seasons/:fflPlayerSeasonId` | `ffl.player_season.id` | FFL club view — one ownership stint, club-specific notes, averages scoped to that stint |
+
+**Why each page exists:**
+
+- `/ffl/afl/player-seasons/` — the most valuable page in the system. Nowhere else shows FFL scoring + FFL ownership history for an AFL player in one place. Unowned periods are visible (trade-target intelligence). Entry point from AFL match view and FFL squad view.
+- `/ffl/player-seasons/` — one club's ownership stint. Notes are private to that club. Averages scoped to "while they were mine". Already partially exists as the expand-row in SquadView; this is a promotion to a full page.
+
+**Traded player example** on `/ffl/afl/player-seasons/42`:
+```
+Rnd   FFL Club    Pos   K   H   M   T   R   G    *
+1–4   (unowned)   —     8   6   3   2   0   0    —
+5–10  Ruiboys     DEF   9   5   4   3   0   0   38
+11–13 Cheetahs    MID  11   7   2   4   1   0   52
+```
+The `/ffl/player-seasons/` for Ruiboys is a separate page covering rounds 5–10 with Ruiboys' own notes.
+
+---
+
+### Club pages
+
+| URL | Key | What it shows |
+|---|---|---|
+| `/ffl/afl/club-seasons/:aflClubSeasonId` | `afl.club_season.id` | FFL league view of an AFL club — all players, FFL ownership, * averages (see layout below) |
+
+`/ffl/club-seasons/:fflClubSeasonId` already exists (SquadView). No new page needed.
+
+**`/ffl/afl/club-seasons/:id` page layout — multiple sections:**
+
+1. **Master table** — all players at this AFL club (including unowned), alpha default, sortable columns: name / FFL club / position(s) / k / h / m / t / r / g / * avg.
+2. **FFL ownership summary** — "6 Ruiboys, 4 Cheetahs, 3 unowned"; total * scoring contribution per FFL club from this AFL club's players.
+3. **Best unowned** — sublist of unowned players sorted by * average desc. *(A full cross-club free-agent list is a separate future feature.)*
+
+---
+
+### Future all-time pages (noted, not scoped)
+
+- `/ffl/afl/clubs/:aflClubId` — FFL history of an AFL club across all seasons (how many players drafted, aggregate scoring over the years, etc.)
+- `/ffl/afl/players/:aflPlayerId` — FFL career of an AFL player (how many seasons, which FFL clubs, total * points, FFL games played, etc.)
+
+---
+
+## Navigation diagram
+
+```plantuml
+@startuml
+!theme plain
+skinparam defaultTextAlignment center
+skinparam rectangle {
+  BackgroundColor #f8f8f8
+  BorderColor #aaaaaa
+}
+skinparam package {
+  BackgroundColor #eef4ff
+  BorderColor #7799cc
+}
+
+package "AFL section" {
+  rectangle "/afl\nHome / Ladder" as AFL_Home
+  rectangle "/afl/rounds/:id\nRound" as AFL_Round
+  rectangle "/afl/matches/:id\nMatch" as AFL_Match
+}
+
+package "FFL section — club management" {
+  rectangle "/ffl\nHome" as FFL_Home
+  rectangle "/ffl/rounds/:id\nRound" as FFL_Round
+  rectangle "/ffl/matches/:id\nMatch" as FFL_Match
+  rectangle "/ffl/club-seasons/:id\nSquad (existing)" as FFL_Squad
+}
+
+package "FFL section — AFL lens  (new)" {
+  rectangle "/ffl/afl/club-seasons/:id\nAFL Club Season" as FFL_AFL_Club
+  rectangle "/ffl/afl/player-seasons/:id\nAFL Player Season" as FFL_AFL_Player
+  rectangle "/ffl/player-seasons/:id\nPlayer Stint" as FFL_Player_Stint
+}
+
+AFL_Home      --> AFL_Round        : round nav
+AFL_Round     --> AFL_Match        : match row
+AFL_Match     --> FFL_AFL_Player   : player name
+AFL_Home      --> FFL_AFL_Club     : ladder club name
+
+FFL_Home      --> FFL_Round        : round nav
+FFL_Round     --> FFL_Match        : match row
+FFL_Round     --> FFL_Squad        : club name
+FFL_Squad     --> FFL_AFL_Club     : AFL club name
+FFL_Squad     --> FFL_Player_Stint : player name
+FFL_Match     --> FFL_Player_Stint : player name
+
+FFL_AFL_Club  --> FFL_AFL_Player   : player name
+FFL_AFL_Player --> FFL_Player_Stint : own-club stint row
+FFL_Player_Stint --> FFL_AFL_Player : "season overview"
+
+@enduml
+```
+
+---
+
+## Backend work per page
+
+| Page | Backend needed |
+|---|---|
+| `/ffl/afl/player-seasons/` | FFL query by AFL player season ID; return all FFL stints + unowned rounds; cross-subgraph via federation |
+| `/ffl/player-seasons/` | Largely exists; may need a dedicated `fflPlayerSeason(id)` resolver with more detail than SquadView currently fetches |
+| `/ffl/afl/club-seasons/` | New resolver: `AFLClubSeason.players → [AFLPlayerSeason!]!`; FFL ownership joined in via federation |

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -218,23 +218,24 @@ Full stack rebuild (backend + frontend). Gateway introduced early so frontends a
 - [ ] Pluggable FFL scoring formula — strategy pattern keyed per season (prerequisite for Phase 23 backfill)
 - [ ] Close out: drop `ffl.player.drv_name`, retire `parse_forum.py`, move stats import status to dataops table
 
-## Phase 21: Search Frontend + Index Enrichment
+## Phase 21: UX — Player & Club Pages
+
+**Goal:** FFL-lens player and club detail pages. See [`plans/player-club-pages.md`](player-club-pages.md) for full design.
+
+- [ ] `/ffl/afl/club-seasons/:id` — FFL view of AFL club: all players (incl. unowned), FFL ownership summary, best unowned sublist, sortable master table
+- [ ] `/ffl/afl/player-seasons/:id` — FFL league view of AFL player: all FFL stints + unowned gaps, per-round stats + * score + position
+- [ ] `/ffl/player-seasons/:id` — FFL club view of one player stint: scoped averages, club-specific notes (promotion of SquadView expand-row)
+- [ ] Wire AFL ladder club links → `/ffl/afl/club-seasons/`; AFL match player links → `/ffl/afl/player-seasons/`
+- [ ] Team Builder player analytics — season averages, rolling averages, last-N-games stats surfaced at team-building time (season average is first use case, required for bye scoring)
+- [ ] Playwright tests
+
+## Phase 22: Search Frontend + Index Enrichment
 
 **Goal:** Search UI backed by an enriched Typesense index with whatever data the UX needs.
 
 - [ ] Search view — full-text search with filters (source, type)
 - [ ] Expand search index as needed to support UX data requirements (player stats, aggregates, etc.)
 - [ ] Playwright tests
-
-## Phase 22: UX — Player & Team Pages
-
-**Goal:** Player and team detail pages with career stats, season history, and richer stat data across existing views.
-
-- [ ] Player pages — career stats, season history, club timeline
-- [ ] Team pages — squad, round-by-round scores, season summary
-- [ ] Other season pages (TBD based on usage)
-- [ ] Richer stat data surfaced in existing views
-- [ ] Team Builder player analytics — season averages, rolling averages, last-N-games stats, and other aggregates surfaced at team-building time to support TM decision-making (season average is first use case, required for bye scoring)
 
 ## Phase 23: Data Management — Data Setup & Historical Import
 

--- a/services/ffl/api/graphql/query.graphqls
+++ b/services/ffl/api/graphql/query.graphqls
@@ -13,6 +13,8 @@ type Query {
 
   fflRoundByAflRound(aflRoundId: ID!): FFLRound
   fflClubMatch(id: ID!): FFLClubMatch
+
+  fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: ID!): [FFLPlayerSeason!]!
 }
 
 type FFLSeason {
@@ -81,6 +83,7 @@ type FFLPlayer {
 type FFLPlayerSeason {
   id: ID!
   player: FFLPlayer!
+  club: FFLClub!
   clubSeasonId: ID!
   aflPlayerSeasonId: ID
   aflPlayerSeason: AFLPlayerSeason
@@ -88,6 +91,7 @@ type FFLPlayerSeason {
   toRoundId: ID
   notes: String
   costCents: Int
+  playerMatches: [FFLPlayerMatch!]!
 }
 
 type FFLPlayerSeasonConnection {

--- a/services/ffl/gqlgen.yml
+++ b/services/ffl/gqlgen.yml
@@ -58,7 +58,9 @@ models:
 
   FFLPlayerSeason:
     fields:
+      club: { resolver: true }
       aflPlayerSeason: { resolver: true }
+      playerMatches: { resolver: true }
 
   FFLPlayerMatch:
     fields:

--- a/services/ffl/internal/application/queries.go
+++ b/services/ffl/internal/application/queries.go
@@ -123,6 +123,14 @@ func (q *Queries) GetPlayerSeasonByID(ctx context.Context, id int) (domain.Playe
 	return q.playerSeasons.FindByID(ctx, id)
 }
 
+func (q *Queries) GetPlayerSeasonsByAFLPlayerSeasonID(ctx context.Context, aflPlayerSeasonID int) ([]domain.PlayerSeason, error) {
+	return q.playerSeasons.FindByAFLPlayerSeasonID(ctx, aflPlayerSeasonID)
+}
+
+func (q *Queries) GetPlayerMatchesByPlayerSeasonID(ctx context.Context, playerSeasonID int) ([]domain.PlayerMatch, error) {
+	return q.playerMatches.FindByPlayerSeasonID(ctx, playerSeasonID)
+}
+
 func (q *Queries) GetClubsByIDs(ctx context.Context, ids []int) (map[int]domain.Club, error) {
 	return q.clubs.FindByIDs(ctx, ids)
 }

--- a/services/ffl/internal/domain/player_match.go
+++ b/services/ffl/internal/domain/player_match.go
@@ -188,6 +188,7 @@ type PlayerMatchRepository interface {
 	DeleteByID(ctx context.Context, id int) error
 	FindByClubMatchID(ctx context.Context, clubMatchID int) ([]PlayerMatch, error)
 	FindByID(ctx context.Context, id int) (PlayerMatch, error)
+	FindByPlayerSeasonID(ctx context.Context, playerSeasonID int) ([]PlayerMatch, error)
 	FindByPlayerSeasonAndRound(ctx context.Context, playerSeasonID int, roundID int) (PlayerMatch, error)
 	UpdateAFLPlayerMatchID(ctx context.Context, id int, aflPlayerMatchID int) error
 	UpdateStatus(ctx context.Context, id int, status PlayerMatchStatus) error

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -560,6 +560,19 @@ func (r *PlayerMatchRepository) FindByID(ctx context.Context, id int) (domain.Pl
 		row.Position, row.Status, row.DrvAflStatus, row.BackupPositions, row.InterchangePosition, row.DisplayOrder, row.DrvScore, row.AflPlayerMatchID), nil
 }
 
+func (r *PlayerMatchRepository) FindByPlayerSeasonID(ctx context.Context, playerSeasonID int) ([]domain.PlayerMatch, error) {
+	rows, err := r.q.FindPlayerMatchesByPlayerSeasonID(ctx, int32(playerSeasonID))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.PlayerMatch, len(rows))
+	for i, row := range rows {
+		out[i] = toPlayerMatch(row.ID, row.ClubMatchID, row.PlayerSeasonID,
+			row.Position, row.Status, row.DrvAflStatus, row.BackupPositions, row.InterchangePosition, row.DisplayOrder, row.DrvScore, row.AflPlayerMatchID)
+	}
+	return out, nil
+}
+
 func (r *PlayerMatchRepository) FindByPlayerSeasonAndRound(ctx context.Context, playerSeasonID int, roundID int) (domain.PlayerMatch, error) {
 	row, err := r.q.FindPlayerMatchByPlayerSeasonAndRound(ctx, sqlcgen.FindPlayerMatchByPlayerSeasonAndRoundParams{
 		PlayerSeasonID: int32(playerSeasonID),

--- a/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/player_match.sql
@@ -1,3 +1,10 @@
+-- name: FindPlayerMatchesByPlayerSeasonID :many
+SELECT id, club_match_id, player_season_id,
+       position, status, drv_afl_status, backup_positions, interchange_position, display_order, drv_score, afl_player_match_id
+FROM ffl.player_match
+WHERE player_season_id = $1 AND deleted_at IS NULL
+ORDER BY id;
+
 -- name: FindPlayerMatchesByClubMatchID :many
 SELECT id, club_match_id, player_season_id,
        position, status, drv_afl_status, backup_positions, interchange_position, display_order, drv_score, afl_player_match_id

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/player_match.sql.go
@@ -186,6 +186,60 @@ func (q *Queries) FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchI
 	return items, nil
 }
 
+const findPlayerMatchesByPlayerSeasonID = `-- name: FindPlayerMatchesByPlayerSeasonID :many
+SELECT id, club_match_id, player_season_id,
+       position, status, drv_afl_status, backup_positions, interchange_position, display_order, drv_score, afl_player_match_id
+FROM ffl.player_match
+WHERE player_season_id = $1 AND deleted_at IS NULL
+ORDER BY id
+`
+
+type FindPlayerMatchesByPlayerSeasonIDRow struct {
+	ID                  int32
+	ClubMatchID         int32
+	PlayerSeasonID      int32
+	Position            *string
+	Status              *string
+	DrvAflStatus        *string
+	BackupPositions     *string
+	InterchangePosition *string
+	DisplayOrder        int32
+	DrvScore            *int32
+	AflPlayerMatchID    *int32
+}
+
+func (q *Queries) FindPlayerMatchesByPlayerSeasonID(ctx context.Context, playerSeasonID int32) ([]FindPlayerMatchesByPlayerSeasonIDRow, error) {
+	rows, err := q.db.Query(ctx, findPlayerMatchesByPlayerSeasonID, playerSeasonID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindPlayerMatchesByPlayerSeasonIDRow{}
+	for rows.Next() {
+		var i FindPlayerMatchesByPlayerSeasonIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ClubMatchID,
+			&i.PlayerSeasonID,
+			&i.Position,
+			&i.Status,
+			&i.DrvAflStatus,
+			&i.BackupPositions,
+			&i.InterchangePosition,
+			&i.DisplayOrder,
+			&i.DrvScore,
+			&i.AflPlayerMatchID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateAFLPlayerMatchID = `-- name: UpdateAFLPlayerMatchID :exec
 UPDATE ffl.player_match
 SET afl_player_match_id = $2, updated_at = CURRENT_TIMESTAMP

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -36,6 +36,7 @@ type Querier interface {
 	FindPlayerMatchByID(ctx context.Context, id int32) (FindPlayerMatchByIDRow, error)
 	FindPlayerMatchByPlayerSeasonAndRound(ctx context.Context, arg FindPlayerMatchByPlayerSeasonAndRoundParams) (FindPlayerMatchByPlayerSeasonAndRoundRow, error)
 	FindPlayerMatchesByClubMatchID(ctx context.Context, clubMatchID int32) ([]FindPlayerMatchesByClubMatchIDRow, error)
+	FindPlayerMatchesByPlayerSeasonID(ctx context.Context, playerSeasonID int32) ([]FindPlayerMatchesByPlayerSeasonIDRow, error)
 	FindPlayerSeasonByID(ctx context.Context, id int32) (FindPlayerSeasonByIDRow, error)
 	FindPlayerSeasonsByAFLPlayerSeasonID(ctx context.Context, aflPlayerSeasonID int32) ([]FindPlayerSeasonsByAFLPlayerSeasonIDRow, error)
 	FindPlayerSeasonsByClubSeasonID(ctx context.Context, clubSeasonID int32) ([]FindPlayerSeasonsByClubSeasonIDRow, error)

--- a/services/ffl/internal/interface/graphql/afl_player_season_integration_test.go
+++ b/services/ffl/internal/interface/graphql/afl_player_season_integration_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+package graphql_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFflPlayerSeasonsByAflPlayerSeason covers the new query and the two new
+// fields it exposes: FFLPlayerSeason.club and FFLPlayerSeason.playerMatches.
+func TestFflPlayerSeasonsByAflPlayerSeason(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+	ctx := context.Background()
+
+	// Create a real AFL player season so the FK is valid.
+	aflSeasonID := insertAFLSeason(t, pool)
+	aflPlayerSeasonID := insertAFLPlayerSeason(t, pool, aflSeasonID)
+
+	// Point the seeded FFL player season at the real AFL player season.
+	_, err := pool.Exec(ctx,
+		"UPDATE ffl.player_season SET afl_player_season_id = $1 WHERE id = $2",
+		aflPlayerSeasonID, ids.playerSeasonID)
+	require.NoError(t, err)
+
+	apsIDStr := fmt.Sprintf("%d", aflPlayerSeasonID)
+
+	result := execQuery(t, server, `{
+		fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: "`+apsIDStr+`") {
+			id
+			clubSeasonId
+			club { id name }
+			playerMatches {
+				id
+				position
+				status
+				aflStatus
+				score
+			}
+		}
+	}`)
+	require.Empty(t, result.Errors)
+
+	var data struct {
+		FflPlayerSeasonsByAflPlayerSeason []struct {
+			ID           string `json:"id"`
+			ClubSeasonID string `json:"clubSeasonId"`
+			Club         struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"club"`
+			PlayerMatches []struct {
+				ID        string  `json:"id"`
+				Position  *string `json:"position"`
+				Status    *string `json:"status"`
+				AflStatus *string `json:"aflStatus"`
+				Score     int     `json:"score"`
+			} `json:"playerMatches"`
+		} `json:"fflPlayerSeasonsByAflPlayerSeason"`
+	}
+	require.NoError(t, json.Unmarshal(result.Data, &data))
+
+	t.Run("returns the player season linked to the AFL player season ID", func(t *testing.T) {
+		require.Len(t, data.FflPlayerSeasonsByAflPlayerSeason, 1)
+		assert.Equal(t, fmt.Sprintf("%d", ids.playerSeasonID), data.FflPlayerSeasonsByAflPlayerSeason[0].ID)
+		assert.Equal(t, fmt.Sprintf("%d", ids.homeClubSeaID), data.FflPlayerSeasonsByAflPlayerSeason[0].ClubSeasonID)
+	})
+
+	t.Run("club is resolved from the club season", func(t *testing.T) {
+		require.Len(t, data.FflPlayerSeasonsByAflPlayerSeason, 1)
+		club := data.FflPlayerSeasonsByAflPlayerSeason[0].Club
+		assert.NotEmpty(t, club.ID)
+		assert.Equal(t, "Test Eagles", club.Name)
+	})
+
+	t.Run("player matches are returned with correct position and score", func(t *testing.T) {
+		require.Len(t, data.FflPlayerSeasonsByAflPlayerSeason, 1)
+		pms := data.FflPlayerSeasonsByAflPlayerSeason[0].PlayerMatches
+		require.Len(t, pms, 1)
+		require.NotNil(t, pms[0].Position)
+		assert.Equal(t, "goals", *pms[0].Position)
+		require.NotNil(t, pms[0].AflStatus)
+		assert.Equal(t, "played", *pms[0].AflStatus)
+		assert.Equal(t, 15, pms[0].Score)
+	})
+}
+
+func TestFflPlayerSeasonsByAflPlayerSeason_UnknownID(t *testing.T) {
+	pool := connectDB(t)
+	seedTestData(t, pool)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+
+	result := execQuery(t, server, `{
+		fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: "999999") { id }
+	}`)
+	require.Empty(t, result.Errors)
+
+	var data struct {
+		FflPlayerSeasonsByAflPlayerSeason []struct{ ID string } `json:"fflPlayerSeasonsByAflPlayerSeason"`
+	}
+	require.NoError(t, json.Unmarshal(result.Data, &data))
+
+	t.Run("returns empty list for an AFL player season with no FFL stints", func(t *testing.T) {
+		assert.Empty(t, data.FflPlayerSeasonsByAflPlayerSeason)
+	})
+}
+
+func TestFflPlayerSeasonsByAflPlayerSeason_MultipleFflStints(t *testing.T) {
+	pool := connectDB(t)
+	ids := seedTestData(t, pool)
+	server := setupTestServer(t, pool)
+	defer server.Close()
+	ctx := context.Background()
+
+	// Create a real AFL player season.
+	aflSeasonID := insertAFLSeason(t, pool)
+	aflPlayerSeasonID := insertAFLPlayerSeason(t, pool, aflSeasonID)
+
+	// Link the existing FFL player season (home club) to this AFL player season.
+	_, err := pool.Exec(ctx,
+		"UPDATE ffl.player_season SET afl_player_season_id = $1 WHERE id = $2",
+		aflPlayerSeasonID, ids.playerSeasonID)
+	require.NoError(t, err)
+
+	// Add a second FFL player season for the same AFL player season (away club — simulates a trade).
+	var ps2ID int
+	require.NoError(t, pool.QueryRow(ctx,
+		"INSERT INTO ffl.player_season (player_id, club_season_id, afl_player_season_id) VALUES ($1, $2, $3) RETURNING id",
+		ids.playerID, ids.awayClubSeaID, aflPlayerSeasonID).Scan(&ps2ID))
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM ffl.player_season WHERE id = $1", ps2ID)
+	})
+
+	apsIDStr := fmt.Sprintf("%d", aflPlayerSeasonID)
+	result := execQuery(t, server, `{
+		fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: "`+apsIDStr+`") {
+			id
+			club { name }
+		}
+	}`)
+	require.Empty(t, result.Errors)
+
+	var data struct {
+		FflPlayerSeasonsByAflPlayerSeason []struct {
+			ID   string `json:"id"`
+			Club struct {
+				Name string `json:"name"`
+			} `json:"club"`
+		} `json:"fflPlayerSeasonsByAflPlayerSeason"`
+	}
+	require.NoError(t, json.Unmarshal(result.Data, &data))
+
+	t.Run("returns one stint per FFL club that held the player", func(t *testing.T) {
+		assert.Len(t, data.FflPlayerSeasonsByAflPlayerSeason, 2)
+	})
+
+	t.Run("each stint resolves its own FFL club", func(t *testing.T) {
+		clubs := make(map[string]bool)
+		for _, ps := range data.FflPlayerSeasonsByAflPlayerSeason {
+			clubs[ps.Club.Name] = true
+		}
+		assert.True(t, clubs["Test Eagles"], "expected Test Eagles")
+		assert.True(t, clubs["Test Lions"], "expected Test Lions")
+	})
+}

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -137,12 +137,14 @@ type ComplexityRoot struct {
 	FFLPlayerSeason struct {
 		AflPlayerSeason   func(childComplexity int) int
 		AflPlayerSeasonID func(childComplexity int) int
+		Club              func(childComplexity int) int
 		ClubSeasonID      func(childComplexity int) int
 		CostCents         func(childComplexity int) int
 		FromRoundID       func(childComplexity int) int
 		ID                func(childComplexity int) int
 		Notes             func(childComplexity int) int
 		Player            func(childComplexity int) int
+		PlayerMatches     func(childComplexity int) int
 		ToRoundID         func(childComplexity int) int
 	}
 
@@ -195,19 +197,20 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		FflClub            func(childComplexity int, id string) int
-		FflClubMatch       func(childComplexity int, id string) int
-		FflClubSeason      func(childComplexity int, id string) int
-		FflClubs           func(childComplexity int) int
-		FflMatch           func(childComplexity int, id string) int
-		FflPlayer          func(childComplexity int, id string) int
-		FflPlayers         func(childComplexity int) int
-		FflRound           func(childComplexity int, id string) int
-		FflRoundByAflRound func(childComplexity int, aflRoundID string) int
-		FflSeason          func(childComplexity int, id string) int
-		FflSeasons         func(childComplexity int) int
-		__resolve__service func(childComplexity int) int
-		__resolve_entities func(childComplexity int, representations []map[string]any) int
+		FflClub                           func(childComplexity int, id string) int
+		FflClubMatch                      func(childComplexity int, id string) int
+		FflClubSeason                     func(childComplexity int, id string) int
+		FflClubs                          func(childComplexity int) int
+		FflMatch                          func(childComplexity int, id string) int
+		FflPlayer                         func(childComplexity int, id string) int
+		FflPlayerSeasonsByAflPlayerSeason func(childComplexity int, aflPlayerSeasonID string) int
+		FflPlayers                        func(childComplexity int) int
+		FflRound                          func(childComplexity int, id string) int
+		FflRoundByAflRound                func(childComplexity int, aflRoundID string) int
+		FflSeason                         func(childComplexity int, id string) int
+		FflSeasons                        func(childComplexity int) int
+		__resolve__service                func(childComplexity int) int
+		__resolve_entities                func(childComplexity int, representations []map[string]any) int
 	}
 
 	ResolvedPlayer struct {
@@ -256,7 +259,11 @@ type FFLPlayerMatchResolver interface {
 	AflPlayerMatch(ctx context.Context, obj *FFLPlayerMatch) (*AFLPlayerMatch, error)
 }
 type FFLPlayerSeasonResolver interface {
+	Club(ctx context.Context, obj *FFLPlayerSeason) (*FFLClub, error)
+
 	AflPlayerSeason(ctx context.Context, obj *FFLPlayerSeason) (*AFLPlayerSeason, error)
+
+	PlayerMatches(ctx context.Context, obj *FFLPlayerSeason) ([]*FFLPlayerMatch, error)
 }
 type FFLRoundResolver interface {
 	AflRound(ctx context.Context, obj *FFLRound) (*AFLRound, error)
@@ -294,6 +301,7 @@ type QueryResolver interface {
 	FflPlayer(ctx context.Context, id string) (*FFLPlayer, error)
 	FflRoundByAflRound(ctx context.Context, aflRoundID string) (*FFLRound, error)
 	FflClubMatch(ctx context.Context, id string) (*FFLClubMatch, error)
+	FflPlayerSeasonsByAflPlayerSeason(ctx context.Context, aflPlayerSeasonID string) ([]*FFLPlayerSeason, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -688,6 +696,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FFLPlayerSeason.AflPlayerSeasonID(childComplexity), true
+	case "FFLPlayerSeason.club":
+		if e.ComplexityRoot.FFLPlayerSeason.Club == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLPlayerSeason.Club(childComplexity), true
 	case "FFLPlayerSeason.clubSeasonId":
 		if e.ComplexityRoot.FFLPlayerSeason.ClubSeasonID == nil {
 			break
@@ -724,6 +738,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FFLPlayerSeason.Player(childComplexity), true
+	case "FFLPlayerSeason.playerMatches":
+		if e.ComplexityRoot.FFLPlayerSeason.PlayerMatches == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLPlayerSeason.PlayerMatches(childComplexity), true
 	case "FFLPlayerSeason.toRoundId":
 		if e.ComplexityRoot.FFLPlayerSeason.ToRoundID == nil {
 			break
@@ -1038,6 +1058,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.FflPlayer(childComplexity, args["id"].(string)), true
+	case "Query.fflPlayerSeasonsByAflPlayerSeason":
+		if e.ComplexityRoot.Query.FflPlayerSeasonsByAflPlayerSeason == nil {
+			break
+		}
+
+		args, err := ec.field_Query_fflPlayerSeasonsByAflPlayerSeason_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.FflPlayerSeasonsByAflPlayerSeason(childComplexity, args["aflPlayerSeasonId"].(string)), true
 	case "Query.fflPlayers":
 		if e.ComplexityRoot.Query.FflPlayers == nil {
 			break
@@ -1291,7 +1322,11 @@ var sources = []*ast.Source{
   "Calculate and store the fantasy score for a player match from AFL stats."
   calculateFFLFantasyScore(input: CalculateFFLFantasyScoreInput!): FFLPlayerMatch!
 
-  "Set the complete team selection for a club match."
+  """
+  Set the complete team selection for a club match.
+  Errors:
+    BYE_INELIGIBLE — extensions.playerSeasonId identifies the ineligible player.
+  """
   setFFLTeam(input: SetFFLTeamInput!): [FFLPlayerMatch!]!
 
   "Parse a forum post and resolve players against the squad. Returns a result for review — no DB writes."
@@ -1432,6 +1467,8 @@ enum FFLReorderDirection {
 
   fflRoundByAflRound(aflRoundId: ID!): FFLRound
   fflClubMatch(id: ID!): FFLClubMatch
+
+  fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: ID!): [FFLPlayerSeason!]!
 }
 
 type FFLSeason {
@@ -1500,6 +1537,7 @@ type FFLPlayer {
 type FFLPlayerSeason {
   id: ID!
   player: FFLPlayer!
+  club: FFLClub!
   clubSeasonId: ID!
   aflPlayerSeasonId: ID
   aflPlayerSeason: AFLPlayerSeason
@@ -1507,6 +1545,7 @@ type FFLPlayerSeason {
   toRoundId: ID
   notes: String
   costCents: Int
+  playerMatches: [FFLPlayerMatch!]!
 }
 
 type FFLPlayerSeasonConnection {
@@ -1931,6 +1970,17 @@ func (ec *executionContext) field_Query_fflMatch_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_fflPlayerSeasonsByAflPlayerSeason_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "aflPlayerSeasonId", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["aflPlayerSeasonId"] = arg0
 	return args, nil
 }
 
@@ -3509,6 +3559,8 @@ func (ec *executionContext) fieldContext_FFLPlayerMatch_playerSeason(_ context.C
 				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerSeason_player(ctx, field)
+			case "club":
+				return ec.fieldContext_FFLPlayerSeason_club(ctx, field)
 			case "clubSeasonId":
 				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
 			case "aflPlayerSeasonId":
@@ -3523,6 +3575,8 @@ func (ec *executionContext) fieldContext_FFLPlayerMatch_playerSeason(_ context.C
 				return ec.fieldContext_FFLPlayerSeason_notes(ctx, field)
 			case "costCents":
 				return ec.fieldContext_FFLPlayerSeason_costCents(ctx, field)
+			case "playerMatches":
+				return ec.fieldContext_FFLPlayerSeason_playerMatches(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
 		},
@@ -3898,6 +3952,41 @@ func (ec *executionContext) fieldContext_FFLPlayerSeason_player(_ context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _FFLPlayerSeason_club(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerSeason) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLPlayerSeason_club,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.FFLPlayerSeason().Club(ctx, obj)
+		},
+		nil,
+		ec.marshalNFFLClub2ᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLClub,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLPlayerSeason_club(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLPlayerSeason",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLClub_id(ctx, field)
+			case "name":
+				return ec.fieldContext_FFLClub_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLClub", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FFLPlayerSeason_clubSeasonId(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerSeason) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4105,6 +4194,63 @@ func (ec *executionContext) fieldContext_FFLPlayerSeason_costCents(_ context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _FFLPlayerSeason_playerMatches(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerSeason) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLPlayerSeason_playerMatches,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.FFLPlayerSeason().PlayerMatches(ctx, obj)
+		},
+		nil,
+		ec.marshalNFFLPlayerMatch2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayerMatchᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLPlayerSeason_playerMatches(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLPlayerSeason",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLPlayerMatch_id(ctx, field)
+			case "playerSeasonId":
+				return ec.fieldContext_FFLPlayerMatch_playerSeasonId(ctx, field)
+			case "playerSeason":
+				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
+			case "player":
+				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "position":
+				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
+			case "status":
+				return ec.fieldContext_FFLPlayerMatch_status(ctx, field)
+			case "aflStatus":
+				return ec.fieldContext_FFLPlayerMatch_aflStatus(ctx, field)
+			case "backupPositions":
+				return ec.fieldContext_FFLPlayerMatch_backupPositions(ctx, field)
+			case "interchangePosition":
+				return ec.fieldContext_FFLPlayerMatch_interchangePosition(ctx, field)
+			case "displayOrder":
+				return ec.fieldContext_FFLPlayerMatch_displayOrder(ctx, field)
+			case "score":
+				return ec.fieldContext_FFLPlayerMatch_score(ctx, field)
+			case "aflPlayerMatchId":
+				return ec.fieldContext_FFLPlayerMatch_aflPlayerMatchId(ctx, field)
+			case "aflPlayerMatch":
+				return ec.fieldContext_FFLPlayerMatch_aflPlayerMatch(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerMatch", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FFLPlayerSeasonConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerSeasonConnection) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4133,6 +4279,8 @@ func (ec *executionContext) fieldContext_FFLPlayerSeasonConnection_nodes(_ conte
 				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerSeason_player(ctx, field)
+			case "club":
+				return ec.fieldContext_FFLPlayerSeason_club(ctx, field)
 			case "clubSeasonId":
 				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
 			case "aflPlayerSeasonId":
@@ -4147,6 +4295,8 @@ func (ec *executionContext) fieldContext_FFLPlayerSeasonConnection_nodes(_ conte
 				return ec.fieldContext_FFLPlayerSeason_notes(ctx, field)
 			case "costCents":
 				return ec.fieldContext_FFLPlayerSeason_costCents(ctx, field)
+			case "playerMatches":
+				return ec.fieldContext_FFLPlayerSeason_playerMatches(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
 		},
@@ -4613,6 +4763,8 @@ func (ec *executionContext) fieldContext_Mutation_addFFLPlayerToSeason(ctx conte
 				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerSeason_player(ctx, field)
+			case "club":
+				return ec.fieldContext_FFLPlayerSeason_club(ctx, field)
 			case "clubSeasonId":
 				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
 			case "aflPlayerSeasonId":
@@ -4627,6 +4779,8 @@ func (ec *executionContext) fieldContext_Mutation_addFFLPlayerToSeason(ctx conte
 				return ec.fieldContext_FFLPlayerSeason_notes(ctx, field)
 			case "costCents":
 				return ec.fieldContext_FFLPlayerSeason_costCents(ctx, field)
+			case "playerMatches":
+				return ec.fieldContext_FFLPlayerSeason_playerMatches(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
 		},
@@ -4715,6 +4869,8 @@ func (ec *executionContext) fieldContext_Mutation_updateFFLPlayerSeason(ctx cont
 				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerSeason_player(ctx, field)
+			case "club":
+				return ec.fieldContext_FFLPlayerSeason_club(ctx, field)
 			case "clubSeasonId":
 				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
 			case "aflPlayerSeasonId":
@@ -4729,6 +4885,8 @@ func (ec *executionContext) fieldContext_Mutation_updateFFLPlayerSeason(ctx cont
 				return ec.fieldContext_FFLPlayerSeason_notes(ctx, field)
 			case "costCents":
 				return ec.fieldContext_FFLPlayerSeason_costCents(ctx, field)
+			case "playerMatches":
+				return ec.fieldContext_FFLPlayerSeason_playerMatches(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
 		},
@@ -5978,6 +6136,71 @@ func (ec *executionContext) fieldContext_Query_fflClubMatch(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_fflClubMatch_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_fflPlayerSeasonsByAflPlayerSeason(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_fflPlayerSeasonsByAflPlayerSeason,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().FflPlayerSeasonsByAflPlayerSeason(ctx, fc.Args["aflPlayerSeasonId"].(string))
+		},
+		nil,
+		ec.marshalNFFLPlayerSeason2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayerSeasonᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_fflPlayerSeasonsByAflPlayerSeason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
+			case "player":
+				return ec.fieldContext_FFLPlayerSeason_player(ctx, field)
+			case "club":
+				return ec.fieldContext_FFLPlayerSeason_club(ctx, field)
+			case "clubSeasonId":
+				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
+			case "aflPlayerSeasonId":
+				return ec.fieldContext_FFLPlayerSeason_aflPlayerSeasonId(ctx, field)
+			case "aflPlayerSeason":
+				return ec.fieldContext_FFLPlayerSeason_aflPlayerSeason(ctx, field)
+			case "fromRoundId":
+				return ec.fieldContext_FFLPlayerSeason_fromRoundId(ctx, field)
+			case "toRoundId":
+				return ec.fieldContext_FFLPlayerSeason_toRoundId(ctx, field)
+			case "notes":
+				return ec.fieldContext_FFLPlayerSeason_notes(ctx, field)
+			case "costCents":
+				return ec.fieldContext_FFLPlayerSeason_costCents(ctx, field)
+			case "playerMatches":
+				return ec.fieldContext_FFLPlayerSeason_playerMatches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_fflPlayerSeasonsByAflPlayerSeason_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9607,6 +9830,42 @@ func (ec *executionContext) _FFLPlayerSeason(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "club":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._FFLPlayerSeason_club(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "clubSeasonId":
 			out.Values[i] = ec._FFLPlayerSeason_clubSeasonId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -9655,6 +9914,42 @@ func (ec *executionContext) _FFLPlayerSeason(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._FFLPlayerSeason_notes(ctx, field, obj)
 		case "costCents":
 			out.Values[i] = ec._FFLPlayerSeason_costCents(ctx, field, obj)
+		case "playerMatches":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._FFLPlayerSeason_playerMatches(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10472,6 +10767,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_fflClubMatch(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "fflPlayerSeasonsByAflPlayerSeason":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_fflPlayerSeasonsByAflPlayerSeason(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -138,15 +138,17 @@ type FFLPlayerMatch struct {
 }
 
 type FFLPlayerSeason struct {
-	ID                string           `json:"id"`
-	Player            *FFLPlayer       `json:"player"`
-	ClubSeasonID      string           `json:"clubSeasonId"`
-	AflPlayerSeasonID *string          `json:"aflPlayerSeasonId,omitempty"`
-	AflPlayerSeason   *AFLPlayerSeason `json:"aflPlayerSeason,omitempty"`
-	FromRoundID       *string          `json:"fromRoundId,omitempty"`
-	ToRoundID         *string          `json:"toRoundId,omitempty"`
-	Notes             *string          `json:"notes,omitempty"`
-	CostCents         *int             `json:"costCents,omitempty"`
+	ID                string            `json:"id"`
+	Player            *FFLPlayer        `json:"player"`
+	Club              *FFLClub          `json:"club"`
+	ClubSeasonID      string            `json:"clubSeasonId"`
+	AflPlayerSeasonID *string           `json:"aflPlayerSeasonId,omitempty"`
+	AflPlayerSeason   *AFLPlayerSeason  `json:"aflPlayerSeason,omitempty"`
+	FromRoundID       *string           `json:"fromRoundId,omitempty"`
+	ToRoundID         *string           `json:"toRoundId,omitempty"`
+	Notes             *string           `json:"notes,omitempty"`
+	CostCents         *int              `json:"costCents,omitempty"`
+	PlayerMatches     []*FFLPlayerMatch `json:"playerMatches"`
 }
 
 type FFLPlayerSeasonConnection struct {

--- a/services/ffl/internal/interface/graphql/mutation.resolvers.go
+++ b/services/ffl/internal/interface/graphql/mutation.resolvers.go
@@ -10,10 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-
-	"github.com/vektah/gqlparser/v2/gqlerror"
 	"xffl/services/ffl/internal/application"
 	"xffl/services/ffl/internal/domain"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // AddFFLPlayerToSeason is the resolver for the addFFLPlayerToSeason field.

--- a/services/ffl/internal/interface/graphql/query.resolvers.go
+++ b/services/ffl/internal/interface/graphql/query.resolvers.go
@@ -146,6 +146,19 @@ func (r *fFLPlayerMatchResolver) AflPlayerMatch(ctx context.Context, obj *FFLPla
 	return &AFLPlayerMatch{ID: *obj.AflPlayerMatchID}, nil
 }
 
+// Club is the resolver for the club field.
+func (r *fFLPlayerSeasonResolver) Club(ctx context.Context, obj *FFLPlayerSeason) (*FFLClub, error) {
+	csID, err := fromID(obj.ClubSeasonID)
+	if err != nil {
+		return nil, err
+	}
+	club, err := r.Queries.GetClubForClubSeason(ctx, csID)
+	if err != nil {
+		return nil, err
+	}
+	return convertClub(club), nil
+}
+
 // AflPlayerSeason is the resolver for the aflPlayerSeason field.
 // Returns a stub with the AFL entity ID; the router fetches full data from the AFL subgraph.
 func (r *fFLPlayerSeasonResolver) AflPlayerSeason(ctx context.Context, obj *FFLPlayerSeason) (*AFLPlayerSeason, error) {
@@ -153,6 +166,28 @@ func (r *fFLPlayerSeasonResolver) AflPlayerSeason(ctx context.Context, obj *FFLP
 		return nil, nil
 	}
 	return &AFLPlayerSeason{ID: *obj.AflPlayerSeasonID}, nil
+}
+
+// PlayerMatches is the resolver for the playerMatches field.
+func (r *fFLPlayerSeasonResolver) PlayerMatches(ctx context.Context, obj *FFLPlayerSeason) ([]*FFLPlayerMatch, error) {
+	psID, err := fromID(obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	pms, err := r.Queries.GetPlayerMatchesByPlayerSeasonID(ctx, psID)
+	if err != nil {
+		return nil, err
+	}
+	loaders := LoadersFromCtx(ctx)
+	result := make([]*FFLPlayerMatch, len(pms))
+	for i, pm := range pms {
+		player, err := loaders.PlayerByPlayerSeasonID.Load(ctx, pm.PlayerSeasonID)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = convertPlayerMatch(pm, *player)
+	}
+	return result, nil
 }
 
 // AflRound is the resolver for the aflRound field.
@@ -410,6 +445,28 @@ func (r *queryResolver) FflClubMatch(ctx context.Context, id string) (*FFLClubMa
 	seasonID := toID(round.SeasonID)
 	result.RoundID = &roundID
 	result.SeasonID = &seasonID
+	return result, nil
+}
+
+// FflPlayerSeasonsByAflPlayerSeason is the resolver for the fflPlayerSeasonsByAflPlayerSeason field.
+func (r *queryResolver) FflPlayerSeasonsByAflPlayerSeason(ctx context.Context, aflPlayerSeasonID string) ([]*FFLPlayerSeason, error) {
+	aflPsID, err := fromID(aflPlayerSeasonID)
+	if err != nil {
+		return nil, err
+	}
+	playerSeasons, err := r.Queries.GetPlayerSeasonsByAFLPlayerSeasonID(ctx, aflPsID)
+	if err != nil {
+		return nil, err
+	}
+	loaders := LoadersFromCtx(ctx)
+	result := make([]*FFLPlayerSeason, len(playerSeasons))
+	for i, ps := range playerSeasons {
+		player, err := loaders.PlayerByPlayerSeasonID.Load(ctx, ps.ID)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = convertPlayerSeason(ps, *player)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
Adds the /ffl/afl/player-seasons/:id page — a per-player FFL lens showing AFL stats alongside all FFL ownership stints — and closes out ordering/display improvements across the Team Builder and data layer.

## Changes

- **New page: FFL view of AFL player season** — `/ffl/afl/player-seasons/:id` shows AFL per-match stats with averages, plus FFL stints (club, position, * score, AFL status) for the season; entry points wired from AFL match player names and FFL squad player names.
- **FFL GraphQL schema** — new `fflPlayerSeasonsByAflPlayerSeason` query; `FFLPlayerSeason.club` and `.playerMatches` resolvers; `FindPlayerMatchesByPlayerSeasonID` SQL + repo method.
- **Player display ordering** — `display_order` on `ffl.player_match` persisted via `SetTeam`; new `reorderFFLPlayerMatch` mutation; Team Builder exposes ↑/↓ controls in manage mode.
- **BYE_INELIGIBLE structured error** — application layer returns a typed error; GraphQL maps it to structured extensions; Team Builder shows the player name in the message.
- **DB query ordering** — AFL and FFL match, club-match, and player-match queries all have explicit `ORDER BY` clauses for deterministic results.
- **AFL stats import** — `importAFLMatchStats` returns the updated `AFLMatch` for Apollo cache normalisation.
- **Tests** — 3 new FFL integration tests covering the new resolvers (153 total pass); cookbook documents the GraphQL structured-error convention.
- **Plans** — player and club pages design doc added; Phase 21/22 reordered in roadmap.