### PR TITLE
Phase 21: Round-aware UX navigation across AFL/FFL/DataOps

### DIFF
--- a/frontend/web/e2e/ffl-data-ops.spec.ts
+++ b/frontend/web/e2e/ffl-data-ops.spec.ts
@@ -39,12 +39,11 @@ test.describe('FFL Data Ops', () => {
       await expect(page.getByRole('cell', { name: 'Ruiboys' })).toBeVisible()
     })
 
-    test('round selector defaults to the live round', async ({ page }) => {
-      // Clock override puts us in Round 3.
-      const roundSelect = page.locator('select').first()
-      await expect(roundSelect).toHaveValue(/\d+/)
-      const selectedText = await roundSelect.locator('option:checked').textContent()
-      expect(selectedText).toContain('Round 3')
+    test('round nav defaults to the live round (Round 3 selected)', async ({ page }) => {
+      // Clock override puts us in Round 3 — its pill should be the active selection.
+      const roundNav = page.locator('main nav').last()
+      const round3 = roundNav.getByRole('link', { name: '3', exact: true })
+      await expect(round3).toHaveClass(/bg-active/)
     })
 
     test('import panel opens inside a card with Cancel and Read Team buttons', async ({ page }) => {
@@ -76,7 +75,7 @@ test.describe('FFL Data Ops', () => {
       await page.getByRole('row').filter({ hasText: 'Ruiboys' }).first().getByRole('button', { name: 'Import Team' }).click()
 
       // Select team format
-      await page.locator('select').nth(1).selectOption('Ruiboys')
+      await page.locator('select').first().selectOption('Ruiboys')
 
       // Paste post
       await page.locator('textarea').fill(minimalRuiboysPost)
@@ -101,7 +100,7 @@ test.describe('FFL Data Ops', () => {
     test('back button returns to input phase', async ({ page }) => {
       // Open import panel for Ruiboys, select format, paste, read
       await page.getByRole('row').filter({ hasText: 'Ruiboys' }).first().getByRole('button', { name: 'Import Team' }).click()
-      await page.locator('select').nth(1).selectOption('Ruiboys')
+      await page.locator('select').first().selectOption('Ruiboys')
       await page.locator('textarea').fill(minimalRuiboysPost)
       await page.getByRole('button', { name: 'Read Team' }).click()
 

--- a/frontend/web/e2e/ffl-round.spec.ts
+++ b/frontend/web/e2e/ffl-round.spec.ts
@@ -24,7 +24,7 @@ test.describe('FFL Round', () => {
 
   test('FFL breadcrumb link navigates back to home', async ({ page }) => {
     await page.locator('main').getByRole('link', { name: 'FFL 2026' }).click()
-    await expect(page).toHaveURL('/ffl')
+    await expect(page).toHaveURL(/\/ffl\/rounds\//)
   })
 
   test('displays match summaries', async ({ page }) => {

--- a/frontend/web/e2e/ffl-squad.spec.ts
+++ b/frontend/web/e2e/ffl-squad.spec.ts
@@ -72,7 +72,7 @@ test.describe('FFL Squad', () => {
   })
 
   test('Manage button hidden when viewing another club squad', async ({ page }) => {
-    await page.goto('/ffl')
+    await page.goto('/ffl/ladder')
     await page.locator('main').getByRole('link', { name: 'Ruiboys' }).first().click()
     await page.waitForURL(/\/ffl\/club-seasons\//)
     await page.waitForLoadState('networkidle')

--- a/frontend/web/e2e/navigation.spec.ts
+++ b/frontend/web/e2e/navigation.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from './fixtures'
+import { setupFflSession, setupAflSession } from './helpers'
+
+test.describe('Navigation — Phase 21', () => {
+  test.describe('NAV-1: Header links navigate to live round', () => {
+    test('FFL header link navigates to the live FFL round', async ({ page }) => {
+      await setupFflSession(page)
+      const topNav = page.getByRole('navigation').first()
+      await topNav.getByRole('link', { name: 'FFL', exact: true }).filter({ hasText: 'FFL' }).click()
+      await expect(page).toHaveURL(/\/ffl\/rounds\//)
+    })
+
+    test('AFL header link navigates to the live AFL round', async ({ page }) => {
+      await setupFflSession(page)
+      const topNav = page.getByRole('navigation').first()
+      await topNav.getByRole('link', { name: 'AFL', exact: true }).filter({ hasText: 'AFL' }).click()
+      await expect(page).toHaveURL(/\/afl\/rounds\//)
+    })
+  })
+
+  test.describe('NAV-2: Cross-domain round pill in round header', () => {
+    test('FFL round view shows AFL cross-domain pill', async ({ page }) => {
+      await setupFflSession(page)
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForLoadState('networkidle')
+      const pill = page.getByRole('link', { name: /↔ AFL Round/ })
+      await expect(pill).toBeVisible()
+    })
+
+    test('AFL cross-domain pill navigates to the AFL round', async ({ page }) => {
+      await setupFflSession(page)
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForLoadState('networkidle')
+      await page.getByRole('link', { name: /↔ AFL Round/ }).click()
+      await expect(page).toHaveURL(/\/afl\/rounds\//)
+      await expect(page.getByRole('heading', { level: 1 })).toContainText('Round')
+    })
+
+    test('AFL round view shows FFL cross-domain pill', async ({ page }) => {
+      await setupAflSession(page)
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForLoadState('networkidle')
+      const pill = page.getByRole('link', { name: /↔ FFL Round/ })
+      await expect(pill).toBeVisible()
+    })
+
+    test('FFL cross-domain pill on AFL round navigates to FFL round', async ({ page }) => {
+      await setupAflSession(page)
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForLoadState('networkidle')
+      await page.getByRole('link', { name: /↔ FFL Round/ }).click()
+      await expect(page).toHaveURL(/\/ffl\/rounds\//)
+    })
+  })
+
+  test.describe('NAV-3: Ladder pill in RoundNav', () => {
+    test('FFL RoundNav has ladder pill as first item', async ({ page }) => {
+      await setupFflSession(page)
+      const roundNav = page.locator('main nav').last()
+      const ladderPill = roundNav.getByTitle('Ladder')
+      await expect(ladderPill).toBeVisible()
+    })
+
+    test('FFL ladder pill navigates to FFL home', async ({ page }) => {
+      await setupFflSession(page)
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForURL(/\/ffl\/rounds\//)
+      await page.locator('main nav').last().getByTitle('Ladder').click()
+      await expect(page).toHaveURL('/ffl')
+    })
+
+    test('AFL RoundNav has ladder pill as first item', async ({ page }) => {
+      await setupAflSession(page)
+      const roundNav = page.locator('main nav').last()
+      await expect(roundNav.getByTitle('Ladder')).toBeVisible()
+    })
+
+    test('AFL ladder pill navigates to AFL home', async ({ page }) => {
+      await setupAflSession(page)
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForURL(/\/afl\/rounds\//)
+      await page.locator('main nav').last().getByTitle('Ladder').click()
+      await expect(page).toHaveURL('/afl')
+    })
+  })
+
+  test.describe('NAV-4: DataOps icon always visible in header', () => {
+    test('DataOps icon is visible in header on FFL home', async ({ page }) => {
+      await setupFflSession(page)
+      await expect(page.getByTitle('Data Ops')).toBeVisible()
+    })
+
+    test('DataOps icon is visible in header on AFL home', async ({ page }) => {
+      await setupAflSession(page)
+      await expect(page.getByTitle('Data Ops')).toBeVisible()
+    })
+
+    test('DataOps icon links to data-ops page', async ({ page }) => {
+      await setupFflSession(page)
+      await page.getByTitle('Data Ops').click()
+      await expect(page).toHaveURL(/\/ffl\/data-ops/)
+    })
+  })
+
+  test.describe('NAV-5: DataOps uses RoundNav instead of dropdowns', () => {
+    test.beforeEach(async ({ page }) => {
+      await setupFflSession(page)
+      await page.goto('/ffl/data-ops')
+    })
+
+    test('FFL Teams tab shows round nav pills instead of a select', async ({ page }) => {
+      await page.getByRole('button', { name: 'FFL Teams' }).click()
+      await page.waitForLoadState('networkidle')
+      // Should have no round select dropdown
+      await expect(page.locator('select').filter({ hasText: /Round/ })).not.toBeAttached()
+      // Should have round nav with numbered pills
+      const roundNav = page.locator('main nav').last()
+      await expect(roundNav.getByRole('link', { name: '1', exact: true })).toBeVisible()
+    })
+
+    test('AFL Stats tab shows round nav pills instead of a select', async ({ page }) => {
+      await page.getByRole('button', { name: 'AFL Stats' }).click()
+      await page.waitForLoadState('networkidle')
+      const roundNav = page.locator('main nav').last()
+      await expect(roundNav.getByRole('link', { name: '1', exact: true })).toBeVisible()
+    })
+
+    test('clicking a round pill in FFL Teams tab updates the displayed round', async ({ page }) => {
+      await page.getByRole('button', { name: 'FFL Teams' }).click()
+      await page.waitForLoadState('networkidle')
+      // Click round 1
+      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
+      await page.waitForLoadState('networkidle')
+      // Round 1 pill should now be active
+      const round1 = page.locator('main nav').last().getByRole('link', { name: '1', exact: true })
+      await expect(round1).toHaveClass(/bg-active/)
+    })
+
+    test('DataOps FFL Teams round nav has a ladder pill', async ({ page }) => {
+      await page.getByRole('button', { name: 'FFL Teams' }).click()
+      await page.waitForLoadState('networkidle')
+      await expect(page.locator('main nav').last().getByTitle('Ladder')).toBeVisible()
+    })
+  })
+})

--- a/frontend/web/e2e/navigation.spec.ts
+++ b/frontend/web/e2e/navigation.spec.ts
@@ -18,41 +18,6 @@ test.describe('Navigation — Phase 21', () => {
     })
   })
 
-  test.describe('NAV-2: Cross-domain round pill in round header', () => {
-    test('FFL round view shows AFL cross-domain pill', async ({ page }) => {
-      await setupFflSession(page)
-      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
-      await page.waitForLoadState('networkidle')
-      const pill = page.getByRole('link', { name: /↔ AFL Round/ })
-      await expect(pill).toBeVisible()
-    })
-
-    test('AFL cross-domain pill navigates to the AFL round', async ({ page }) => {
-      await setupFflSession(page)
-      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
-      await page.waitForLoadState('networkidle')
-      await page.getByRole('link', { name: /↔ AFL Round/ }).click()
-      await expect(page).toHaveURL(/\/afl\/rounds\//)
-      await expect(page.getByRole('heading', { level: 1 })).toContainText('Round')
-    })
-
-    test('AFL round view shows FFL cross-domain pill', async ({ page }) => {
-      await setupAflSession(page)
-      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
-      await page.waitForLoadState('networkidle')
-      const pill = page.getByRole('link', { name: /↔ FFL Round/ })
-      await expect(pill).toBeVisible()
-    })
-
-    test('FFL cross-domain pill on AFL round navigates to FFL round', async ({ page }) => {
-      await setupAflSession(page)
-      await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
-      await page.waitForLoadState('networkidle')
-      await page.getByRole('link', { name: /↔ FFL Round/ }).click()
-      await expect(page).toHaveURL(/\/ffl\/rounds\//)
-    })
-  })
-
   test.describe('NAV-3: Ladder pill in RoundNav', () => {
     test('FFL RoundNav has ladder pill as first item', async ({ page }) => {
       await setupFflSession(page)
@@ -66,7 +31,7 @@ test.describe('Navigation — Phase 21', () => {
       await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
       await page.waitForURL(/\/ffl\/rounds\//)
       await page.locator('main nav').last().getByTitle('Ladder').click()
-      await expect(page).toHaveURL('/ffl')
+      await expect(page).toHaveURL('/ffl/ladder')
     })
 
     test('AFL RoundNav has ladder pill as first item', async ({ page }) => {
@@ -80,7 +45,7 @@ test.describe('Navigation — Phase 21', () => {
       await page.locator('main nav').last().getByRole('link', { name: '1', exact: true }).click()
       await page.waitForURL(/\/afl\/rounds\//)
       await page.locator('main nav').last().getByTitle('Ladder').click()
-      await expect(page).toHaveURL('/afl')
+      await expect(page).toHaveURL('/afl/ladder')
     })
   })
 

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -6,12 +6,14 @@
         <router-link to="/ffl" class="flex items-center">
           <img src="/images/ffl-eagle-logo.png" alt="FFL" class="h-10 w-auto transition-transform duration-200 hover:scale-[3] origin-top-left" />
         </router-link>
-        <router-link to="/ffl" class="text-sm text-text-muted hover:text-text transition-colors">
-          FFL
-        </router-link>
-        <router-link to="/afl" class="text-sm text-text-muted hover:text-text transition-colors">
-          AFL
-        </router-link>
+        <router-link
+          :to="fflLiveRoundId ? { name: 'ffl-round', params: { roundId: fflLiveRoundId } } : { name: 'home' }"
+          class="text-sm text-text-muted hover:text-text transition-colors"
+        >FFL</router-link>
+        <router-link
+          :to="aflLiveRoundId ? { name: 'afl-round', params: { roundId: aflLiveRoundId } } : { name: 'afl-home' }"
+          class="text-sm text-text-muted hover:text-text transition-colors"
+        >AFL</router-link>
 
         <!-- Right: FFL nav + settings -->
         <div class="ml-auto flex items-center gap-4">
@@ -33,6 +35,15 @@
               @update:model-value="setClub"
             />
           </template>
+
+          <!-- DataOps link -->
+          <router-link
+            :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: fflLiveRoundId || undefined } }"
+            class="text-text-muted hover:text-text transition-colors translate-y-0.5"
+            title="Data Ops"
+          >
+            <IconDataOps class="w-5 h-5" />
+          </router-link>
 
           <!-- Settings cog -->
           <div class="relative" ref="settingsContainer">
@@ -80,13 +91,16 @@ import { useRoute } from 'vue-router'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON_CLUBS } from '@/features/ffl/api/queries'
 import { useFflState } from '@/features/ffl/composables/useFflState'
+import { useAflState } from '@/features/afl/composables/useAflState'
 import ClubSelector from '@/features/ffl/components/ClubSelector.vue'
 import IconSquad from '@/features/ffl/components/icons/IconSquad.vue'
+import IconDataOps from '@/features/data-ops/components/icons/IconDataOps.vue'
 
 import { useLiveRoundBootstrap } from '@/app/useLiveRoundBootstrap'
 
 const route = useRoute()
-const { selectedClubId, liveSeasonId, setClub } = useFflState()
+const { selectedClubId, liveSeasonId, liveRoundId: fflLiveRoundId, setClub } = useFflState()
+const { liveRoundId: aflLiveRoundId } = useAflState()
 useLiveRoundBootstrap()
 
 const isFfl = computed(() => route.path.startsWith('/ffl'))

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -7,11 +7,11 @@
           <img src="/images/ffl-eagle-logo.png" alt="FFL" class="h-10 w-auto transition-transform duration-200 hover:scale-[3] origin-top-left" />
         </router-link>
         <router-link
-          :to="fflLiveRoundId ? { name: 'ffl-round', params: { roundId: fflLiveRoundId } } : { name: 'home' }"
+          :to="fflSelectedRoundId ? { name: 'ffl-round', params: { roundId: fflSelectedRoundId } } : { name: 'home' }"
           class="text-sm text-text-muted hover:text-text transition-colors"
         >FFL</router-link>
         <router-link
-          :to="aflLiveRoundId ? { name: 'afl-round', params: { roundId: aflLiveRoundId } } : { name: 'afl-home' }"
+          :to="aflSelectedRoundId ? { name: 'afl-round', params: { roundId: aflSelectedRoundId } } : { name: 'afl-home' }"
           class="text-sm text-text-muted hover:text-text transition-colors"
         >AFL</router-link>
 
@@ -38,7 +38,7 @@
 
           <!-- DataOps link -->
           <router-link
-            :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: fflLiveRoundId || undefined } }"
+            :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: fflSelectedRoundId || undefined } }"
             class="text-text-muted hover:text-text transition-colors translate-y-0.5"
             title="Data Ops"
           >
@@ -99,8 +99,8 @@ import IconDataOps from '@/features/data-ops/components/icons/IconDataOps.vue'
 import { useLiveRoundBootstrap } from '@/app/useLiveRoundBootstrap'
 
 const route = useRoute()
-const { selectedClubId, liveSeasonId, liveRoundId: fflLiveRoundId, setClub } = useFflState()
-const { liveRoundId: aflLiveRoundId } = useAflState()
+const { selectedClubId, liveSeasonId, selectedRoundId: fflSelectedRoundId, setClub } = useFflState()
+const { selectedRoundId: aflSelectedRoundId } = useAflState()
 useLiveRoundBootstrap()
 
 const isFfl = computed(() => route.path.startsWith('/ffl'))

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -1,4 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { useFflState } from '@/features/ffl/composables/useFflState'
+import { useAflState } from '@/features/afl/composables/useAflState'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -13,6 +15,16 @@ const router = createRouter({
     {
       path: '/ffl',
       name: 'home',
+      redirect: () => {
+        const { liveRoundId } = useFflState()
+        return liveRoundId.value
+          ? { name: 'ffl-round', params: { roundId: liveRoundId.value } }
+          : { name: 'ffl-ladder' }
+      },
+    },
+    {
+      path: '/ffl/ladder',
+      name: 'ffl-ladder',
       component: () => import('@/features/ffl/views/HomeView.vue'),
     },
     {
@@ -55,6 +67,16 @@ const router = createRouter({
     {
       path: '/afl',
       name: 'afl-home',
+      redirect: () => {
+        const { liveRoundId } = useAflState()
+        return liveRoundId.value
+          ? { name: 'afl-round', params: { roundId: liveRoundId.value } }
+          : { name: 'afl-ladder' }
+      },
+    },
+    {
+      path: '/afl/ladder',
+      name: 'afl-ladder',
       component: () => import('@/features/afl/views/HomeView.vue'),
     },
     {

--- a/frontend/web/src/features/afl/components/RoundNav.vue
+++ b/frontend/web/src/features/afl/components/RoundNav.vue
@@ -1,17 +1,36 @@
 <template>
   <nav class="flex flex-wrap gap-2">
+    <!-- Ladder pill -->
+    <router-link
+      :to="{ name: 'afl-home' }"
+      class="w-8 h-8 rounded-full flex items-center justify-center transition-colors bg-control text-text-muted hover:bg-control-hover hover:text-text"
+      title="Ladder"
+    >
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="13" width="4" height="8" rx="0.5" />
+        <rect x="9.5" y="8" width="4" height="13" rx="0.5" />
+        <rect x="16" y="3" width="4" height="18" rx="0.5" />
+      </svg>
+    </router-link>
+
+    <!-- Round pills -->
     <router-link
       v-for="round in rounds"
       :key="round.id"
-      :to="{ name: 'afl-round', params: { roundId: round.id } }"
-      class="w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors"
-      :class="activeRoundId === round.id
+      :to="toRound ? toRound(round) : { name: 'afl-round', params: { roundId: round.id } }"
+      class="relative w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors"
+      :class="effectiveActiveId === round.id
         ? 'bg-active text-active-text'
         : round.id === liveRoundId
           ? ['ring-2 ring-active ring-offset-2 ring-offset-surface', 'bg-control text-text-muted hover:bg-control-hover hover:text-text']
           : 'bg-control text-text-muted hover:bg-control-hover hover:text-text'"
     >
       {{ round.name === 'Opening Round' ? '0' : round.name.replace(/^Round\s+/i, '') }}
+      <!-- Pulsing dot when this is the live round and it starts today -->
+      <span
+        v-if="round.id === liveRoundId && isLiveToday"
+        class="absolute top-0 right-0 w-2 h-2 rounded-full bg-active animate-pulse"
+      />
     </router-link>
   </nav>
 </template>
@@ -19,17 +38,27 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
 
 interface Round {
   id: string
   name: string
 }
 
-defineProps<{
+const props = defineProps<{
   rounds: Round[]
   liveRoundId: string
+  liveStartDate?: string
+  activeId?: string
+  toRound?: (r: Round) => RouteLocationRaw
 }>()
 
 const route = useRoute()
-const activeRoundId = computed(() => route.params.roundId as string | undefined)
+const effectiveActiveId = computed(() => props.activeId ?? route.params.roundId as string | undefined)
+
+const isLiveToday = computed(() => {
+  if (!props.liveStartDate) return false
+  const today = new Date().toISOString().slice(0, 10)
+  return props.liveStartDate.slice(0, 10) === today
+})
 </script>

--- a/frontend/web/src/features/afl/components/RoundNav.vue
+++ b/frontend/web/src/features/afl/components/RoundNav.vue
@@ -2,7 +2,7 @@
   <nav class="flex flex-wrap gap-2">
     <!-- Ladder pill -->
     <router-link
-      :to="{ name: 'afl-home' }"
+      :to="{ name: 'afl-ladder' }"
       class="w-8 h-8 rounded-full flex items-center justify-center transition-colors bg-control text-text-muted hover:bg-control-hover hover:text-text"
       title="Ladder"
     >
@@ -18,6 +18,7 @@
       v-for="round in rounds"
       :key="round.id"
       :to="toRound ? toRound(round) : { name: 'afl-round', params: { roundId: round.id } }"
+      :title="round.name"
       class="relative w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors"
       :class="effectiveActiveId === round.id
         ? 'bg-active text-active-text'

--- a/frontend/web/src/features/afl/composables/useAflState.ts
+++ b/frontend/web/src/features/afl/composables/useAflState.ts
@@ -1,4 +1,4 @@
-import { ref, readonly } from 'vue'
+import { ref, readonly, computed } from 'vue'
 
 interface AflState {
   seasonId: string
@@ -47,11 +47,22 @@ function setLiveRound(seasonId: string, roundId: string, startDate: string) {
   writeCookie({ seasonId, roundId, startDate })
 }
 
+// In-memory only (not persisted) — sticks to whichever round the user last
+// navigated to, falling back to the live round. Resets on page reload.
+const selectedRoundOverride = ref<string>('')
+const selectedRoundId = computed(() => selectedRoundOverride.value || liveRoundId.value)
+
+function setSelectedRound(roundId: string) {
+  selectedRoundOverride.value = roundId
+}
+
 export function useAflState() {
   return {
     liveSeasonId: readonly(liveSeasonId),
     liveRoundId: readonly(liveRoundId),
     liveStartDate: readonly(liveStartDate),
+    selectedRoundId,
     setLiveRound,
+    setSelectedRound,
   }
 }

--- a/frontend/web/src/features/afl/views/HomeView.vue
+++ b/frontend/web/src/features/afl/views/HomeView.vue
@@ -10,7 +10,7 @@
         class="mb-8"
         :rounds="data.season.rounds"
         :live-round-id="liveRoundId"
-        :season-id="data.season.id"
+        :live-start-date="liveStartDate"
       />
 
       <section>
@@ -30,7 +30,7 @@ import Breadcrumb from '../components/Breadcrumb.vue'
 import LadderTable from '../components/LadderTable.vue'
 import RoundNav from '../components/RoundNav.vue'
 
-const { liveRoundId, setLiveRound } = useAflState()
+const { liveRoundId, liveStartDate, setLiveRound } = useAflState()
 const { result, loading, error } = useQuery(GET_AFL_LIVE_ROUND)
 
 const data = computed(() => {

--- a/frontend/web/src/features/afl/views/RoundView.vue
+++ b/frontend/web/src/features/afl/views/RoundView.vue
@@ -4,14 +4,22 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
       <Breadcrumb :items="[{ label: 'AFL' }, { label: data.season.name, to: { name: 'afl-home' } }]" />
-      <h1 class="text-2xl font-bold mb-6">
-        {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
-      </h1>
+      <div class="flex items-center gap-3 mb-6">
+        <h1 class="text-2xl font-bold">
+          {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
+        </h1>
+        <router-link
+          v-if="fflRoundTo"
+          :to="fflRoundTo"
+          class="inline-flex items-center gap-1.5 rounded-full bg-control px-3 py-1 text-sm text-text-muted hover:bg-control-hover hover:text-text transition-colors"
+        >↔ FFL {{ data.round.name }}</router-link>
+      </div>
 
       <RoundNav
         class="mb-8"
         :rounds="data.season.rounds"
         :live-round-id="liveRoundId"
+        :live-start-date="liveStartDate"
       />
 
       <section class="mb-8">
@@ -48,15 +56,6 @@
         </div>
       </section>
 
-      <div class="mt-8">
-        <router-link
-          :to="{ name: 'ffl-data-ops', query: { tab: 'afl-stats', round: props.roundId } }"
-          class="flex items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
-        >
-          <IconDataOps class="w-4 h-4" />
-          Data Ops
-        </router-link>
-      </div>
 
     </template>
   </div>
@@ -66,18 +65,29 @@
 import { computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_AFL_ROUND } from '../api/queries'
+import { GET_FFL_ROUND_ID_BY_AFL_ROUND } from '@/features/ffl/api/queries'
 import { useAflState } from '../composables/useAflState'
 import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
 import RoundNav from '../components/RoundNav.vue'
 import TopPlayers from '../components/TopPlayers.vue'
-import IconDataOps from '@/features/data-ops/components/icons/IconDataOps.vue'
 
 const props = defineProps<{ roundId: string }>()
 
-const { liveRoundId } = useAflState()
+const { liveRoundId, liveStartDate } = useAflState()
 const { result, loading, error } = useQuery(GET_AFL_ROUND, () => ({ roundId: props.roundId }))
+
+const { result: fflRoundResult } = useQuery(
+  GET_FFL_ROUND_ID_BY_AFL_ROUND,
+  () => ({ aflRoundId: props.roundId }),
+)
+
+const fflRoundTo = computed(() => {
+  const id = fflRoundResult.value?.fflRoundByAflRound?.id
+  if (!id) return null
+  return { name: 'ffl-round', params: { roundId: id } }
+})
 
 const data = computed(() => {
   const round = result.value?.aflRound

--- a/frontend/web/src/features/afl/views/RoundView.vue
+++ b/frontend/web/src/features/afl/views/RoundView.vue
@@ -4,16 +4,9 @@
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="data">
       <Breadcrumb :items="[{ label: 'AFL' }, { label: data.season.name, to: { name: 'afl-home' } }]" />
-      <div class="flex items-center gap-3 mb-6">
-        <h1 class="text-2xl font-bold">
-          {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
-        </h1>
-        <router-link
-          v-if="fflRoundTo"
-          :to="fflRoundTo"
-          class="inline-flex items-center gap-1.5 rounded-full bg-control px-3 py-1 text-sm text-text-muted hover:bg-control-hover hover:text-text transition-colors"
-        >↔ FFL {{ data.round.name }}</router-link>
-      </div>
+      <h1 class="text-2xl font-bold mb-6">
+        {{ data.round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
+      </h1>
 
       <RoundNav
         class="mb-8"
@@ -62,11 +55,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_AFL_ROUND } from '../api/queries'
 import { GET_FFL_ROUND_ID_BY_AFL_ROUND } from '@/features/ffl/api/queries'
 import { useAflState } from '../composables/useAflState'
+import { useFflState } from '@/features/ffl/composables/useFflState'
 import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
@@ -75,7 +69,8 @@ import TopPlayers from '../components/TopPlayers.vue'
 
 const props = defineProps<{ roundId: string }>()
 
-const { liveRoundId, liveStartDate } = useAflState()
+const { liveRoundId, liveStartDate, setSelectedRound } = useAflState()
+const { setSelectedRound: setFflSelectedRound } = useFflState()
 const { result, loading, error } = useQuery(GET_AFL_ROUND, () => ({ roundId: props.roundId }))
 
 const { result: fflRoundResult } = useQuery(
@@ -83,10 +78,14 @@ const { result: fflRoundResult } = useQuery(
   () => ({ aflRoundId: props.roundId }),
 )
 
-const fflRoundTo = computed(() => {
-  const id = fflRoundResult.value?.fflRoundByAflRound?.id
-  if (!id) return null
-  return { name: 'ffl-round', params: { roundId: id } }
+// Visiting a round makes it "stick" for cross-domain navigation (header
+// links, DataOps) until the page is reloaded. The corresponding FFL round
+// sticks too, so switching domains lands on the matching round.
+watch(() => props.roundId, (id) => setSelectedRound(id), { immediate: true })
+
+watch(fflRoundResult, (r) => {
+  const id = r?.fflRoundByAflRound?.id
+  if (id) setFflSelectedRound(id)
 })
 
 const data = computed(() => {

--- a/frontend/web/src/features/data-ops/views/DataOpsView.vue
+++ b/frontend/web/src/features/data-ops/views/DataOpsView.vue
@@ -27,22 +27,13 @@
       <div v-else-if="liveRoundError" class="text-red-400">{{ liveRoundError.message }}</div>
       <template v-else>
         <!-- Round selector -->
-        <div class="mb-5 max-w-xs">
-          <div class="flex items-center justify-between mb-1">
-            <label class="block text-xs font-medium text-text-muted">Round</label>
-            <router-link
-              v-if="selectedAflRoundId"
-              :to="{ name: 'afl-round', params: { roundId: selectedAflRoundId } }"
-              class="text-xs text-text-faint hover:text-active transition-colors"
-            >View round →</router-link>
-          </div>
-          <select
-            v-model="selectedAflRoundId"
-            class="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:ring-1 focus:ring-active"
-          >
-            <option v-for="r in aflRounds" :key="r.id" :value="r.id">{{ r.name }}</option>
-          </select>
-        </div>
+        <AflRoundNav
+          class="mb-5"
+          :rounds="aflRounds"
+          :live-round-id="aflLiveRoundId"
+          :active-id="selectedAflRoundId"
+          :to-round="(r) => ({ name: 'ffl-data-ops', query: { tab: 'afl-stats', round: r.id } })"
+        />
 
         <!-- Match list -->
         <div v-if="loadingRoundStats" class="text-text-faint text-sm">Loading matches…</div>
@@ -247,22 +238,13 @@
       <template v-else-if="season">
 
         <!-- Round selector -->
-        <div class="mb-5 max-w-xs">
-          <div class="flex items-center justify-between mb-1">
-            <label class="block text-xs font-medium text-text-muted">Round</label>
-            <router-link
-              v-if="liveSeasonId && selectedRoundId"
-              :to="{ name: 'ffl-round', params: { roundId: selectedRoundId } }"
-              class="text-xs text-text-faint hover:text-active transition-colors"
-            >View round →</router-link>
-          </div>
-          <select
-            v-model="selectedRoundId"
-            class="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:ring-1 focus:ring-active"
-          >
-            <option v-for="r in season.rounds" :key="r.id" :value="r.id">{{ r.name }}</option>
-          </select>
-        </div>
+        <FflRoundNav
+          class="mb-5"
+          :rounds="season.rounds"
+          :live-round-id="liveRoundId"
+          :active-id="selectedRoundId"
+          :to-round="(r) => ({ name: 'ffl-data-ops', query: { tab: 'team-submission', round: r.id } })"
+        />
 
         <!-- Club list for selected round -->
         <div v-if="!selectedRound" class="text-text-faint text-sm">Select a round.</div>
@@ -497,14 +479,18 @@ import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_FFL_DATA_OPS, GET_AFL_ROUND_STATS } from '../api/queries'
 import { PARSE_TEAM_SUBMISSION, CONFIRM_TEAM_SUBMISSION, IMPORT_AFL_MATCH_STATS, MARK_AFL_MATCH_STATS_COMPLETE, MARK_FFL_TEAM_FINAL, MARK_FFL_TEAM_SUBMITTED, RECALCULATE_AFL_LADDER, RECALCULATE_FFL_LADDER, RECALCULATE_FFL_CLUB_MATCH_SCORE } from '../api/mutations'
 import { useFflState } from '@/features/ffl/composables/useFflState'
+import { useAflState } from '@/features/afl/composables/useAflState'
 import { GET_AFL_LIVE_ROUND } from '@/features/afl/api/queries'
 import { clubLogoUrl } from '@/features/afl/utils/clubLogos'
 import { clubLogoUrl as fflClubLogoUrl } from '@/features/ffl/utils/clubLogos'
 import { POSITION_COLORS, POSITION_LABEL, POSITION_SLOTS } from '@/features/ffl/utils/position'
 import PlayerSearchModal from '../components/PlayerSearchModal.vue'
 import FflPlayerLinkModal from '../components/FflPlayerLinkModal.vue'
+import AflRoundNav from '@/features/afl/components/RoundNav.vue'
+import FflRoundNav from '@/features/ffl/components/RoundNav.vue'
 
 const { liveSeasonId, liveRoundId } = useFflState()
+const { liveRoundId: aflLiveRoundId } = useAflState()
 const route = useRoute()
 
 const initialTab = (route.query.tab as string) || 'team-submission'
@@ -701,6 +687,14 @@ const selectedRoundId = ref(initialTab === 'team-submission' && initialRound ? i
 watch(liveRoundId, (val) => {
   if (val && !selectedRoundId.value) selectedRoundId.value = val
 }, { immediate: true })
+
+// Sync tab + round from route query params when RoundNav navigates within DataOps
+watch(() => route.query.tab, (val) => { if (val) activeTab.value = val as string })
+watch(() => route.query.round, (val) => {
+  if (!val) return
+  if (activeTab.value === 'afl-stats') selectedAflRoundId.value = val as string
+  if (activeTab.value === 'team-submission') selectedRoundId.value = val as string
+})
 
 const selectedRound = computed(() =>
   season.value?.rounds.find((r: any) => r.id === selectedRoundId.value) ?? null,

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -90,6 +90,15 @@ export const GET_FFL_ROUND_IDS_BY_AFL_ROUND = gql`
   }
 `
 
+export const GET_FFL_ROUND_ID_BY_AFL_ROUND = gql`
+  query GetFFLRoundIdByAflRound($aflRoundId: ID!) {
+    fflRoundByAflRound(aflRoundId: $aflRoundId) {
+      id
+      name
+    }
+  }
+`
+
 export const GET_FFL_ROUND_BY_AFL_ROUND = gql`
   query GetFFLRoundByAflRound($aflRoundId: ID!) {
     fflRoundByAflRound(aflRoundId: $aflRoundId) {

--- a/frontend/web/src/features/ffl/components/RoundNav.vue
+++ b/frontend/web/src/features/ffl/components/RoundNav.vue
@@ -1,17 +1,36 @@
 <template>
   <nav class="flex flex-wrap gap-2">
+    <!-- Ladder pill -->
+    <router-link
+      :to="{ name: 'home' }"
+      class="w-8 h-8 rounded-full flex items-center justify-center transition-colors bg-control text-text-muted hover:bg-control-hover hover:text-text"
+      title="Ladder"
+    >
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="13" width="4" height="8" rx="0.5" />
+        <rect x="9.5" y="8" width="4" height="13" rx="0.5" />
+        <rect x="16" y="3" width="4" height="18" rx="0.5" />
+      </svg>
+    </router-link>
+
+    <!-- Round pills -->
     <router-link
       v-for="round in rounds"
       :key="round.id"
-      :to="{ name: 'ffl-round', params: { roundId: round.id } }"
-      class="w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors"
-      :class="activeRoundId === round.id
+      :to="toRound ? toRound(round) : { name: 'ffl-round', params: { roundId: round.id } }"
+      class="relative w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors"
+      :class="effectiveActiveId === round.id
         ? 'bg-active text-active-text'
         : round.id === liveRoundId
           ? ['ring-2 ring-active ring-offset-2 ring-offset-surface', 'bg-control text-text-muted hover:bg-control-hover hover:text-text']
           : 'bg-control text-text-muted hover:bg-control-hover hover:text-text'"
     >
       {{ round.name.replace(/^Round\s+/i, '') }}
+      <!-- Pulsing dot when this is the live round and it starts today -->
+      <span
+        v-if="round.id === liveRoundId && isLiveToday"
+        class="absolute top-0 right-0 w-2 h-2 rounded-full bg-active animate-pulse"
+      />
     </router-link>
   </nav>
 </template>
@@ -19,17 +38,27 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
 
 interface Round {
   id: string
   name: string
 }
 
-defineProps<{
+const props = defineProps<{
   rounds: Round[]
   liveRoundId: string
+  liveStartDate?: string
+  activeId?: string
+  toRound?: (r: Round) => RouteLocationRaw
 }>()
 
 const route = useRoute()
-const activeRoundId = computed(() => route.params.roundId as string | undefined)
+const effectiveActiveId = computed(() => props.activeId ?? route.params.roundId as string | undefined)
+
+const isLiveToday = computed(() => {
+  if (!props.liveStartDate) return false
+  const today = new Date().toISOString().slice(0, 10)
+  return props.liveStartDate.slice(0, 10) === today
+})
 </script>

--- a/frontend/web/src/features/ffl/components/RoundNav.vue
+++ b/frontend/web/src/features/ffl/components/RoundNav.vue
@@ -2,7 +2,7 @@
   <nav class="flex flex-wrap gap-2">
     <!-- Ladder pill -->
     <router-link
-      :to="{ name: 'home' }"
+      :to="{ name: 'ffl-ladder' }"
       class="w-8 h-8 rounded-full flex items-center justify-center transition-colors bg-control text-text-muted hover:bg-control-hover hover:text-text"
       title="Ladder"
     >
@@ -18,6 +18,7 @@
       v-for="round in rounds"
       :key="round.id"
       :to="toRound ? toRound(round) : { name: 'ffl-round', params: { roundId: round.id } }"
+      :title="round.name"
       class="relative w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors"
       :class="effectiveActiveId === round.id
         ? 'bg-active text-active-text'

--- a/frontend/web/src/features/ffl/composables/useFflState.ts
+++ b/frontend/web/src/features/ffl/composables/useFflState.ts
@@ -1,4 +1,4 @@
-import { ref, readonly } from 'vue'
+import { ref, readonly, computed } from 'vue'
 
 const FFL_COOKIE = 'xffl_ffl'
 
@@ -53,13 +53,24 @@ function setLiveRound(seasonId: string, roundId: string, startDate: string) {
   setCookie(FFL_COOKIE, JSON.stringify({ seasonId, roundId, startDate }))
 }
 
+// In-memory only (not persisted) — sticks to whichever round the user last
+// navigated to, falling back to the live round. Resets on page reload.
+const selectedRoundOverride = ref<string>('')
+const selectedRoundId = computed(() => selectedRoundOverride.value || liveRoundId.value)
+
+function setSelectedRound(roundId: string) {
+  selectedRoundOverride.value = roundId
+}
+
 export function useFflState() {
   return {
     selectedClubId: readonly(selectedClubId),
     liveSeasonId: readonly(liveSeasonId),
     liveRoundId: readonly(liveRoundId),
     liveStartDate: readonly(liveStartDate),
+    selectedRoundId,
     setClub,
     setLiveRound,
+    setSelectedRound,
   }
 }

--- a/frontend/web/src/features/ffl/views/HomeView.vue
+++ b/frontend/web/src/features/ffl/views/HomeView.vue
@@ -14,7 +14,7 @@
         class="mb-8"
         :rounds="fflRound.season.rounds"
         :live-round-id="liveRoundId"
-        :season-id="fflRound.season.id"
+        :live-start-date="liveStartDate"
       />
 
       <section>
@@ -34,7 +34,7 @@ import Breadcrumb from '../components/Breadcrumb.vue'
 import LadderTable from '../components/LadderTable.vue'
 import RoundNav from '../components/RoundNav.vue'
 
-const { liveRoundId, setLiveRound } = useFflState()
+const { liveRoundId, liveStartDate, setLiveRound } = useFflState()
 
 // Step 1: get the live AFL round
 const { result: aflResult, loading: aflLoading, error: aflError } = useQuery(GET_AFL_LIVE_ROUND)

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -5,16 +5,9 @@
     <template v-else-if="round">
       <Breadcrumb :items="breadcrumbs" />
 
-      <div class="flex items-center gap-3 mb-6">
-        <h1 class="text-2xl font-bold">
-          {{ round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
-        </h1>
-        <router-link
-          v-if="aflRoundTo"
-          :to="aflRoundTo"
-          class="inline-flex items-center gap-1.5 rounded-full bg-control px-3 py-1 text-sm text-text-muted hover:bg-control-hover hover:text-text transition-colors"
-        >↔ AFL {{ round.name }}</router-link>
-      </div>
+      <h1 class="text-2xl font-bold mb-6">
+        {{ round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
+      </h1>
 
       <RoundNav
         class="mb-8"
@@ -71,10 +64,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_ROUND } from '../api/queries'
 import { useFflState } from '../composables/useFflState'
+import { useAflState } from '@/features/afl/composables/useAflState'
 import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import RoundNav from '../components/RoundNav.vue'
@@ -82,11 +76,21 @@ import { clubLogoUrl } from '../utils/clubLogos'
 
 const props = defineProps<{ roundId: string }>()
 
-const { liveRoundId, liveStartDate, selectedClubId } = useFflState()
+const { liveRoundId, liveStartDate, selectedClubId, setSelectedRound } = useFflState()
+const { setSelectedRound: setAflSelectedRound } = useAflState()
 const { result, loading, error } = useQuery(GET_FFL_ROUND, () => ({ id: props.roundId }))
 
 const round = computed(() => result.value?.fflRound ?? null)
 const season = computed(() => round.value?.season ?? null)
+
+// Visiting a round makes it "stick" for cross-domain navigation (header
+// links, DataOps) until the page is reloaded. The corresponding AFL round
+// sticks too, so switching domains lands on the matching round.
+watch(() => props.roundId, (id) => setSelectedRound(id), { immediate: true })
+
+watch(round, (r) => {
+  if (r?.aflRoundId) setAflSelectedRound(r.aflRoundId)
+})
 
 const roundStartDate = computed(() => {
   if (!round.value) return null
@@ -100,12 +104,6 @@ const roundStartDate = computed(() => {
   const month = earliest.toLocaleDateString('en-AU', { month: 'short' })
   const year = String(earliest.getFullYear()).slice(-2)
   return `${day} ${month} '${year}`
-})
-
-const aflRoundTo = computed(() => {
-  const aflRoundId = round.value?.aflRoundId
-  if (!aflRoundId) return null
-  return { name: 'afl-round', params: { roundId: aflRoundId } }
 })
 
 const breadcrumbs = computed(() => {

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -5,14 +5,22 @@
     <template v-else-if="round">
       <Breadcrumb :items="breadcrumbs" />
 
-      <h1 class="text-2xl font-bold mb-6">
-        {{ round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
-      </h1>
+      <div class="flex items-center gap-3 mb-6">
+        <h1 class="text-2xl font-bold">
+          {{ round.name }}<span v-if="roundStartDate" class="font-normal text-text-faint"> · {{ roundStartDate }}</span>
+        </h1>
+        <router-link
+          v-if="aflRoundTo"
+          :to="aflRoundTo"
+          class="inline-flex items-center gap-1.5 rounded-full bg-control px-3 py-1 text-sm text-text-muted hover:bg-control-hover hover:text-text transition-colors"
+        >↔ AFL {{ round.name }}</router-link>
+      </div>
 
       <RoundNav
         class="mb-8"
         :rounds="season?.rounds ?? []"
         :live-round-id="liveRoundId"
+        :live-start-date="liveStartDate"
       />
 
       <section class="mb-8">
@@ -57,19 +65,6 @@
 
       </section>
 
-      <div class="mt-8 flex items-center gap-6">
-        <router-link v-if="aflRoundTo" :to="aflRoundTo" class="flex items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors">
-          <IconAfl class="w-4 h-4" />
-          AFL Round
-        </router-link>
-        <router-link
-          :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: props.roundId } }"
-          class="flex items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
-        >
-          <IconDataOps class="w-4 h-4" />
-          Data Ops
-        </router-link>
-      </div>
 
     </template>
   </div>
@@ -84,12 +79,10 @@ import Breadcrumb from '../components/Breadcrumb.vue'
 import MatchSummary from '../components/MatchSummary.vue'
 import RoundNav from '../components/RoundNav.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
-import IconDataOps from '@/features/data-ops/components/icons/IconDataOps.vue'
-import IconAfl from '../components/icons/IconAfl.vue'
 
 const props = defineProps<{ roundId: string }>()
 
-const { liveRoundId, selectedClubId } = useFflState()
+const { liveRoundId, liveStartDate, selectedClubId } = useFflState()
 const { result, loading, error } = useQuery(GET_FFL_ROUND, () => ({ id: props.roundId }))
 
 const round = computed(() => result.value?.fflRound ?? null)

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -9,7 +9,7 @@ See `plans/ideas.md` for full descriptions of each item.
 ## Tasks
 
 - [x] NAV-1: Update header AFL/FFL links to navigate to live round (`/afl/rounds/:liveRoundId`, `/ffl/rounds/:liveRoundId`)
-- [x] NAV-2: Add cross-domain round pill to round view header — "↔ AFL/FFL Round N"; replaces bottom-of-page AFL Round link on FFL round view
+- [x] NAV-2: Cross-domain round-aware navigation — header AFL/FFL/DataOps links follow a session-scoped "selected round" (defaults to live round, sticks to whichever round you're viewing, syncs the corresponding round across domains); replaces the originally-planned cross-domain pill, which was built then superseded by this approach
 - [x] NAV-3: Add Ladder pill as first item in RoundNav (ladder icon + hover tooltip)
 - [x] NAV-4: Add DataOps icon link to header right-side nav (always visible; links to live round)
 - [x] NAV-5: Replace DataOps round dropdown with RoundNav component

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -8,10 +8,10 @@ See `plans/ideas.md` for full descriptions of each item.
 
 ## Tasks
 
-- [ ] NAV-1: Update header AFL/FFL links to navigate to live round (`/afl/rounds/:liveRoundId`, `/ffl/rounds/:liveRoundId`)
-- [ ] NAV-2: Add cross-domain round pill to round view header — "↔ AFL/FFL Round N"; replaces bottom-of-page AFL Round link on FFL round view
-- [ ] NAV-3: Add Ladder pill as first item in RoundNav (ladder icon + hover tooltip)
-- [ ] NAV-4: Add DataOps icon link to header right-side nav (always visible; links to live round)
-- [ ] NAV-5: Replace DataOps round dropdown with RoundNav component
-- [ ] PAGE-7: Enhance current-round pill with pulsing indicator when `start_dt` = today
-- [ ] Playwright tests for new navigation elements
+- [x] NAV-1: Update header AFL/FFL links to navigate to live round (`/afl/rounds/:liveRoundId`, `/ffl/rounds/:liveRoundId`)
+- [x] NAV-2: Add cross-domain round pill to round view header — "↔ AFL/FFL Round N"; replaces bottom-of-page AFL Round link on FFL round view
+- [x] NAV-3: Add Ladder pill as first item in RoundNav (ladder icon + hover tooltip)
+- [x] NAV-4: Add DataOps icon link to header right-side nav (always visible; links to live round)
+- [x] NAV-5: Replace DataOps round dropdown with RoundNav component
+- [x] PAGE-7: Enhance current-round pill with pulsing indicator when `start_dt` = today
+- [x] Playwright tests for new navigation elements


### PR DESCRIPTION
## Summary
- Header AFL/FFL/DataOps links now follow a session-scoped "selected round" — defaults to the live round, sticks to whatever round you're viewing, and syncs the corresponding round across FFL/AFL domains (resets to live round on page reload)
- `/ffl` and `/afl` redirect to the live round; the ladder/season view moves to `/ffl/ladder` and `/afl/ladder`
- Added a Ladder pill (with hover tooltip) and a pulsing live-round indicator to `RoundNav`; round pills now show their full name on hover
- DataOps is always reachable via a header icon, and its round dropdowns are replaced with `RoundNav`
- Replaced the originally-planned cross-domain round pill with the selected-round nav approach (built, then superseded — see updated NAV-2 note in `plans/current-sprint.md`)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Full Playwright e2e suite — 152/152 passing
- [x] Manually verified: visiting an FFL round and switching to AFL via the header lands on the corresponding AFL round; refreshing resets selection back to the live round