### PR TITLE
Player intelligence UX: stats, heatmaps, and smarter team building

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ just run-afl         # AFL service only (port 8080)
 just run-gateway     # Gateway only (port 8090)
 just run-frontend    # Frontend only (port 3000)
 just test-e2e        # Playwright e2e tests (self-contained, no dev stack required)
-just backup-db       # pg_dump → backups/postgres_TIMESTAMP.sql.gz (uploads if BACKUP_REMOTE set)
-just restore-db      # Restore latest backup into dev DB (pass file= to specify a file)
+just db-backup       # pg_dump → backups/postgres_TIMESTAMP.sql.gz (uploads if BACKUP_REMOTE set)
+just db-restore      # Restore latest backup into dev DB (pass file= to specify a file)
 ```
 
 ## Before Coding — Read These (tiered)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ just run-afl         # AFL service only (port 8080)
 just run-gateway     # Gateway only (port 8090)
 just run-frontend    # Frontend only (port 3000)
 just test-e2e        # Playwright e2e tests (self-contained, no dev stack required)
+just test-frontend   # Frontend unit tests (vitest, pure logic only — ADR-019)
 just db-backup       # pg_dump → backups/postgres_TIMESTAMP.sql.gz (uploads if BACKUP_REMOTE set)
 just db-restore      # Restore latest backup into dev DB (pass file= to specify a file)
 ```

--- a/ai/architecture/cookbook.md
+++ b/ai/architecture/cookbook.md
@@ -63,7 +63,7 @@ Files to touch, in order:
 
 This project uses a single environment with no CI migration pipeline. The convention:
 
-1. **Backup first** — `just backup-db` before any schema change; the backup is the safety net
+1. **Backup first** — `just db-backup` before any schema change; the backup is the safety net
 2. **Apply to live DB manually** — `ALTER TABLE schema.table ADD COLUMN col_name TYPE;`
 3. **Update init SQL** — `dev/postgres/init/{01_afl,02_ffl}_schema.sql` — add the same column definition so a fresh `dev-reset` picks it up
 4. **Update test-e2e init SQL** — `dev/postgres/test-e2e/` shares init files with `dev/postgres/init/` via symlinks; verify no divergence

--- a/ai/architecture/frontend.md
+++ b/ai/architecture/frontend.md
@@ -23,6 +23,7 @@ Pure FFL-domain views. Primary audience: FFL club managers.
 | Club Season | `/ffl/club-seasons/:clubSeasonId` |
 | Club Match | `/ffl/club-matches/:clubMatchId` |
 | Team Builder | `/ffl/club-matches/:clubMatchId/edit` — edit-mode overlay on Club Match; only for the selected club |
+| Free Agents | `/ffl/free-agents` — unowned AFL players |
 | Data Ops | `/ffl/data-ops` |
 
 **Money-shot views:** Match (head-to-head fantasy scores in real time) and Team Builder (weekly team selection).
@@ -61,14 +62,16 @@ frontend/web/src/
   features/
     afl/
       api/          — GraphQL queries + mutations
-      components/   — MatchSummary, LadderTable, PlayerStatsTable, TopPlayers, RoundNav
-      utils/        — clubLogos.ts
-      views/        — HomeView, RoundView, MatchView, AdminMatchView, ClubSeasonView
+      components/   — reusable AFL UI components
+      utils/        — AFL-specific utilities (club logos, abbreviations)
+      views/        — AFL page components
     ffl/
       api/          — GraphQL queries + mutations
-      components/   — MatchSummary, LadderTable, SquadTable, RoundNav, StatusBadge
-      utils/        — clubLogos.ts
-      views/        — HomeView, RoundView, MatchView, SquadView, TeamBuilderView, AFLPlayerSeasonView
-  components/       — NavBar (shared)
-  app/              — router.ts
+      components/   — reusable FFL UI components (stat display, squad management, icons)
+      utils/        — FFL-specific utilities (player stats, scoring, position logic, club logos)
+      views/        — FFL page components
+  composables/      — shared Vue composables (theme)
+  utils/            — shared utilities used by both features (heatmap, cookie)
+  components/       — shared UI components
+  app/              — router and app bootstrap
 ```

--- a/ai/architecture/frontend.md
+++ b/ai/architecture/frontend.md
@@ -9,30 +9,43 @@ The primary audience is FFL club managers who use the app to track fantasy score
 
 ## Page Hierarchy
 
-### FFL (primary)
+There are three namespaces, each with a distinct purpose:
+
+### FFL
+
+Pure FFL-domain views. Primary audience: FFL club managers.
 
 | Page | Route |
 |------|-------|
 | Home | `/ffl` |
 | Round | `/ffl/rounds/:roundId` |
 | Match | `/ffl/matches/:matchId` |
-| Team Builder | `/ffl/club-matches/:clubMatchId/edit` |
-| Squad | `/ffl/club-seasons/:clubSeasonId` |
-| Player Season | `/ffl/afl/player-seasons/:aflPlayerSeasonId` |
+| Club Season | `/ffl/club-seasons/:clubSeasonId` |
+| Club Match | `/ffl/club-matches/:clubMatchId` |
+| Team Builder | `/ffl/club-matches/:clubMatchId/edit` — edit-mode overlay on Club Match; only for the selected club |
 | Data Ops | `/ffl/data-ops` |
 
 **Money-shot views:** Match (head-to-head fantasy scores in real time) and Team Builder (weekly team selection).
 
-### AFL (supporting)
+### AFL
+
+Pure AFL-domain views. Used for real-world stat entry, which feeds FFL scoring.
 
 | Page | Route |
 |------|-------|
 | Home | `/afl` |
 | Round | `/afl/rounds/:roundId` |
 | Match | `/afl/matches/:matchId` |
-| Admin Match | `/afl/matches/:matchId/edit` |
+| Match Edit | `/afl/matches/:matchId/edit` |
 
-AFL pages exist to enter real-world match stats, which feed into FFL scoring.
+### AFL Lens (`/ffl/afl/`)
+
+FFL's view of AFL entities — the bridge between AFL data and FFL decision-making. No pure AFL player or club pages exist; these are the FFL-intelligence equivalents.
+
+| Page | Route |
+|------|-------|
+| Player Season | `/ffl/afl/player-seasons/:aflPlayerSeasonId` |
+| Club Season | `/ffl/afl/club-seasons/:clubSeasonId` |
 
 ## Key Design Decisions
 
@@ -50,12 +63,12 @@ frontend/web/src/
       api/          — GraphQL queries + mutations
       components/   — MatchSummary, LadderTable, PlayerStatsTable, TopPlayers, RoundNav
       utils/        — clubLogos.ts
-      views/        — HomeView, RoundView, MatchView, AdminMatchView
+      views/        — HomeView, RoundView, MatchView, AdminMatchView, ClubSeasonView
     ffl/
       api/          — GraphQL queries + mutations
       components/   — MatchSummary, LadderTable, SquadTable, RoundNav, StatusBadge
       utils/        — clubLogos.ts
-      views/        — HomeView, RoundView, MatchView, TeamBuilderView, PlayersView
+      views/        — HomeView, RoundView, MatchView, SquadView, TeamBuilderView, AFLPlayerSeasonView
   components/       — NavBar (shared)
-  router/           — Vue Router config
+  app/              — router.ts
 ```

--- a/ai/decisions/adr-019-frontend-unit-tests.md
+++ b/ai/decisions/adr-019-frontend-unit-tests.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+date: 2026-07-07
+scope: frontend
+enforceable: true
+rules:
+  - "pure frontend logic (algorithms, stat calculations, formatters) gets vitest unit tests colocated as *.test.ts next to the source"
+  - "vitest tests do not mount components and do not hit the network — component behaviour stays in Playwright e2e"
+  - "npm run test:unit must pass before committing frontend logic changes"
+---
+
+# ADR-019: Vitest for Frontend Unit Tests
+
+## Context
+
+The frontend has accumulated pure algorithmic logic — the Hungarian assignment
+solver behind Best Team (`utils/bestTeam.ts`), trend thresholds and the star
+score formula (`utils/playerStats.ts`) — whose correctness cannot reasonably be
+asserted through Playwright e2e. E2e can show that players moved; it cannot show
+that the assignment was optimal or that a trend arrow fires at exactly the
+threshold. Until now the frontend's only test runner was Playwright.
+
+## Decision
+
+Add **vitest** as a devDependency of `frontend/web` for unit-testing pure
+TypeScript logic.
+
+- Tests live next to the code they test: `src/**/foo.test.ts`.
+- Scope is pure functions and modules: algorithms, stat maths, formatters,
+  data mapping. No component mounting, no DOM, no network.
+- Component and interaction behaviour remains the job of the Playwright e2e
+  suite (`e2e/`), which keeps its isolation model (ADR-free, see
+  `ai/architecture/testing.md`).
+- `npm run test:unit` runs the suite; it is fast enough to run on every change.
+
+## Rationale
+
+- **Vitest over Jest:** shares Vite's config and transform pipeline (the
+  project is already Vite-based, ADR-011), native ESM + TypeScript support,
+  no extra Babel toolchain.
+- **Colocated tests** keep the algorithm and its spec in one place, matching
+  how the Go services colocate `_test.go` files.
+- **Narrow scope** avoids a parallel component-testing stack; Playwright
+  already covers user-visible behaviour end to end.
+
+## Alternatives considered
+
+- **Jest:** would introduce a second transform pipeline alongside Vite.
+  Rejected.
+- **Only e2e:** cannot assert algorithmic optimality or threshold edges;
+  silent regressions in Best Team would ship. Rejected.
+- **Node built-in test runner:** no TS/Vite integration; would need its own
+  build step. Rejected.

--- a/ai/decisions/decisions.md
+++ b/ai/decisions/decisions.md
@@ -22,3 +22,4 @@ Quick reference for agents. Read full ADRs only when you need detail on a specif
 | 016 | Accepted | ✅ | ACL identity mapping: xref tables per source per entity (e.g. `afl.xref_<source>_player`); owned by adapters/import tools; no FK to core schema; no shared integration schema |
 | 017 | Accepted | ✅ | `vikstrous/dataloadgen` as the convention for all resolver entity lookups; resolvers never call single-item repo methods by ID; per-request `Loaders` struct in context; batch functions delegate to repository `FindByIDs` |
 | 018 | Accepted | ✅ | Twirp for synchronous cross-service RPC; port interface in application layer; proto in `contracts/proto/`, generated stubs in `contracts/gen/`; `buf` for codegen |
+| 019 | Accepted | ✅ | vitest for pure frontend logic (algorithms, stat maths) as colocated `*.test.ts`; component behaviour stays in Playwright e2e |

--- a/dev/postgres/test-e2e/10_afl_seed.sql
+++ b/dev/postgres/test-e2e/10_afl_seed.sql
@@ -255,4 +255,14 @@ FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club
 WHERE p.name = 'Jordan Dawson' AND r.name = 'Round 5' AND l.name = 'AFL'
 ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
 
+-- Rounds 1-2 are in the past (CLOCK_OVERRIDE sits in Round 3): mark them final so
+-- player-season stat averages (statsAll/statsLastN) have qualifying matches.
+UPDATE afl.match SET data_status = 'final'
+WHERE round_id IN (
+  SELECT r.id FROM afl.round r
+  JOIN afl.season s ON r.season_id = s.id
+  JOIN afl.league l ON s.league_id = l.id
+  WHERE l.name = 'AFL' AND s.name = 'AFL 2026' AND r.name IN ('Round 1', 'Round 2')
+);
+
 COMMIT;

--- a/dev/postgres/test-e2e/10_afl_seed.sql
+++ b/dev/postgres/test-e2e/10_afl_seed.sql
@@ -265,4 +265,35 @@ WHERE round_id IN (
   WHERE l.name = 'AFL' AND s.name = 'AFL 2026' AND r.name IN ('Round 1', 'Round 2')
 );
 
+-- Free agents: AFL players with stats but no FFL squad (the FFL seed never
+-- references them), so the Free Agents page has rows to rank and hover.
+INSERT INTO afl.player (name) VALUES
+('Floyd Ranger'),
+('Ossie Vacant')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO afl.player_season (player_id, club_season_id)
+SELECT p.id, cs.id
+FROM afl.player p, afl.club_season cs
+JOIN afl.club c ON cs.club_id = c.id
+JOIN afl.season s ON cs.season_id = s.id
+JOIN afl.league l ON s.league_id = l.id
+WHERE p.name IN ('Floyd Ranger', 'Ossie Vacant')
+  AND c.name = 'Adelaide Crows' AND l.name = 'AFL' AND s.name = 'AFL 2026'
+ON CONFLICT (player_id, club_season_id) DO NOTHING;
+
+-- Round 1 stat lines (Round 1 is final, so these feed statsAll/statsLastN).
+-- Floyd out-kicks Ossie so kick-ranking order is deterministic.
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 25, 10, 5, 0, 3, 1, 0
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.match m ON cm.match_id = m.id JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Floyd Ranger' AND c.name = 'Adelaide Crows' AND r.name = 'Round 1'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
+INSERT INTO afl.player_match (player_season_id, club_match_id, kicks, handballs, marks, hitouts, tackles, goals, behinds)
+SELECT ps.id, cm.id, 12, 8, 3, 0, 6, 0, 1
+FROM afl.player_season ps JOIN afl.player p ON ps.player_id = p.id JOIN afl.club_season cs ON ps.club_season_id = cs.id JOIN afl.club c ON cs.club_id = c.id JOIN afl.club_match cm ON cm.club_season_id = cs.id JOIN afl.match m ON cm.match_id = m.id JOIN afl.round r ON m.round_id = r.id
+WHERE p.name = 'Ossie Vacant' AND c.name = 'Adelaide Crows' AND r.name = 'Round 1'
+ON CONFLICT (player_season_id, club_match_id) DO NOTHING;
+
 COMMIT;

--- a/dev/router/supergraph.graphql
+++ b/dev/router/supergraph.graphql
@@ -84,6 +84,7 @@ type AFLClubSeason
   against: Int!
   percentage: Float!
   premiershipPoints: Int!
+  playerSeasons: [AFLPlayerSeason!]!
 }
 
 type AFLLiveRound
@@ -155,6 +156,11 @@ type AFLPlayerSeason
   a rolling form window. Returns null if the player has no qualifying matches.
   """
   stats(upToRoundId: ID, lastN: Int, method: AFLStatSummaryMethod): AFLStatSummary @join__field(graph: AFL)
+
+  """
+  All FFL player seasons linked to this AFL player season (across all FFL clubs/stints).
+  """
+  fflPlayerSeasons: [FFLPlayerSeason!]! @join__field(graph: FFL)
 }
 
 type AFLPlayerSeasonConnection
@@ -333,8 +339,6 @@ type FFLPlayerMatch
   playerSeasonId: ID!
   playerSeason: FFLPlayerSeason!
   player: FFLPlayer!
-
-  """The FFL match this player match belongs to."""
   matchId: ID
   position: String
   status: FFLPlayerMatchStatus
@@ -616,6 +620,7 @@ type Query
   aflClubs: [AFLClub!]! @join__field(graph: AFL)
   aflClub(id: ID!): AFLClub! @join__field(graph: AFL)
   aflPlayerSeason(id: ID!): AFLPlayerSeason @join__field(graph: AFL)
+  aflClubSeason(id: ID!): AFLClubSeason @join__field(graph: AFL)
   aflLiveRound: AFLLiveRound @join__field(graph: AFL)
   aflPlayerSearch(query: String!): [AFLPlayer!]! @join__field(graph: AFL)
   fflSeasons: [FFLSeason!]! @join__field(graph: FFL)

--- a/dev/router/supergraph.graphql
+++ b/dev/router/supergraph.graphql
@@ -333,6 +333,9 @@ type FFLPlayerMatch
   playerSeasonId: ID!
   playerSeason: FFLPlayerSeason!
   player: FFLPlayer!
+
+  """The FFL match this player match belongs to."""
+  matchId: ID
   position: String
   status: FFLPlayerMatchStatus
   aflStatus: FFLAFLPlayerMatchStatus

--- a/dev/router/supergraph.graphql
+++ b/dev/router/supergraph.graphql
@@ -211,15 +211,12 @@ type AFLStatSummary
   games: Int!
 }
 
-"""
-Aggregation method to apply over a set of matches.
-Only MEAN is implemented; additional methods (MEDIAN, STDDEV, …) can be added
-without a schema change.
-"""
+"""Aggregation method to apply over a set of matches."""
 enum AFLStatSummaryMethod
   @join__type(graph: AFL)
 {
   MEAN @join__enumValue(graph: AFL)
+  MEDIAN @join__enumValue(graph: AFL)
 }
 
 input CalculateFFLFantasyScoreInput

--- a/doc/review-findings.md
+++ b/doc/review-findings.md
@@ -1,0 +1,212 @@
+# Codebase Review — Findings
+
+**Date:** 2026-07-06 · **Scope:** full repo at branch `phase-23-ux-player-intelligence` (commit `1ce978c`)
+
+**Framing:** the repo is deliberately architecture-forward; findings judge design and execution quality on their own terms, never proportionality to project size.
+
+**How to read a finding:** each one leads with a plain-language headline; the tags after it are `severity · good/bad/improve · classification`. For doc-vs-code mismatches, the classification says which side should change (**code drift** = fix the code, **doc should change** = fix the doc).
+
+| Severity | Meaning |
+|-----|---------|
+| `critical` | Undermines a core guarantee the system claims to provide |
+| `significant` | Real drift/defect; will bite as the system grows or is relied on |
+| `minor` | Worth fixing; low blast radius |
+| `nit` | Cosmetic / judgement call |
+
+---
+
+## 1. Architecture — are the rules coherent?
+
+### Good
+
+- **The layer rules are crisp, consistent, and genuinely enforceable.** `good` — Stated coherently across `principles.md`, ADR-005, and ADR-012. ADR-012 in particular is exemplary: domain purity, aggregate completeness, time/randomness injection, and repository responsibility each stated as enforceable rules with rationale and named negative consequences (`ai/decisions/adr-012-domain-purity-aggregate-completeness.md:74-81`).
+- **Bounded contexts are applied correctly, not just claimed.** `good` — AFL and FFL share term names (`PlayerMatch`, `ClubMatch`, `Score`) with deliberately different meanings per context, documented side by side in `domain.md`; schemas are per-context; cross-context linkage is by plain integer IDs, not foreign keys (`ai/architecture/domain.md:163-165`). Textbook context-mapping (Separate Ways + ACL + published-language events).
+- **ADR-013 is a model of how to reverse a decision.** `good` — History section, original premise restated, the specific evidence that invalidated it (three named traversal patterns), and an explicit consequences list touching ADR-008/015/017/018 (`adr-013:17-37`).
+- **The anti-corruption layer is correct DDD.** `good` — ADR-016 + `integrations.md`: identity mapping owned by the adapter, never referenced by domain repositories, kept inside the service's own schema to preserve ADR-003's boundary.
+- **The decision index is a strong human/agent interface.** `good` — `decisions.md` with status + enforceable flags, machine-readable frontmatter `rules:` on most ADRs, and an explicit source-of-truth hierarchy (`principles.md:72-80`).
+
+### Bad / Improve
+
+- **Two accepted ADRs give opposite instructions about calling back to the producer.** `significant · bad · docs contradict each other` — ADR-004's enforceable rule *"subscribers must not call back to the producer"* (`adr-004:9`) is contradicted by the current *designed* event flow: FFL's handlers for `AFL.PlayerMatchUpdated` / `AFL.MatchUpdated` call back to AFL over Twirp on every event (`services/ffl/internal/application/score.go:40,81`, sanctioned by `event-flow.md`). ADR-013/018 introduced sync RPC but never amended ADR-004. Either amend ADR-004 to scope the rule, or fatten the event payloads so recalculation doesn't need the callback.
+- **ADR-008 still says the opposite of what was decided.** `significant · bad · doc should change` — Its frontmatter says `status: accepted` (`adr-008:2`) while `decisions.md` marks it superseded, and its closing guidance — *"Stay on path-based routing. Federation … was evaluated and rejected — see ADR-013"* (`adr-008:29`) — points at ADR-013 as the *rejection* of federation when ADR-013 *adopts* it. A reader who follows the ADR file rather than the index gets the exact opposite of reality. ADR-006 shows the correct retirement pattern.
+- **"Interfaces defined where consumed" conflicts with where repository interfaces actually live.** `minor · improve` — ADR-005 states the Go idiom, but repository interfaces live in the **domain** layer (defined there, consumed by application — `services/ffl/internal/domain/club_match.go:392`), following the DDD convention instead. Clarify the rule ("repository interfaces live in domain as part of the model; all *other* ports are defined where consumed").
+- **ADR-012 doesn't follow the ADR format the others use.** `minor · improve` — It lacks the standard frontmatter (status/date/scope/enforceable/rules); its enforceable rules live in prose, so any tooling reading frontmatter misses them.
+- **ADR-004 contains stale facts about the event system.** `minor · bad · doc should change` — The event-flow diagram lists `FFL.FantasyScoreCalculated` (`adr-004:47`), which shipped as `FFL.PlayerMatchUpdated`; the payload-size rationale says "two event types" where there are now six (`contracts/events/events.go:5-26`).
+- **The denormalised-data ADR never says how derived data stays trustworthy.** `minor · improve` — ADR-010 states "consistency maintained through domain logic on writes" but is silent on the obligations that make the pattern safe: every `drv_` field needs an idempotent rebuild path and staleness must be detectable. Both gaps materialise as concrete defects in §6. Adding those two invariants would make ADR-010 a genuinely reusable exemplar.
+- **Aggregates validate on write, but persistence is column-at-a-time — so invariants can be bypassed.** `minor · improve · internal tension` — "Aggregates enforce consistency" (principles) sits awkwardly with repository interfaces that are field-level setters (`UpdateStatus`, `UpdatePosition`, `UpdateScore`, `UpdateDataStatus` — `domain/player_match.go:187-201`). The aggregate validates on `SubmitTeam`, but nothing structurally prevents writing an invariant-violating combination. See §3.
+
+---
+
+## 2. Domain & documentation
+
+### Good
+
+- **`domain.md` is an excellent ubiquitous-language document.** `good` — The position/multiplier table, bench rules as numbered hard rules mirroring `validateTeam`, the two-axis data-status → score-tier matrix, and the explicit "TM declarations are always explicit" statement all match the code precisely (star excluding hitouts: `domain.md:125` ↔ `ffl/internal/domain/player_match.go:116-120`; per-stat flooring in bye scores: `domain.md:222` ↔ `player_match.go:140-167`).
+- **`event-flow.md`'s mental model is exactly what a newcomer needs.** `good` — Two inputs, everything else derived; provisional vs final tiers; and the ASCII event chain matches the handler code hop for hop.
+- **The cookbook recipes are the strongest agent-facing docs in the repo.** `good` — Add-a-column with 10 ordered steps, generation-order warning, error-code convention.
+
+### Findings
+
+- **The docs describe FFL match storage that doesn't exist.** `significant · bad · doc should change` — `domain.md`'s Match style section says *"`clubs` stores club_season_ids … `home_club_match_id` / `away_club_match_id` are nullable"* (`domain.md:249-251`). The schema has neither column — sides are modelled by `ffl.club_match.side` (`dev/postgres/init/02_ffl_schema.sql:86`), and `match_style` exists in the DB but is absent from the Go domain (`ffl/internal/domain/match.go:18-26`), the GraphQL schema, and all logic. A parked design is presented as current fact — and per the doc's own charter, column names shouldn't be there at all.
+- **The docs deny a player status ("named") that the code actively produces and stores.** `significant · bad · pick a side` — `domain.md` says twice that pre-match `named` is *not tracked* (`domain.md:90,203`), but AFL derives `"named"` whenever a player_match row exists and the match is still `no_data` (`afl/internal/domain/player_match.go:37-46`), ships it over Twirp (`afl/internal/interface/twirp/player_lookup.go:138`) and GraphQL (`afl … convert.go:126`), FFL persists it into `drv_afl_status` (`ffl/internal/application/score.go:151-154`), and FFL's GraphQL enum includes `named` (`ffl/api/graphql/query.graphqls:130-136`). Recommend **doc should change** — three layers of code already agree with each other.
+- **The cookbook says Search is REST; it's GraphQL. It also misdescribes the gateway.** `minor · bad · doc should change` — Topology table at `cookbook.md:38` vs `services/search/cmd/main.go:66-74`; the gateway is described as "routes to AFL/FFL" but actually proxies `/query` to Apollo Router and `/search/query` to Search (`services/gateway/cmd/main.go:84-88`).
+- **The cookbook's pagination recipe contradicts the pagination ADR.** `minor · bad · doc contradicts ADR` — The recipe puts `totalCount: Int!` on the Connection type (`cookbook.md:114-118`); ADR-014's enforceable rule puts nullable `totalCount` inside `PageInfo` (`adr-014:11`). The code follows ADR-014 (`afl/api/graphql/common.graphqls:1-5`). Fix the recipe.
+- **The repo map is stale in several places.** `minor · bad · doc should change` — References `ai/architecture/service-map.md`, which doesn't exist (`repo-map.md:10`); omits `event-flow.md`, `frontend.md`, `integrations.md`, `testing.md`, `data-ops-workflow.md`; omits the search service; shows `contracts/` as events-only (no `proto/`, `gen/`); docker-compose line omits the Apollo Router (`dev/docker-compose.yml:29-40`). CLAUDE.md's `just dev-up` description has the same router omission.
+- **The testing doc names e2e seed files that don't exist.** `minor · bad · doc should change` — `testing.md:232` says `dev/postgres/test-e2e/{03_afl_seed,04_ffl_seed}.sql`; the actual files are `10_afl_seed.sql` / `11_ffl_seed.sql` (confirmed by `e2e/helpers/reset-db.ts:7-10`).
+- **The cookbook says schemas are shared "via symlinks"; they're actually copied.** `minor · bad · doc should change` — `cookbook.md:69` vs the `test-e2e` recipe, which copies files in and deletes them after (`justfile:116-135`).
+- **The ACL mapping tables have three different naming conventions across two docs and the code.** `minor · bad` — `decisions.md` says `xref_<source>_<entity>`; ADR-016's body example is `player_source_map`; the actual tables are `afl.dataops_match_source` / `afl.dataops_player_source` (`dev/postgres/init/03_dataops.sql:4,16`); the cookbook references `<n>_<service>_integrations.sql` (actual file: `03_dataops.sql`). Pick one convention and align the rest.
+- **The frontend doc describes a shared components directory that doesn't exist, and misses a whole feature.** `minor · bad · doc should change` — `frontend.md:60-77` lists `src/components/` (absent) and omits `features/data-ops/` entirely; the route table omits `/ffl/ladder` and `/afl/ladder` (`router.ts:26-28,95-97`).
+- **Code comments name events that don't exist.** `nit · bad · code drift` — `team.go:44` claims SetTeam "publishes FFL.TeamSubmitted"; `team.go:254` mentions "FFL.SubsDeclared". Neither exists — both paths publish `FFL.ClubMatchUpdated`.
+- **Planning docs are in genuinely good shape.** `good` — `current-sprint.md` is checked off and matches the branch's actual work; roadmap phases reference the migration strategy and carry an explicit ADR decision-gate (Phase 26).
+
+**Newcomer verdict:** a newcomer reading `domain.md` + `event-flow.md` + `cookbook.md` could build with confidence in the FFL scoring core; the traps are the match-style fiction, the `named` status, and the topology table — all doc-side fixes.
+
+---
+
+## 3. Services — is the code following the rules?
+
+### Good
+
+- **Layer discipline is real, not aspirational.** `good` — Both services match the cookbook layout file-for-file; domain packages import only stdlib; time comes from an injected clock (`shared/clock`, `afl/cmd/main.go:146-157`), satisfying ADR-012; generated code is confined to `sqlcgen`/`generated.go`; transaction boundaries live in the application layer via `TxManager`/`WriteRepos` exactly as ADR-009 specifies (`ffl/internal/infrastructure/postgres/db.go:30-49`).
+- **Service isolation holds.** `good` — No cross-service Go imports anywhere; AFL↔FFL communicate exclusively via `contracts/` events and the Twirp port (`ffl/internal/infrastructure/rpc/player_lookup.go`), matching ADR-018's port pattern precisely.
+- **The ACL is honoured in practice.** `good` — External IDs live only in `dataops_*` tables accessed by dedicated repositories (`afl/internal/application/ports.go:66-86`); domain repositories never touch them.
+
+### Drift topics, by severity
+
+1. **The error-translation function required by ADR-009 exists but is never called.** `significant · bad · code drift` — `MapPgError` (`shared/database/errors.go:19`) is dead code. Exactly one repo method does an ad-hoc `pgx.ErrNoRows` → `domain.ErrNotFound` translation (`ffl/…/postgres/repository.go:131-132`, with `ErrNotFound` re-declared locally in `ffl/internal/domain/round.go:8`); every other `FindByID` leaks raw pgx errors up to resolvers. Either wire `MapPgError` into the repository adapters or amend ADR-009 — currently the ADR describes a fiction.
+
+2. **Repositories return half-loaded aggregates, which ADR-012 explicitly forbids.** `significant · bad · code drift` — `ClubMatchRepository.FindByID` returns a `ClubMatch` with no `PlayerMatches`; every use case manually stitches the aggregate together (`team.go:56-71`, `score.go:161-170`). ADR-012 forbids "partially-loaded aggregates that require further data fetching" and endorses use-case-specific methods (`GetMatchWithDetails` exists for Match — the pattern is known). Relatedly, the field-level setter repositories mean team invariants are only enforced on the `SubmitTeam` path; `DeclareSubs` writes statuses/positions with no aggregate-level revalidation (`team.go:216-232`). A `SaveTeam(cm)`-style method would make the aggregate boundary real at the persistence layer.
+
+3. **Scoring business rules are leaking out of the domain into the application layer.** `significant · improve` — The rule "an unactivated interchange bench player scores at their declared interchange position" is implemented inline in `RecalculateScore` (`score.go:136-141`) rather than in the domain (where `DeclareSubs`/`CalculateScore` live and where `domain.md` describes it). Same for "bye bench score applied at activation", split across `applyByeScoresForActivated` (`team.go:429-531`). The domain layer is where these belong and where they'd be unit-testable.
+
+4. **Finalising a match is a chain of separate best-effort steps — a mid-sequence failure leaves inconsistent data with only a log line.** `significant · bad` — `MarkMatchStatsFinal` performs status update → result derivation → ladder recalc → event publication as separate steps outside any transaction, each failure only logged (`afl/internal/application/dataops.go:330-424`). `SetTeam`'s post-commit recalculation and publish degrade the same way (`team.go:150-185`). Combined with §6's lack of repair loops, this means permanently inconsistent derived state with no signal. At minimum, result derivation + ladder recalc for the finalised match belong in one transaction.
+
+5. **A restore only works if the init SQL exactly matches the live schema — and nothing checks that it does.** `significant · improve` — The documented migration strategy (manual `ALTER` + keep init SQL in sync, `cookbook.md:62-75`) is coherent, but the backup is **data-only** (`pg_dump --data-only --disable-triggers`, `dev/backup/backup.sh:14`), so restoring depends on init SQL matching the schema at backup time. A forgotten init-SQL update is discovered at the next `dev-reset`/restore — the worst possible moment. Cheap fixes: also dump the schema (`pg_dump -s`) alongside each backup, and/or a recipe that diffs live schema against a fresh init-SQL database.
+
+6. **Every schema change must be hand-applied to two independent seed datasets.** `minor · improve` — Dev seeds (6 files, `dev/postgres/seed/`) and e2e seeds (2 files, `dev/postgres/test-e2e/1{0,1}_*.sql`) are separately hand-maintained over the same schema; the cookbook recipe only mentions the dev seed (step 9). Consider generating one from the other, or documenting the dual obligation.
+
+7. **The AFL service runs an event listener that can never receive anything.** `minor · bad · code drift` — `main.go` starts `dispatcher.Listen` with **zero subscriptions** (`afl/cmd/main.go:68-73`) — a goroutine and a pinned pool connection doing nothing.
+
+8. **A comment promises fuzzy club-name matching that the code doesn't do — possibly a latent import bug.** `minor · bad · comment drift` — `filterByClub`'s comment says case-insensitive prefix with a contains fallback; the code is exact `==` (`afl/internal/application/dataops.go:648-658`). If FootyWire really does shorten club names, imports will silently drop a whole club's stats.
+
+9. **The Go gateway still exists even though ADR-013 says the Apollo Router replaces it.** `minor · bad · reconcile doc or code` — ADR-013's consequence says "Apollo Router replaces `services/gateway` … CORS and `/health` move to the Router config" (`adr-013:125`); what exists is a Go proxy fronting the Router and Search (`gateway/cmd/main.go`). Keeping a stable origin is defensible — but then the ADR consequence should be revised; today the docs say the gateway shouldn't exist.
+
+10. **The adapter documentation convention is ignored.** `nit` — `integrations.md` mandates a `doc.go` per adapter package ("the first thing a developer reads"); neither `footywire` nor `forum` has one — nor even a package comment.
+
+---
+
+## 4. Frontend
+
+### Good
+
+- **The feature-folder shape is right.** `good` — `features/{afl,ffl,data-ops}/{api,components,composables,utils,views}`, lazy-loaded route components throughout `router.ts`, GraphQL documents centralised per feature.
+- **State management matches the ADR's staged intent.** `good` — Apollo cache is the only server state; the module-singleton composable pattern (`useFflState.ts:27-32`) is a clean sub-Pinia solution; `useLiveRoundBootstrap` correctly centralises the deep-link bootstrap in `App.vue`.
+- **The e2e harness is the best part of the frontend estate.** `good` — See §7.
+
+### Findings
+
+- **The "no cross-feature imports" rule is violated everywhere, in both directions.** `significant · bad · pick doc or code` — FFL views import AFL utils/composables/queries (`ffl/views/FreeAgentsView.vue:105`, `ffl/views/RoundView.vue:71`), AFL views import FFL components/queries (`afl/views/ClubSeasonView.vue:67-70`), data-ops imports AFL wholesale (`data-ops/views/DataOpsView.vue:478-485`), and the router mounts an AFL view on an FFL-lens route (`router.ts:66-71`). Either amend `frontend.md` to define an allowed dependency direction (e.g. "ffl → afl allowed" — the AFL-lens concept implies exactly this), or create the shared `src/components`/`src/composables` home the doc already claims exists and move `Breadcrumb`, `RoundNav`, `LadderTable`, `MatchSummary`, club-logo utils, and `useXxxState` there.
+- **The two most important views are unmaintainable monoliths.** `significant · improve` — `TeamBuilderView.vue` is 1,601 lines (7 queries, 3 interaction modes, drag/reorder, subs pairing, client-side bench validation, copy-previous-team); `DataOpsView.vue` is 1,022; `SquadView.vue` 590. No decomposition into per-mode components or composables, and pure logic (bench validation mirroring `domain.validateTeam`) is trapped inside a component where it can't be unit-tested. Largest single maintainability risk in the frontend.
+- **The hottest pages fetch far more data than they show.** `significant · bad` — Team Builder edits **one club's** team but fetches `GET_FFL_ROUND` — every match in the round with full player lists, per-player season stats, AFL stat lines, and suggested subs for every club (`ffl/api/queries.ts:164-249`, used at `TeamBuilderView.vue:616`, re-fetched wholesale after mutations at `:1469,1520`). `SquadView` fetches `GET_FFL_SEASON_POSITIONS` — every player match of every club match of every round — to derive one squad's position history (`queries.ts:323-356`). Both need club-match-scoped queries; both multiply the server-side N+1s in §5.
+- **Dead and near-duplicate GraphQL documents are accumulating.** `minor · bad` — `GET_FFL_SEASON` (82 lines, the heaviest document in the file) is **unused**; three near-identical `fflRoundByAflRound` variants coexist (`queries.ts:108-153`); there are zero fragments — the ~40-line `playerMatches` selection is pasted 6× with small accidental differences, which is exactly what fragments prevent.
+- **Opening the Team Builder costs four sequential round-trips.** `minor · improve` — Club-match bootstrap → round → season → club-season (`TeamBuilderView.vue:597-643`), where the graph could serve one composed query from `fflClubMatch`.
+- **There's no typecheck or lint wired into any recipe.** `nit` — The cookbook documents `npx vue-tsc --noEmit`, but `package.json` has no `typecheck`/lint script and `just test-all` doesn't run one.
+
+### E2e test quality (coverage & brittleness)
+
+- **Coverage maps well to the feature set.** `good` — 15 specs covering home, round, match, squad, team builder (695 lines — save, replicate, clear, subs), free agents, data-ops, navigation, plus AFL admin.
+- **Some selectors will break on any styling refactor.** `minor · improve` — Structural selectors tied to Tailwind utility classes — `page.locator('div.mb-6').filter({ has: … h3 })` (`e2e/ffl-team-builder.spec.ts:14-20`) — break on a spacing change; prefer `data-testid` or landmark roles. Navigation via `page.locator('main nav').last()` (`:7`) encodes DOM order. Seed-string coupling ("The Howling Cows") is acceptable given the seeded runtime.
+
+---
+
+## 5. GraphQL API
+
+### Good
+
+- **The graph reads the way the principles say it should.** `good` — Queries start from seasons/rounds/clubs and traverse edges; the federated graph gives the frontend natural cross-context traversals (`FFLPlayerMatch.aflPlayerMatch { kicks … }`) exactly as ADR-013 intended, with `@key` stubs on the FFL side (`ffl/api/graphql/query.graphqls:156-177`) and the composed supergraph checked in.
+- **Pagination follows the ADR where it exists.** `good` — `PageInfo` defined once per service with nullable `totalCount`, connections are `nodes + pageInfo` only, `first/after` accepted ahead of real pagination — matching ADR-014's staged-adoption intent.
+- **The player-stats field is the best-designed part of the graph.** `good` — `AFLPlayerSeason.stats(upToRoundId, lastN, method)`: documented semantics, opaque-ID discipline stated in the docstring, reusable `AFLStatSummary` shape, and a DataLoader that batches by param-group (`afl/…/loaders.go:59-104`) — the most sophisticated loader in the repo, done right.
+
+### Findings
+
+- **The "everything goes through a DataLoader" rule is broken all over both services — real N+1s result.** `significant · bad · code drift vs ADR-017` — Many resolvers call single-item repo methods by ID: AFL's `Match.homeClubMatch`/`awayClubMatch` each call `GetClubMatch` + `GetClubForClubSeason` per match (`afl/…/query.resolvers.go:103-148`), `AFLClubMatch.match` calls `GetMatch` (`:38-48`), `AFLPlayerMatch.clubMatch` calls `GetClubMatch` (`:151-165`), and the season/round chains use two singles each. The loader inventory (`loaders.go:24-30`) simply lacks `ClubMatchByID`, `RoundByID`, `SeasonByID`, `ClubSeasonByID`. FFL has the same pattern (`ffl/…/query.resolvers.go:120-148,266-270`). Concrete cost: `aflRound { matches { homeClubMatch awayClubMatch } }` runs ~4 queries **per match**, and the season-wide frontend queries in §4 multiply that by rounds × matches.
+- **Cross-service lookups through federation happen one row at a time.** `significant · bad · code drift vs ADR-013` — ADR-013 says "entity resolvers batch by IDs using the existing dataloadgen pattern"; the implementation is per-representation `Find*ByID` calls (`afl/…/entity.resolvers.go:26-40`), so an FFL club-match page resolving ~30 `aflPlayerMatch` references issues ~30 sequential single-row queries inside one `_entities` call (gqlgen's batched entity-resolver mode is unused). Exactly the cross-service N+1 that ADR-017's "Upcoming pressure" section predicted.
+- **A query root exists that the principles explicitly forbid.** `significant · bad · pick doc or code` — `principles.md:34` names **ClubMatch** as an internal join entity that "must not be a query root", yet `fflClubMatch(id:)` is a root (`ffl/api/graphql/query.graphqls:15`) and Team Builder routes are keyed on club-match IDs. In practice FFL ClubMatch has grown into a page-level aggregate ("a club's team for a round"). Recommend **doc should change** — but restate the principle so it still excludes true join noise.
+- **The two subgraphs model the same kinds of values differently.** `minor · bad` — FFL models statuses as enums (`FFLPlayerMatchStatus`, `FFLAFLPlayerMatchStatus`); AFL exposes `status: String!`, `dataStatus: String!`, `result: String` as bare strings (`afl/api/graphql/query.graphqls:47-56,142`). Same domain, one graph, two conventions — enums should win.
+- **Whether a missing ID errors or returns null is arbitrary per field.** `minor · bad` — `aflSeason(id): AFLSeason!` (error on missing) vs `aflRound(id): AFLRound` (null); `fflClub!` vs `fflClubSeason` — no discernible rule. Pick "nullable + null on not-found" for lookups and apply it.
+- **Some entity resolvers run a query just to throw the result away.** `minor · improve` — `FindAFLPlayerSeasonByID` fetches the row, discards it, and returns an ID-only stub (`entity.resolvers.go:43-54`) — a query per representation purely to 404. Batched entity resolvers make this cost disappear.
+- **A few unbounded lists have no pagination.** `minor · improve` — Mostly defensible under ADR-014's ~50-item rule; the exceptions are `fflPlayers` (grows every season, unbounded) and `AFLClubSeason.playerSeasons`.
+- **The schema documents a filter as "Not supported".** `nit` — `FFLPlayerSeasonFilter.active` (`query.graphqls:117-120`) — remove until real.
+- **Frontend query documents** (over/under-fetch, fragments): covered in §4 — over-fetch significant, zero fragment reuse, one dead document.
+
+---
+
+## 6. Events & data consistency
+
+### Good
+
+- **The designed chain is conceptually strong.** `good` — `AllAFLStatusesFinal` is an elegant finality inference — FFL derives AFL finality from its own data with no cross-service call at check time (`event-flow.md:57-62`; SQL-backed at `ffl/…/player_match.go:199`) — and `dnp` inference via the both-squads status map on `final` is correctly specified and implemented (`afl/…/dataops.go:397-410`).
+- **Ladder recalculation is rebuild-from-scratch idempotent, and repair mutations exist.** `good` — "Entire season recalculated from scratch — simpler and drift-free"; `recalculateFFLLadder`, `recalculateFFLClubMatchScore`, `recalculateAFLLadder`.
+- **Derived scores are kept consistent inside the writing transaction.** `good` — Every synchronous write path re-derives `drv_score` in the same transaction as the player-match write (`SetTeam`, `CalculateFantasyScore`, `RecalculateScore`, `ResolveAFLPlayerMatch`) — ADR-010 honoured on the happy path.
+- **The event chain has dedicated integration tests.** `good` — `ffl/…/event_integration_test.go`, 842 lines — rare and valuable.
+
+### Findings
+
+- **A single lost event permanently stalls match finalization, and nothing will ever notice.** `critical · bad` — Four compounding facts:
+  1. Publishes happen post-commit on a separate connection and every failure is warn-and-continue (`team.go:182-184`, `dataops.go:302-304`, etc.) — a crash or error between commit and publish loses the event.
+  2. There is no outbox/replay (ADR-004 consciously accepts this, deferring the outbox to its scale path).
+  3. If `Listen` errors (DB restart, connection drop), the goroutine logs "listener stopped" and **never restarts** — the service keeps serving traffic with event processing permanently dead (`ffl/cmd/main.go:97-101`, `search/cmd/main.go:58-62`, `shared/events/pg/dispatcher.go:70-88`).
+  4. The user-visible finality pipeline — `ClubMatchScoreFinalized` → `MatchScoreFinalized` → `drv_result` + ladder — is driven **only** by this chain; `markFFLTeamFinal` returns success after a status write and a publish (`ffl/…/dataops.go:222-248`), and everything after is fire-and-forget.
+
+  ADR-004's "lost messages are tolerable because everything can be recalculated" only holds if recalculation paths exist — and `ffl.match.drv_result` has **no** manual rebuild (`RecalculateFflLadder` never calls `UpdateResult`; only `ProcessFflMatchScoreFinalized` does, `reactions.go:255`). Minimum fixes, in leverage order: (a) make `Listen` reconnect with backoff or crash the process — silent degradation is the worst outcome; (b) extend a repair mutation to re-derive `drv_result` and re-run finalization inference for a round; (c) longer-term, the ADR-004 outbox.
+
+- **Un-finalising an AFL match leaves FFL believing it's still final.** `significant · bad` — `MarkMatchStatsFinal(matchID, final=false)` updates AFL's status and returns early — **no event** (`afl/…/dataops.go:347-349`). FFL keeps `drv_afl_status = played/dnp` for every affected player, so `AllAFLStatusesFinal` stays true and a subsequent FFL-side finalization locks scores against AFL data that is officially no longer final. The reversal path must emit `AFL.MatchUpdated(partial)` with a re-derived status map (the FFL side gets this right — `markFFLTeamSubmitted` publishes on reversal, `ffl/…/dataops.go:193-218`).
+
+- **There is no way to detect that derived data has gone stale.** `significant · bad` — Nothing compares stored `drv_score` against a recomputation, or detects club matches that satisfy both-axes finality but never emitted `ClubMatchScoreFinalized`. Every failure in this section is therefore *invisible* until a human notices a wrong ladder. The data-ops workflow already plans "Step 6 — Score reconciliation" (`data-ops-workflow.md:66-73`) — building it as a systematic drv-vs-derived diff closes this hole and satisfies the ADR-010 invariant proposed in §1.
+
+- **One AFL match finalising triggers a storm of calls back to the AFL service.** `significant · bad · see §1` — Every `AFL.MatchUpdated` triggers, per FFL club match in the round, `RecalculateScore` → up to 2 Twirp calls back to AFL plus per-player queries (`reactions.go:115-139`); one `AFL.MatchUpdated(final)` fans out to ~8 club matches × (Twirp + N queries), serially, on the single listener connection. Contradicts ADR-004's no-callback rule and amplifies load on the producer at exactly its busiest moment. Fat events (stats snapshots in the payload) or a batched lookup fixes both.
+
+- **One slow event handler stalls all event processing for the whole service.** `minor · bad` — Handlers run inline and sequentially in the `Listen` loop with the root context and no per-event timeout (`dispatcher.go:101-105`); a hung Twirp call blocks every subsequent event for the process.
+
+- **Tests exercise stricter event semantics than production has.** `minor · bad` — The in-memory dispatcher propagates the first handler error to the publisher (`memory/dispatcher.go:32-37`); the PG dispatcher swallows handler errors (`pg/dispatcher.go:101-105`). A path to "passes in test, silently drops in prod".
+
+- **Finalized events can re-fire; it's benign today, but only by accident.** `minor` — `ClubMatchScoreFinalized` re-fires on every reprocessing of an already-final club match (`reactions.go:130-137`); downstream is idempotent so this is harmless — worth a comment so it stays deliberate.
+
+- **Nothing guards the 8KB NOTIFY payload ceiling.** `nit` — Current payloads (~1–3KB for full-squad maps) have headroom, but nothing checks or logs payload size at publish; an oversized snapshot would fail silently into a warn log.
+
+---
+
+## 7. Testing strategy adherence
+
+### Good
+
+- **Tier discipline is largely real.** `good` — Every `*_integration_test.go` in AFL/FFL carries `//go:build integration`; the `TestMain`-per-package + `testutil.StartPostgres` + truncate-and-seed isolation pattern is implemented exactly as `testing.md` specifies; external HTTP is mocked with `httptest` everywhere (no real network calls found).
+- **Integration coverage is substantial and aimed at the risky seams.** `good` — AFL GraphQL (1,727 lines), FFL GraphQL (1,625), the event chain (842), data-ops import (444), suggested substitutions (447), subs declaration (386), byes (238), Twirp server (374). Testing the event cascade end-to-end at the integration tier is the strategy's standout.
+- **Domain unit tests follow the documented conventions.** `good` — Table-driven, sentence-style case names, want-first asserts; `ffl/internal/domain/club_match_test.go` (19KB) thoroughly covers `validateTeam`, `DeclareSubs`, `Score`, and `SuggestedSubstitutions` — the highest-value pure logic in the system.
+- **The e2e isolation model matches its documentation.** `good` — Auto-reset fixture, `workers: 1` with the rationale in a config comment as promised, fixed `CLOCK_OVERRIDE`, fully isolated stack on separate ports.
+
+### Findings
+
+- **Two test files break the promise that plain `go test ./...` is always safe to run.** `significant · bad · code drift` —
+  1. `services/search/internal/infrastructure/typesense/repository_test.go` starts a **testcontainers** Typesense with no build tag — `go test ./...` in the search service requires Docker, violating `testing.md`'s explicit rule.
+  2. `shared/events/pg/dispatcher_test.go` connects to the **live dev database** (`localhost:5432/xffl`, `dispatcher_test.go:17`), untagged — it fails without the dev stack and touches real shared infrastructure, violating both the tag rule and the hermeticity rule.
+- **The search service and shared packages are never tested by any recipe.** `significant · bad` — `just test-all` runs AFL, FFL, and e2e only (`justfile:138-141`); the two violations above (and any future regressions in those modules) are invisible in the normal workflow.
+- **Coverage gaps line up with the layering drift.** `minor · improve` — AFL's `CalculateLadder` has no unit test (the FFL twin does — `ffl/…/ladder_test.go`); the both-axes finalization inference and status-map application live in `application/reactions.go` with repository dependencies, so they're only covered via heavyweight integration tests — a direct consequence of §3 finding 3. There's no test for listener failure/reconnect behaviour (because there is none to test — §6).
+- **The docs claim strict TDD; the history can't support that claim.** `minor · improve` — Principles list TDD as non-negotiable ("write failing tests first"), which is unverifiable from the history (tests and implementation land together in feature commits). The honest, still-strong claim the repo *does* satisfy is "no behaviour ships untested at the appropriate tier". Reword, or accept it as aspirational process guidance for agents.
+- **Pure frontend logic is only tested through the slowest possible tier.** `minor · improve` — `position.ts`, `scoring.ts`, `heatmap.ts`, and the bench-validation logic trapped in `TeamBuilderView.vue` have zero direct tests — consistent with the documented "frontend = e2e only" strategy, but these are exactly the cheap-to-unit-test functions where e2e is the wrong tier. A small vitest setup closes this without changing the strategy's spirit.
+- **E2e selector brittleness** — see §4. `nit`
+
+---
+
+## Cross-lens prioritised actions
+
+1. **Make event processing fail loudly and recoverably** *(§6 critical)* — reconnect-with-backoff (or fatal exit) when `Listen` dies in FFL/search; log-and-alert on publish failure. This single change removes the silent-permanent-death mode. (`shared/events/pg/dispatcher.go`, both `cmd/main.go`s.)
+2. **Give every derived field a rebuild path and a staleness check** *(§6 + ADR-010)* — extend repair mutations to re-derive `ffl.match.drv_result` and re-run finalization inference for a round; build data-ops Step 6 as a drv-vs-recomputed reconciliation diff. Then amend ADR-010 to state both as invariants of the pattern.
+3. **Emit `AFL.MatchUpdated(partial)` on final→partial reversal** *(§6)* — with a re-derived status map, mirroring what `markFFLTeamSubmitted` already does on the FFL side (`afl/internal/application/dataops.go:347`).
+4. **Finish ADR-017 and batch the federation entity resolvers** *(§5)* — add `ClubMatchByID`/`RoundByID`/`SeasonByID`/`ClubSeasonByID` loaders in AFL (mirror in FFL), convert the direct `Get*` resolver calls, and switch gqlgen federation to batched entity resolvers. This collapses the worst N+1s, including the cross-service one.
+5. **Reconcile the contradicting ADRs** *(§1)* — mark ADR-008 superseded in its own frontmatter and correct its "federation rejected" sentence; amend ADR-004's no-callback rule (or move to fat events) and refresh its stale event names/counts; align ADR-016/decisions.md/cookbook on one ACL table-naming convention.
+6. **Wire `MapPgError` (or delete it and amend ADR-009)** *(§3)* — one adapter-level change per service; kills the raw-pgx-error leak and the duplicated `ErrNotFound`.
+7. **Fix the test-tier violations and recipe gaps** *(§7)* — tag the Typesense container test `integration`; rewrite the pg dispatcher test on testcontainers with a tag; add search + shared to `just test-all`.
+8. **Documentation truth pass** *(§2, one sitting)* — `domain.md` (match-style storage fiction, `named` status), `cookbook.md` (Search=GraphQL, gateway role, symlink→copy, pagination recipe `totalCount`), `testing.md` (seed file names), `repo-map.md` (service-map.md, router, search, contracts), `frontend.md` (cross-feature rule, layout, data-ops).
+9. **Frontend structural pass** *(§4)* — decide the cross-feature import rule and create the shared `src/components`/`composables` home; split `TeamBuilderView.vue` into mode components + composables; introduce fragments for the repeated player-match selection; scope Team Builder and Squad views to club-match-level queries instead of round/season-wide documents.
+10. **Backup/restore parity guard** *(§3)* — dump schema alongside data backups (or add a recipe diffing `pg_dump -s` against a fresh init-SQL database) so manual-migration drift is caught before a restore depends on it.

--- a/frontend/web/e2e/ffl-free-agents.spec.ts
+++ b/frontend/web/e2e/ffl-free-agents.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from './fixtures'
+import { setupFflSession } from './helpers'
+
+test.describe('Free Agents', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupFflSession(page)
+    await page.goto('/ffl/free-agents')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('shows Free Agents heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Free Agents')
+  })
+
+  test('shows all 7 stat tabs', async ({ page }) => {
+    for (const label of ['Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Goals', 'Star']) {
+      await expect(page.getByRole('button', { name: label, exact: true })).toBeVisible()
+    }
+  })
+
+  test('Kicks tab is active by default', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Kicks', exact: true })).toHaveClass(/border-active/)
+  })
+
+  test('shows player table with Player, Club and Gms columns', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'Player' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Club' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Gms' })).toBeVisible()
+  })
+
+  test('switching to Goals tab makes Goals tab active', async ({ page }) => {
+    await page.getByRole('button', { name: 'Goals', exact: true }).click()
+    await expect(page.getByRole('button', { name: 'Goals', exact: true })).toHaveClass(/border-active/)
+    await expect(page.getByRole('button', { name: 'Kicks', exact: true })).not.toHaveClass(/border-active/)
+  })
+})

--- a/frontend/web/e2e/ffl-free-agents.spec.ts
+++ b/frontend/web/e2e/ffl-free-agents.spec.ts
@@ -40,4 +40,29 @@ test.describe('Free Agents', () => {
     await expect(page.getByRole('button', { name: 'Goals', exact: true })).toHaveClass(/text-sky-400/)
     await expect(page.getByRole('button', { name: 'Kicks', exact: true })).not.toHaveClass(/text-sky-400/)
   })
+
+  test('rows are actually ordered by the ranked stat', async ({ page }) => {
+    await page.getByRole('button', { name: 'Kicks', exact: true }).click()
+    await expect(page.locator('tbody tr').first()).toBeVisible()
+    // First StatCell in each row is the K column; its last number is the value
+    // the default rank basis uses (last-N, falling back to season). Missing
+    // stats rank as -1.
+    const kVals = await page.locator('tbody tr').evaluateAll(rows =>
+      rows.map(r => {
+        const spans = r.querySelectorAll('div.flex.items-end')[0]?.querySelectorAll('span') ?? []
+        const v = parseFloat(spans[spans.length - 1]?.textContent ?? '')
+        return Number.isNaN(v) ? -1 : v
+      }),
+    )
+    expect(kVals.length).toBeGreaterThan(1)
+    expect(kVals).toEqual([...kVals].sort((a, b) => b - a))
+  })
+
+  test('hovering a player shows the stats card with averages and round rows', async ({ page }) => {
+    await page.locator('tbody tr').first().getByRole('link').first().hover()
+    const card = page.locator('div.fixed.z-50')
+    await expect(card.getByText(/Season \(\d+\)/)).toBeVisible()
+    await expect(card.getByText(/Last \d+/)).toBeVisible()
+    await expect(card.getByText(/Round/).first()).toBeVisible()
+  })
 })

--- a/frontend/web/e2e/ffl-free-agents.spec.ts
+++ b/frontend/web/e2e/ffl-free-agents.spec.ts
@@ -12,14 +12,21 @@ test.describe('Free Agents', () => {
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Free Agents')
   })
 
-  test('shows all 7 stat tabs', async ({ page }) => {
-    for (const label of ['Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Goals', 'Star']) {
+  test('shows all 7 stat column headers', async ({ page }) => {
+    for (const label of ['Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Goals']) {
       await expect(page.getByRole('button', { name: label, exact: true })).toBeVisible()
     }
+    await expect(page.getByRole('button', { name: /^Star/ })).toBeVisible()
   })
 
-  test('Kicks tab is active by default', async ({ page }) => {
-    await expect(page.getByRole('button', { name: 'Kicks', exact: true })).toHaveClass(/border-active/)
+  test('Kicks header is active by default', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Kicks', exact: true })).toHaveClass(/text-sky-400/)
+  })
+
+  test('rank basis toggle switches between last N and season', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /^Last \d+$/ })).toHaveClass(/bg-control/)
+    await page.getByRole('button', { name: 'Season', exact: true }).click()
+    await expect(page.getByRole('button', { name: 'Season', exact: true })).toHaveClass(/bg-control/)
   })
 
   test('shows player table with Player, Club and Gms columns', async ({ page }) => {
@@ -28,9 +35,9 @@ test.describe('Free Agents', () => {
     await expect(page.getByRole('columnheader', { name: 'Gms' })).toBeVisible()
   })
 
-  test('switching to Goals tab makes Goals tab active', async ({ page }) => {
+  test('clicking the Goals header re-ranks by Goals', async ({ page }) => {
     await page.getByRole('button', { name: 'Goals', exact: true }).click()
-    await expect(page.getByRole('button', { name: 'Goals', exact: true })).toHaveClass(/border-active/)
-    await expect(page.getByRole('button', { name: 'Kicks', exact: true })).not.toHaveClass(/border-active/)
+    await expect(page.getByRole('button', { name: 'Goals', exact: true })).toHaveClass(/text-sky-400/)
+    await expect(page.getByRole('button', { name: 'Kicks', exact: true })).not.toHaveClass(/text-sky-400/)
   })
 })

--- a/frontend/web/e2e/ffl-match.spec.ts
+++ b/frontend/web/e2e/ffl-match.spec.ts
@@ -46,13 +46,14 @@ test.describe('FFL Match', () => {
     await expect(page.getByText('Total').first()).toBeVisible()
   })
 
-  test('shows Team Builder button in selected club column only', async ({ page }) => {
-    // Selected club is The Howling Cows — button should appear once (in their column)
-    await expect(page.getByTitle('Team Builder')).toHaveCount(1)
+  test('shows Team Builder link in selected club column only', async ({ page }) => {
+    // The selected club's h2 link navigates to /edit; the other club's h2 link does not.
+    // The Team Builder icon was merged into the club-name link in this branch (no separate title attr).
+    await expect(page.locator('h2 a[href$="/edit"]')).toHaveCount(1)
   })
 
-  test('Team Builder button navigates to team builder', async ({ page }) => {
-    await page.getByTitle('Team Builder').click()
+  test('Team Builder link navigates to team builder', async ({ page }) => {
+    await page.locator('h2 a[href$="/edit"]').click()
     await expect(page).toHaveURL(/\/ffl\/club-matches\/.*\/edit/)
   })
 

--- a/frontend/web/e2e/ffl-match.spec.ts
+++ b/frontend/web/e2e/ffl-match.spec.ts
@@ -42,10 +42,6 @@ test.describe('FFL Match', () => {
     await expect(page.getByText('Played').first()).toBeVisible()
   })
 
-  test('displays total row', async ({ page }) => {
-    await expect(page.getByText('Total').first()).toBeVisible()
-  })
-
   test('shows Team Builder link in selected club column only', async ({ page }) => {
     // The selected club's h2 link navigates to /edit; the other club's h2 link does not.
     // The Team Builder icon was merged into the club-name link in this branch (no separate title attr).

--- a/frontend/web/e2e/ffl-squad.spec.ts
+++ b/frontend/web/e2e/ffl-squad.spec.ts
@@ -34,6 +34,48 @@ test.describe('FFL Squad', () => {
     await expect(row.getByText('Brisbane Lions')).toBeVisible()
   })
 
+  // ── Stats view sorting ─────────────────────────────────────────────────────
+
+  test('clicking a stat header sorts; clicking again restores position order', async ({ page }) => {
+    await page.getByRole('button', { name: 'Stats' }).click()
+    const firstPlayerBefore = await page.locator('tbody td.sticky.left-0').first().textContent()
+
+    const kicksHeader = page.getByRole('button', { name: 'Kicks', exact: true })
+    await kicksHeader.click()
+    await expect(kicksHeader).toHaveClass(/text-sky-400/)
+
+    // Rows are genuinely ordered by kicks: the first StatCell per row is the K
+    // column; its last number is what the sort uses (last-N, season fallback).
+    const kVals = await page.locator('tbody tr').evaluateAll(rows =>
+      rows
+        .filter(r => r.querySelectorAll('div.flex.items-end').length > 0)
+        .map(r => {
+          const spans = r.querySelectorAll('div.flex.items-end')[0]?.querySelectorAll('span') ?? []
+          const v = parseFloat(spans[spans.length - 1]?.textContent ?? '')
+          return Number.isNaN(v) ? -1 : v
+        }),
+    )
+    expect(kVals.length).toBeGreaterThan(1)
+    expect(kVals).toEqual([...kVals].sort((a, b) => b - a))
+
+    // Second click restores the default position-group order
+    await kicksHeader.click()
+    await expect(kicksHeader).not.toHaveClass(/text-sky-400/)
+    await expect(page.locator('tbody td.sticky.left-0').first()).toHaveText(firstPlayerBefore ?? '')
+  })
+
+  test('clicking Player header sorts by name on stats tab', async ({ page }) => {
+    await page.getByRole('button', { name: 'Stats' }).click()
+    const playerHeader = page.getByRole('button', { name: 'Player', exact: true })
+    await playerHeader.click()
+    await expect(playerHeader).toHaveClass(/text-sky-400/)
+    const names = (await page.locator('tbody td.sticky.left-0').allTextContents())
+      .map(n => n.trim()).filter(Boolean)
+    const lastNames = names.map(n => n.split(' ').pop()!.toLowerCase())
+    expect(lastNames.length).toBeGreaterThan(1)
+    expect(lastNames).toEqual([...lastNames].sort((a, b) => a.localeCompare(b)))
+  })
+
   // ── Manage toolbar ─────────────────────────────────────────────────────────
 
   test('shows Manage button initially', async ({ page }) => {

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -35,8 +35,8 @@ test.describe('FFL Team Builder', () => {
       await expect(page.getByRole('heading', { level: 1 })).toContainText('The Howling Cows')
     })
 
-    test('Manage button visible; Save Team not visible', async ({ page }) => {
-      await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+    test('Build Team button visible; Save Team not visible', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Build Team' })).toBeVisible()
       await expect(page.getByRole('button', { name: 'Save Team' })).not.toBeVisible()
     })
 
@@ -83,13 +83,13 @@ test.describe('FFL Team Builder', () => {
   test.describe('layout: manage mode', () => {
     test.beforeEach(async ({ page }) => {
       await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
-    test('Save Team and Cancel visible; Manage button gone', async ({ page }) => {
+    test('Save Team and Cancel visible; Build Team button gone', async ({ page }) => {
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeVisible()
       await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Manage' })).not.toBeVisible()
+      await expect(page.getByRole('button', { name: 'Build Team' })).not.toBeVisible()
     })
 
     test('Save Team disabled until a change is made', async ({ page }) => {
@@ -103,7 +103,7 @@ test.describe('FFL Team Builder', () => {
       const filledBefore = await goalsSection.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).count()
       await page.getByRole('button', { name: 'Remove' }).first().click()
       await page.getByRole('button', { name: 'Cancel' }).click()
-      await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Build Team' })).toBeVisible()
       const filledAfter = await goalsSection.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).count()
       expect(filledAfter).toBe(filledBefore)
     })
@@ -128,7 +128,7 @@ test.describe('FFL Team Builder', () => {
     test('Save Team saves and returns to read-only mode', async ({ page }) => {
       await page.getByRole('button', { name: 'Remove' }).first().click()
       await page.getByRole('button', { name: 'Save Team' }).click()
-      await expect(page.getByRole('button', { name: 'Manage' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Build Team' })).toBeVisible()
       await expect(page.getByRole('button', { name: 'Save Team' })).not.toBeVisible()
       await expect(page.getByRole('heading', { name: /Squad \(/ })).not.toBeVisible()
     })
@@ -139,7 +139,7 @@ test.describe('FFL Team Builder', () => {
   test.describe('bench: dual-position slots', () => {
     test.beforeEach(async ({ page }) => {
       await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
     test('B button adds player to a bench slot', async ({ page }) => {
@@ -174,7 +174,7 @@ test.describe('FFL Team Builder', () => {
   test.describe('bench: validation', () => {
     test.beforeEach(async ({ page }) => {
       await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
     test('save blocked when bench player has no position assigned', async ({ page }) => {
@@ -207,7 +207,7 @@ test.describe('FFL Team Builder', () => {
   test.describe('interchange', () => {
     test.beforeEach(async ({ page }) => {
       await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
     test('interchange dropdown lists all 7 positions', async ({ page }) => {
@@ -231,7 +231,7 @@ test.describe('FFL Team Builder', () => {
       await expect(benchSection(page).getByText(/·\s*Int/)).toBeVisible()
 
       // Re-enter manage — interchange dropdown still set
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       await expect(page.getByLabel('Interchange')).toHaveValue('star')
     })
   })
@@ -244,7 +244,7 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('local edits not reset when re-entering manage mode (state retention)', async ({ page }) => {
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       const panel = squadPanel(page)
 
       const playerName = await panel.locator('.font-medium').first().textContent()
@@ -252,19 +252,19 @@ test.describe('FFL Team Builder', () => {
 
       await page.getByRole('button', { name: 'Save Team' }).click()
 
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       const kicksSection = positionSection(page, 'Kicks')
       await expect(kicksSection.getByText(playerName!.trim())).toBeVisible()
     })
 
     test('two rounds of editing accumulate correctly', async ({ page }) => {
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       let panel = squadPanel(page)
       const player1 = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'H' }).first().click()
       await page.getByRole('button', { name: 'Save Team' }).click()
 
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       panel = squadPanel(page)
       const player2 = await panel.locator('.font-medium').first().textContent()
       await panel.getByRole('button', { name: 'K' }).first().click()
@@ -437,23 +437,25 @@ test.describe('FFL Team Builder', () => {
       await expect(benchSection(page).locator('.rounded-lg').filter({ hasText: 'Brock Thunder' })).toBeVisible()
     })
 
-    test('interchange is pre-applied when bench outscores target starter', async ({ page }) => {
+    test('interchange starts not applied (amber) even when bench outscores starter', async ({ page }) => {
       await page.getByRole('button', { name: 'Substitutions' }).click()
-      // Brock (50) outscores Hugh (30) → interchange beneficial → row shows sky border (applied)
+      // Brock (50) outscores Hugh (30) → interchange beneficial, but NOT auto-applied;
+      // user must explicitly click to apply (phase 23 UX change)
       const brockRow = benchSection(page).locator('.rounded-lg').filter({ hasText: 'Brock Thunder' })
-      await expect(brockRow).toHaveClass(/border-sky-500/)
+      await expect(brockRow).toHaveClass(/border-amber-600/)
     })
 
-    test('clicking interchange row toggles it off (amber border)', async ({ page }) => {
+    test('clicking interchange row toggles it on (sky border)', async ({ page }) => {
       await page.getByRole('button', { name: 'Substitutions' }).click()
       const brockRow = benchSection(page).locator('.rounded-lg').filter({ hasText: 'Brock Thunder' })
       await brockRow.click()
-      await expect(brockRow).toHaveClass(/border-amber-600/)
+      await expect(brockRow).toHaveClass(/border-sky-500/)
     })
 
     test('Save Subs persists interchanged_out and interchanged_in statuses', async ({ page }) => {
       await page.getByRole('button', { name: 'Substitutions' }).click()
-      // Interchange is pre-applied (beneficial) — save immediately
+      // Interchange is NOT auto-applied — user must click Brock to apply it
+      await benchSection(page).locator('.rounded-lg').filter({ hasText: 'Brock Thunder' }).click()
       await page.getByRole('button', { name: 'Save Subs' }).click()
       await expect(page.getByRole('button', { name: 'Substitutions' })).toBeVisible({ timeout: 10000 })
 
@@ -464,10 +466,9 @@ test.describe('FFL Team Builder', () => {
       await expect(positionSection(page, 'Goals').getByText('Played').first()).toBeVisible()
     })
 
-    test('declining interchange saves with no statuses changed', async ({ page }) => {
+    test('saving without applying interchange leaves no statuses changed', async ({ page }) => {
       await page.getByRole('button', { name: 'Substitutions' }).click()
-      // Toggle interchange off
-      await benchSection(page).locator('.rounded-lg').filter({ hasText: 'Brock Thunder' }).click()
+      // Interchange starts NOT applied (amber) — save immediately without clicking
       await page.getByRole('button', { name: 'Save Subs' }).click()
       await expect(page.getByRole('button', { name: 'Substitutions' })).toBeVisible({ timeout: 10000 })
 
@@ -517,7 +518,7 @@ test.describe('FFL Team Builder', () => {
       const hbSection = positionSection(page, 'Handballs')
       const existingNames = await hbSection.locator('.font-medium').allTextContents()
 
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       const newPlayerName = await squadPanel(page).locator('.font-medium').first().textContent()
       await squadPanel(page).getByRole('button', { name: 'H' }).first().click()
       await page.getByRole('button', { name: 'Save Team' }).click()
@@ -527,7 +528,7 @@ test.describe('FFL Team Builder', () => {
       }
       await expect(hbSection.getByText(newPlayerName!.trim())).toBeVisible()
 
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       for (const name of existingNames) {
         await expect(hbSection.getByText(name.trim())).toBeVisible()
       }
@@ -574,7 +575,7 @@ test.describe('FFL Team Builder', () => {
   test.describe('manage layout', () => {
     test('squad panel visible alongside team in manage mode', async ({ page }) => {
       await goToTeamBuilder(page)
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       await expect(page.getByRole('heading', { name: /Squad \(/ })).toBeVisible()
     })
   })
@@ -607,7 +608,7 @@ test.describe('FFL Team Builder', () => {
       // R2-Ruiboys=3, R2-Cows=4, R3-Ruiboys=5, R3-Cows=6).
       await page.goto('/ffl/club-matches/6/edit')
       await page.waitForLoadState('networkidle')
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
 
       // Traded toggle is visible with a count.
       const tradedToggle = page.getByRole('button', { name: /Traded \(\d+\)/ })
@@ -648,7 +649,7 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('pill hidden in manage mode', async ({ page }) => {
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
       await expect(page.getByText('Improve your score:')).not.toBeVisible()
     })
   })
@@ -680,7 +681,7 @@ test.describe('FFL Team Builder', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/ffl/club-matches/4/edit')
       await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15000 })
-      await page.getByRole('button', { name: 'Manage' }).click()
+      await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
     test('Replicate Round button visible in manage mode when previous round exists', async ({ page }) => {

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -413,6 +413,23 @@ test.describe('FFL Team Builder', () => {
     })
   })
 
+  // ── Best team ─────────────────────────────────────────────────────────────
+
+  test.describe('best team', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Build Team' }).click()
+    })
+
+    test('Best Team fills starters with the highest projected assignment', async ({ page }) => {
+      await page.getByRole('button', { name: 'Best Team' }).click()
+      // Players with form stats leave the squad panel and become starters
+      await expect(squadPanel(page).getByText('Hugh McCluggage')).not.toBeVisible()
+      await expect(page.getByRole('button', { name: 'Save Team' })).toBeEnabled()
+      await expect(page.getByText(/Projected ~\d+/)).toBeVisible()
+    })
+  })
+
   // ── Subs mode — substitution ─────────────────────────────────────────────
   //
   // Round 2, The Howling Cows (club_match id=4):

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -422,6 +422,8 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('Best Team fills starters with the highest projected assignment', async ({ page }) => {
+      // Wait for the squad (and its stats, same query) to load before applying
+      await expect(squadPanel(page).getByText('Hugh McCluggage')).toBeVisible()
       await page.getByRole('button', { name: 'Best Team' }).click()
       // Players with form stats leave the squad panel and become starters
       await expect(squadPanel(page).getByText('Hugh McCluggage')).not.toBeVisible()

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -20,7 +20,22 @@ function benchSection(page: import('@playwright/test').Page) {
 }
 
 function squadPanel(page: import('@playwright/test').Page) {
-  return page.getByRole('heading', { name: /Squad \(/ }).locator('..')
+  // The heading sits inside a flex header row; the panel is that row's parent.
+  return page.getByRole('heading', { name: /Squad \(/ }).locator('../..')
+}
+
+// Adds the first available squad player via the "+" popup menu.
+// `option` matches the menu entry, e.g. /^Kicks/ or /^Bench/.
+async function addFromSquad(page: import('@playwright/test').Page, option: RegExp) {
+  const panel = squadPanel(page)
+  await panel.getByRole('button', { name: 'Add to team' }).first().click()
+  await panel.getByRole('button', { name: option }).click()
+}
+
+// Removes the first filled starter via the row's "−" popup menu.
+async function removeFirstStarter(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: 'Player actions' }).first().click()
+  await page.getByRole('button', { name: 'Remove' }).click()
 }
 
 test.describe('FFL Team Builder', () => {
@@ -94,14 +109,14 @@ test.describe('FFL Team Builder', () => {
 
     test('Save Team disabled until a change is made', async ({ page }) => {
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeDisabled()
-      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await removeFirstStarter(page)
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeEnabled()
     })
 
     test('Cancel resets changes and exits manage mode', async ({ page }) => {
       const goalsSection = positionSection(page, 'Goals')
       const filledBefore = await goalsSection.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).count()
-      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await removeFirstStarter(page)
       await page.getByRole('button', { name: 'Cancel' }).click()
       await expect(page.getByRole('button', { name: 'Build Team' })).toBeVisible()
       const filledAfter = await goalsSection.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).count()
@@ -112,13 +127,47 @@ test.describe('FFL Team Builder', () => {
       await expect(page.getByRole('heading', { name: /Squad \(/ })).toBeVisible()
     })
 
-    test('Remove buttons visible on filled starter slots', async ({ page }) => {
-      await expect(page.getByRole('button', { name: 'Remove' }).first()).toBeVisible()
+    test('starter menu offers Remove on filled starter slots', async ({ page }) => {
+      await page.getByRole('button', { name: 'Player actions' }).first().click()
+      await expect(page.getByRole('button', { name: 'Remove' })).toBeVisible()
     })
 
-    test('B button appears in squad panel', async ({ page }) => {
+    test('add menu in squad panel offers all positions and Bench', async ({ page }) => {
       const panel = squadPanel(page)
-      await expect(panel.getByRole('button', { name: 'B' }).first()).toBeVisible()
+      await panel.getByRole('button', { name: 'Add to team' }).first().click()
+      for (const name of ['Goals', 'Kicks', 'Handballs', 'Marks', 'Tackles', 'Hitouts', 'Star', 'Bench']) {
+        await expect(panel.getByRole('button', { name: new RegExp(`^${name}`) })).toBeVisible()
+      }
+    })
+
+    test('squad panel shows stat summary columns', async ({ page }) => {
+      await expect(page.locator('[title="Last 5 form averages"]').first()).toBeVisible()
+    })
+
+    test('form/season toggle switches the stat source', async ({ page }) => {
+      await expect(page.locator('[title="Last 5 form averages"]').first()).toBeVisible()
+      await page.getByRole('button', { name: 'Season', exact: true }).click()
+      await expect(page.locator('[title="Season averages"]').first()).toBeVisible()
+    })
+
+    test('summary bar shows projected team total', async ({ page }) => {
+      await expect(page.getByText(/Projected ~\d+/)).toBeVisible()
+    })
+
+    test('clicking a stat header sorts squad cards by that stat', async ({ page }) => {
+      const panel = squadPanel(page)
+      const cards = panel.locator('[draggable="true"]')
+      await expect(cards.first()).toBeVisible()
+      await panel.getByRole('button', { name: 'K', exact: true }).click()
+      // K is the first stat cell on each card; values must be non-increasing
+      const kVals = await cards.evaluateAll(els =>
+        els.map(c => {
+          const v = parseFloat(c.querySelectorAll('span.w-9')[0]?.textContent ?? '')
+          return Number.isNaN(v) ? -1 : v
+        }),
+      )
+      expect(kVals.length).toBeGreaterThan(1)
+      expect(kVals).toEqual([...kVals].sort((a, b) => b - a))
     })
 
     test('interchange dropdown visible in manage mode', async ({ page }) => {
@@ -126,7 +175,7 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('Save Team saves and returns to read-only mode', async ({ page }) => {
-      await page.getByRole('button', { name: 'Remove' }).first().click()
+      await removeFirstStarter(page)
       await page.getByRole('button', { name: 'Save Team' }).click()
       await expect(page.getByRole('button', { name: 'Build Team' })).toBeVisible()
       await expect(page.getByRole('button', { name: 'Save Team' })).not.toBeVisible()
@@ -142,30 +191,42 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
-    test('B button adds player to a bench slot', async ({ page }) => {
+    test('Bench menu option adds player to a bench slot', async ({ page }) => {
       const panel = squadPanel(page)
       const playerName = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'B' }).first().click()
+      await addFromSquad(page, /^Bench/)
       await expect(benchSection(page).getByText(playerName!.trim())).toBeVisible()
     })
 
     test('position selectors appear on filled bench slot', async ({ page }) => {
-      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await addFromSquad(page, /^Bench/)
       await expect(page.getByLabel('Position 1')).toBeVisible()
       await expect(page.getByLabel('Position 2')).toBeVisible()
     })
 
     test('selecting Star as position 1 hides position 2 selector', async ({ page }) => {
-      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await addFromSquad(page, /^Bench/)
       await page.getByLabel('Position 1').selectOption('star')
       await expect(page.getByLabel('Position 2')).not.toBeVisible()
     })
 
-    test('removing bench player clears slot back to empty', async ({ page }) => {
+    test('removing bench player via menu clears slot back to empty', async ({ page }) => {
       const bench = benchSection(page)
-      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
-      await bench.getByRole('button', { name: 'Remove' }).first().click()
+      await addFromSquad(page, /^Bench/)
+      await bench.getByRole('button', { name: 'Bench player actions' }).first().click()
+      await page.getByRole('button', { name: 'Remove' }).click()
       await expect(bench.getByText('Empty slot').first()).toBeVisible()
+    })
+
+    test('bench menu moves player to a starter position', async ({ page }) => {
+      const bench = benchSection(page)
+      const panel = squadPanel(page)
+      const playerName = (await panel.locator('.font-medium').first().textContent())!.trim()
+      await addFromSquad(page, /^Bench/)
+      await bench.getByRole('button', { name: 'Bench player actions' }).first().click()
+      await page.getByRole('button', { name: /^Kicks/ }).click()
+      await expect(positionSection(page, 'Kicks').getByText(playerName)).toBeVisible()
+      await expect(bench.getByText(playerName)).not.toBeVisible()
     })
   })
 
@@ -178,21 +239,20 @@ test.describe('FFL Team Builder', () => {
     })
 
     test('save blocked when bench player has no position assigned', async ({ page }) => {
-      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await addFromSquad(page, /^Bench/)
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeDisabled()
       await expect(page.getByText('Each bench player must have a position assigned')).toBeVisible()
     })
 
     test('save unblocked when bench player has valid star position', async ({ page }) => {
-      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await addFromSquad(page, /^Bench/)
       await page.getByLabel('Position 1').selectOption('star')
       await expect(page.getByRole('button', { name: 'Save Team' })).toBeEnabled()
     })
 
     test('save blocked when two bench players set but no interchange chosen', async ({ page }) => {
-      const panel = squadPanel(page)
-      await panel.getByRole('button', { name: 'B' }).nth(0).click()
-      await panel.getByRole('button', { name: 'B' }).nth(0).click()
+      await addFromSquad(page, /^Bench/)
+      await addFromSquad(page, /^Bench/)
       // Assign valid positions to both
       await page.getByLabel('Position 1').nth(0).selectOption('star')
       await page.getByLabel('Position 1').nth(1).selectOption('goals')
@@ -221,7 +281,7 @@ test.describe('FFL Team Builder', () => {
 
     test('interchange selection persists through Save → re-open Manage', async ({ page }) => {
       // Add bench player with star position (valid, single bench = no IC required)
-      await squadPanel(page).getByRole('button', { name: 'B' }).first().click()
+      await addFromSquad(page, /^Bench/)
       await page.getByLabel('Position 1').selectOption('star')
       await page.getByLabel('Interchange').selectOption('star')
 
@@ -248,7 +308,7 @@ test.describe('FFL Team Builder', () => {
       const panel = squadPanel(page)
 
       const playerName = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'K' }).first().click()
+      await addFromSquad(page, /^Kicks/)
 
       await page.getByRole('button', { name: 'Save Team' }).click()
 
@@ -261,17 +321,95 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('button', { name: 'Build Team' }).click()
       let panel = squadPanel(page)
       const player1 = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'H' }).first().click()
+      await addFromSquad(page, /^Handballs/)
       await page.getByRole('button', { name: 'Save Team' }).click()
 
       await page.getByRole('button', { name: 'Build Team' }).click()
       panel = squadPanel(page)
       const player2 = await panel.locator('.font-medium').first().textContent()
-      await panel.getByRole('button', { name: 'K' }).first().click()
+      await addFromSquad(page, /^Kicks/)
       await page.getByRole('button', { name: 'Save Team' }).click()
 
       await expect(positionSection(page, 'Handballs').getByText(player1!.trim())).toBeVisible()
       await expect(positionSection(page, 'Kicks').getByText(player2!.trim())).toBeVisible()
+    })
+  })
+
+  // ── Starter popup menu ────────────────────────────────────────────────────
+
+  test.describe('starter popup menu', () => {
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Build Team' }).click()
+    })
+
+    test('− menu moves starter to another position', async ({ page }) => {
+      const goals = positionSection(page, 'Goals')
+      const row = goals.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).first()
+      const name = await row.locator('.font-medium').first().textContent()
+      await row.getByRole('button', { name: 'Player actions' }).click()
+      await page.getByRole('button', { name: /^Kicks/ }).click()
+      await expect(positionSection(page, 'Kicks').getByText(name!.trim())).toBeVisible()
+    })
+
+    test('− menu moves starter to bench', async ({ page }) => {
+      const goals = positionSection(page, 'Goals')
+      const row = goals.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).first()
+      const name = await row.locator('.font-medium').first().textContent()
+      await row.getByRole('button', { name: 'Player actions' }).click()
+      await page.getByRole('button', { name: /^Bench/ }).click()
+      await expect(benchSection(page).getByText(name!.trim())).toBeVisible()
+    })
+
+    test('− menu removes starter from the team', async ({ page }) => {
+      const goals = positionSection(page, 'Goals')
+      const row = goals.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).first()
+      const name = (await row.locator('.font-medium').first().textContent())!.trim()
+      await row.getByRole('button', { name: 'Player actions' }).click()
+      await page.getByRole('button', { name: 'Remove' }).click()
+      await expect(goals.getByText(name)).not.toBeVisible()
+      await expect(squadPanel(page).getByText(name)).toBeVisible()
+    })
+  })
+
+  // ── Drag and drop ─────────────────────────────────────────────────────────
+
+  test.describe('drag and drop', () => {
+    // Tall viewport: native HTML5 drag breaks if Playwright has to scroll mid-drag,
+    // so keep source and target both on screen.
+    test.use({ viewport: { width: 1280, height: 2400 } })
+
+    test.beforeEach(async ({ page }) => {
+      await goToTeamBuilder(page)
+      await page.getByRole('button', { name: 'Build Team' }).click()
+    })
+
+    test('drag squad player onto an empty starter slot assigns them', async ({ page }) => {
+      const panel = squadPanel(page)
+      const card = panel.locator('[draggable="true"]').first()
+      const name = await card.locator('.font-medium').first().textContent()
+      const target = positionSection(page, 'Kicks').locator('.rounded-lg').filter({ hasText: 'Empty slot' }).first()
+      await card.dragTo(target)
+      await expect(positionSection(page, 'Kicks').getByText(name!.trim())).toBeVisible()
+    })
+
+    test('drag squad player onto an empty bench slot assigns them', async ({ page }) => {
+      const panel = squadPanel(page)
+      const card = panel.locator('[draggable="true"]').first()
+      const name = await card.locator('.font-medium').first().textContent()
+      const target = benchSection(page).locator('.rounded-lg').filter({ hasText: 'Empty slot' }).first()
+      await card.dragTo(target)
+      await expect(benchSection(page).getByText(name!.trim())).toBeVisible()
+    })
+
+    test('drag starter back to squad panel removes them from the team', async ({ page }) => {
+      const goals = positionSection(page, 'Goals')
+      const row = goals.locator('.rounded-lg').filter({ hasNot: page.getByText('Empty slot') }).first()
+      const name = (await row.locator('.font-medium').first().textContent())!.trim()
+      const panel = squadPanel(page)
+      await row.dragTo(panel.locator('[draggable="true"]').first())
+      await expect(goals.getByText(name)).not.toBeVisible()
+      await expect(panel.getByText(name)).toBeVisible()
     })
   })
 
@@ -520,7 +658,7 @@ test.describe('FFL Team Builder', () => {
 
       await page.getByRole('button', { name: 'Build Team' }).click()
       const newPlayerName = await squadPanel(page).locator('.font-medium').first().textContent()
-      await squadPanel(page).getByRole('button', { name: 'H' }).first().click()
+      await addFromSquad(page, /^Handballs/)
       await page.getByRole('button', { name: 'Save Team' }).click()
 
       for (const name of existingNames) {
@@ -616,7 +754,7 @@ test.describe('FFL Team Builder', () => {
       await tradedToggle.click()
 
       // Henry Smith now appears in the available pool's Traded section.
-      const squadPanel = page.getByRole('heading', { name: /Squad \(/ }).locator('..')
+      const squadPanel = page.getByRole('heading', { name: /Squad \(/ }).locator('../..')
       await expect(squadPanel.getByText('Henry Smith')).toBeVisible()
     })
   })

--- a/frontend/web/e2e/ffl-team-builder.spec.ts
+++ b/frontend/web/e2e/ffl-team-builder.spec.ts
@@ -827,10 +827,10 @@ test.describe('FFL Team Builder', () => {
     })
   })
 
-  // ── Replicate and Clear buttons ───────────────────────────────────────────
+  // ── Previous-round team and Clear buttons ─────────────────────────────────
   //
   // Round 2 (club_match id=4): prevRound is Round 1, which has Howling Cows
-  // data → Replicate Round 1 button visible in manage mode.
+  // data → "Round 1 Team" button visible in manage mode.
 
   test.describe('replicate and clear buttons', () => {
     test.beforeEach(async ({ page }) => {
@@ -839,8 +839,8 @@ test.describe('FFL Team Builder', () => {
       await page.getByRole('button', { name: 'Build Team' }).click()
     })
 
-    test('Replicate Round button visible in manage mode when previous round exists', async ({ page }) => {
-      await expect(page.getByRole('button', { name: /Replicate Round/ })).toBeVisible()
+    test('previous round team button visible in manage mode when previous round exists', async ({ page }) => {
+      await expect(page.getByRole('button', { name: /Round \d+ Team/ })).toBeVisible()
     })
 
     test('Clear button visible in manage mode', async ({ page }) => {

--- a/frontend/web/e2e/match-view.spec.ts
+++ b/frontend/web/e2e/match-view.spec.ts
@@ -27,7 +27,8 @@ test.describe('Match view', () => {
   })
 
   test('displays stat column headers', async ({ page }) => {
-    for (const label of ['K', 'HB', 'M', 'HO', 'T', 'G', 'B', 'D', 'SC']) {
+    // Labels updated in this branch: HB→H, HO→R, SC→Pts; order: K H D M R T G B Pts
+    for (const label of ['K', 'H', 'D', 'M', 'R', 'T', 'G', 'B', 'Pts']) {
       await expect(page.getByRole('columnheader', { name: label }).first()).toBeVisible()
     }
   })

--- a/frontend/web/e2e/navigation.spec.ts
+++ b/frontend/web/e2e/navigation.spec.ts
@@ -60,10 +60,27 @@ test.describe('Navigation — Phase 21', () => {
       await expect(page.getByTitle('Data Ops')).toBeVisible()
     })
 
-    test('DataOps icon links to data-ops page', async ({ page }) => {
+    // DataOps link opens in a new tab (target="_blank") — check href, not navigation
+    test('DataOps icon href points to data-ops page', async ({ page }) => {
       await setupFflSession(page)
-      await page.getByTitle('Data Ops').click()
-      await expect(page).toHaveURL(/\/ffl\/data-ops/)
+      await expect(page.getByTitle('Data Ops')).toHaveAttribute('href', /\/ffl\/data-ops/)
+    })
+  })
+
+  test.describe('NAV-6: Free Agents icon visible on FFL routes only', () => {
+    test('Free Agents icon is visible in header on FFL home', async ({ page }) => {
+      await setupFflSession(page)
+      await expect(page.getByTitle('Free Agents')).toBeVisible()
+    })
+
+    test('Free Agents icon is not visible on AFL routes', async ({ page }) => {
+      await setupAflSession(page)
+      await expect(page.getByTitle('Free Agents')).not.toBeVisible()
+    })
+
+    test('Free Agents icon href points to /ffl/free-agents', async ({ page }) => {
+      await setupFflSession(page)
+      await expect(page.getByTitle('Free Agents')).toHaveAttribute('href', /\/ffl\/free-agents/)
     })
   })
 

--- a/frontend/web/e2e/navigation.spec.ts
+++ b/frontend/web/e2e/navigation.spec.ts
@@ -60,8 +60,7 @@ test.describe('Navigation — Phase 21', () => {
       await expect(page.getByTitle('Data Ops')).toBeVisible()
     })
 
-    // DataOps link opens in a new tab (target="_blank") — check href, not navigation
-    test('DataOps icon href points to data-ops page', async ({ page }) => {
+    test('DataOps icon navigates to data-ops page', async ({ page }) => {
       await setupFflSession(page)
       await expect(page.getByTitle('Data Ops')).toHaveAttribute('href', /\/ffl\/data-ops/)
     })

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -23,7 +23,8 @@
         "postcss": "^8.5.4",
         "tailwindcss": "^4.1.8",
         "typescript": "~5.7.2",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -993,6 +994,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1264,6 +1272,24 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1283,6 +1309,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/apollo-composable": {
@@ -1487,6 +1636,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -1592,6 +1751,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1640,6 +1816,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1698,6 +1881,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2118,6 +2311,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optimism": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
@@ -2129,6 +2336,13 @@
         "@wry/trie": "^0.5.0",
         "tslib": "^2.3.0"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2311,6 +2525,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2319,6 +2540,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
@@ -2359,6 +2594,23 @@
         "node": ">=12.22"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2374,6 +2626,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-essentials": {
@@ -2528,6 +2790,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
@@ -2562,6 +2914,23 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zen-observable": {

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test"
   },
   "devDependencies": {
@@ -17,7 +18,8 @@
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@apollo/client": "^3.13.4",

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -49,7 +49,6 @@
             :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: fflSelectedRoundId || undefined } }"
             class="text-text-muted hover:text-text transition-colors translate-y-0.5"
             title="Data Ops"
-            target="_blank" rel="noopener noreferrer"
           >
             <IconDataOps class="w-5 h-5" />
           </router-link>

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -36,7 +36,15 @@
             />
           </template>
 
-          <!-- DataOps link -->
+          <!-- Free Agents + DataOps -->
+          <router-link
+            v-if="isFfl"
+            :to="{ name: 'ffl-free-agents' }"
+            class="text-text-muted hover:text-text transition-colors translate-y-0.5"
+            title="Free Agents"
+          >
+            <IconFreeAgents class="w-5 h-5" />
+          </router-link>
           <router-link
             :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: fflSelectedRoundId || undefined } }"
             class="text-text-muted hover:text-text transition-colors translate-y-0.5"
@@ -96,6 +104,7 @@ import { useFflState } from '@/features/ffl/composables/useFflState'
 import { useAflState } from '@/features/afl/composables/useAflState'
 import ClubSelector from '@/features/ffl/components/ClubSelector.vue'
 import IconSquad from '@/features/ffl/components/icons/IconSquad.vue'
+import IconFreeAgents from '@/features/ffl/components/icons/IconFreeAgents.vue'
 import IconDataOps from '@/features/data-ops/components/icons/IconDataOps.vue'
 
 import { useLiveRoundBootstrap } from '@/app/useLiveRoundBootstrap'

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -41,6 +41,7 @@
             :to="{ name: 'ffl-data-ops', query: { tab: 'team-submission', round: fflSelectedRoundId || undefined } }"
             class="text-text-muted hover:text-text transition-colors translate-y-0.5"
             title="Data Ops"
+            target="_blank" rel="noopener noreferrer"
           >
             <IconDataOps class="w-5 h-5" />
           </router-link>

--- a/frontend/web/src/App.vue
+++ b/frontend/web/src/App.vue
@@ -88,6 +88,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { useTheme, initTheme } from '@/composables/useTheme'
 import { useRoute } from 'vue-router'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_SEASON_CLUBS } from '@/features/ffl/api/queries'
@@ -146,32 +147,6 @@ onMounted(() => document.addEventListener('mousedown', onClickOutside))
 onUnmounted(() => document.removeEventListener('mousedown', onClickOutside))
 
 // Theme
-const isDark = ref(false)
-
-function getThemeCookie(): string {
-  const match = document.cookie.match(/(^| )xffl_dark_mode=([^;]+)/)
-  return match ? match[2] : ''
-}
-
-function setThemeCookie(dark: boolean) {
-  const expires = new Date()
-  expires.setFullYear(expires.getFullYear() + 10)
-  document.cookie = `xffl_dark_mode=${dark ? '1' : '0'};expires=${expires.toUTCString()};path=/`
-}
-
-function applyTheme(dark: boolean) {
-  document.documentElement.classList.toggle('dark', dark)
-  setThemeCookie(dark)
-  isDark.value = dark
-}
-
-function toggleTheme() {
-  applyTheme(!isDark.value)
-}
-
-onMounted(() => {
-  const saved = getThemeCookie()
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  applyTheme(saved !== '' ? saved === '1' : prefersDark)
-})
+const { isDark, toggleTheme } = useTheme()
+onMounted(() => initTheme())
 </script>

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -46,6 +46,12 @@ const router = createRouter({
       props: true,
     },
     {
+      path: '/ffl/club-matches/:clubMatchId',
+      name: 'ffl-club-match',
+      component: () => import('@/features/ffl/views/TeamBuilderView.vue'),
+      props: (route) => ({ clubMatchId: route.params.clubMatchId as string, readonly: true }),
+    },
+    {
       path: '/ffl/club-matches/:clubMatchId/edit',
       name: 'ffl-club-match-edit',
       component: () => import('@/features/ffl/views/TeamBuilderView.vue'),
@@ -55,6 +61,12 @@ const router = createRouter({
       path: '/ffl/afl/player-seasons/:aflPlayerSeasonId',
       name: 'ffl-afl-player-season',
       component: () => import('@/features/ffl/views/AFLPlayerSeasonView.vue'),
+      props: true,
+    },
+    {
+      path: '/ffl/afl/club-seasons/:clubSeasonId',
+      name: 'ffl-afl-club-season',
+      component: () => import('@/features/afl/views/ClubSeasonView.vue'),
       props: true,
     },
     {
@@ -95,12 +107,6 @@ const router = createRouter({
       path: '/afl/matches/:matchId/edit',
       name: 'afl-match-edit',
       component: () => import('@/features/afl/views/AdminMatchView.vue'),
-      props: true,
-    },
-    {
-      path: '/afl/club-seasons/:clubSeasonId',
-      name: 'afl-club-season',
-      component: () => import('@/features/afl/views/ClubSeasonView.vue'),
       props: true,
     },
   ],

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -97,6 +97,12 @@ const router = createRouter({
       component: () => import('@/features/afl/views/AdminMatchView.vue'),
       props: true,
     },
+    {
+      path: '/afl/club-seasons/:clubSeasonId',
+      name: 'afl-club-season',
+      component: () => import('@/features/afl/views/ClubSeasonView.vue'),
+      props: true,
+    },
   ],
 })
 

--- a/frontend/web/src/app/router.ts
+++ b/frontend/web/src/app/router.ts
@@ -70,6 +70,11 @@ const router = createRouter({
       props: true,
     },
     {
+      path: '/ffl/free-agents',
+      name: 'ffl-free-agents',
+      component: () => import('@/features/ffl/views/FreeAgentsView.vue'),
+    },
+    {
       path: '/ffl/data-ops',
       name: 'ffl-data-ops',
       component: () => import('@/features/data-ops/views/DataOpsView.vue'),

--- a/frontend/web/src/composables/useTheme.ts
+++ b/frontend/web/src/composables/useTheme.ts
@@ -1,0 +1,23 @@
+import { ref, readonly } from 'vue'
+import { getCookie, setCookie } from '@/utils/cookie'
+
+const isDark = ref(false)
+
+function applyTheme(dark: boolean) {
+  document.documentElement.classList.toggle('dark', dark)
+  setCookie('xffl_dark_mode', dark ? '1' : '0', 365 * 10)
+  isDark.value = dark
+}
+
+export function initTheme() {
+  const saved = getCookie('xffl_dark_mode')
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  applyTheme(saved !== '' ? saved === '1' : prefersDark)
+}
+
+export function useTheme() {
+  return {
+    isDark: readonly(isDark),
+    toggleTheme: () => applyTheme(!isDark.value),
+  }
+}

--- a/frontend/web/src/features/afl/api/queries.ts
+++ b/frontend/web/src/features/afl/api/queries.ts
@@ -138,6 +138,7 @@ export const GET_AFL_MATCH = gql`
       }
       homeClubMatch {
         id
+        clubSeasonId
         club { id name }
         rushedBehinds
         score
@@ -159,6 +160,7 @@ export const GET_AFL_MATCH = gql`
       }
       awayClubMatch {
         id
+        clubSeasonId
         club { id name }
         rushedBehinds
         score

--- a/frontend/web/src/features/afl/components/PlayerStatsTable.vue
+++ b/frontend/web/src/features/afl/components/PlayerStatsTable.vue
@@ -37,7 +37,7 @@
               class="w-14 rounded bg-transparent px-1 py-1 text-right text-text tabular-nums hover:bg-control focus:bg-control focus:outline-none focus:ring-1 focus:ring-control-ring"
               @change="onStatChange(pm, col.key, $event)"
             />
-            <span v-else class="tabular-nums text-text px-1">{{ pm[col.key] }}</span>
+            <span v-else class="tabular-nums px-1" :style="heatColor(pm[col.key], col.key)">{{ pm[col.key] }}</span>
           </td>
           <td class="py-2 px-2 text-right tabular-nums text-text-muted">{{ pm.disposals }}</td>
           <td v-for="col in postDisposalCols" :key="col.key" class="py-1 px-1 text-right">
@@ -49,7 +49,7 @@
               class="w-14 rounded bg-transparent px-1 py-1 text-right text-text tabular-nums hover:bg-control focus:bg-control focus:outline-none focus:ring-1 focus:ring-control-ring"
               @change="onStatChange(pm, col.key, $event)"
             />
-            <span v-else class="tabular-nums text-text px-1">{{ pm[col.key] }}</span>
+            <span v-else class="tabular-nums px-1" :style="heatColor(pm[col.key], col.key)">{{ pm[col.key] }}</span>
           </td>
           <td class="py-2 px-2 text-right tabular-nums text-text-muted">{{ pm.score }}</td>
         </tr>
@@ -73,6 +73,8 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+import { heatStyle } from '@/utils/heatmap'
 
 interface PlayerMatch {
   id: string
@@ -95,6 +97,8 @@ interface ClubMatch {
   club: { id: string; name: string }
   playerMatches: PlayerMatch[]
 }
+
+const { isDark } = useTheme()
 
 const props = withDefaults(defineProps<{
   clubMatch: ClubMatch
@@ -125,6 +129,24 @@ const postDisposalCols = [
 const statColumns = [...preDisposalCols, ...postDisposalCols]
 
 type StatKey = typeof statColumns[number]['key']
+
+const heatKeys = ['kicks', 'handballs', 'marks', 'hitouts', 'tackles', 'goals', 'behinds', 'disposals', 'score'] as const
+type HeatKey = typeof heatKeys[number]
+
+const columnRange = computed(() => {
+  const range = {} as Record<HeatKey, { min: number; max: number }>
+  for (const key of heatKeys) {
+    const vals = props.clubMatch.playerMatches.map(pm => pm[key])
+    range[key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  return range
+})
+
+function heatColor(value: number, key: HeatKey): Record<string, string> {
+  const r = columnRange.value[key]
+  if (!r) return {}
+  return heatStyle(value, r.min, r.max, isDark.value)
+}
 
 const totals = computed(() => {
   const keys = [...statColumns.map(c => c.key), 'disposals' as const, 'score' as const]

--- a/frontend/web/src/features/afl/components/PlayerStatsTable.vue
+++ b/frontend/web/src/features/afl/components/PlayerStatsTable.vue
@@ -4,11 +4,14 @@
       <thead>
         <tr class="border-b border-border text-left text-text-muted">
           <th class="py-2 pr-4 font-medium">Player</th>
-          <th v-for="col in statColumns" :key="col.key" class="py-2 px-2 font-medium text-right w-16">
+          <th v-for="col in preDisposalCols" :key="col.key" class="py-2 px-2 font-medium text-right w-16">
             {{ col.label }}
           </th>
           <th class="py-2 px-2 font-medium text-right w-16">D</th>
-          <th class="py-2 px-2 font-medium text-right w-16">SC</th>
+          <th v-for="col in postDisposalCols" :key="col.key" class="py-2 px-2 font-medium text-right w-16">
+            {{ col.label }}
+          </th>
+          <th class="py-2 px-2 font-medium text-right w-16">Pts</th>
         </tr>
       </thead>
       <tbody>
@@ -20,10 +23,10 @@
           <td class="py-2 pr-4 font-medium">
             <router-link
               :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pm.playerSeasonId } }"
-              class="hover:underline hover:text-active transition-colors"
+              class="hover:text-active transition-colors"
             >{{ pm.player.name }}</router-link>
           </td>
-          <td v-for="col in statColumns" :key="col.key" class="py-1 px-1 text-right">
+          <td v-for="col in preDisposalCols" :key="col.key" class="py-1 px-1 text-right">
             <input
               v-if="!readonly"
               type="number"
@@ -35,16 +38,30 @@
             <span v-else class="tabular-nums text-text px-1">{{ pm[col.key] }}</span>
           </td>
           <td class="py-2 px-2 text-right tabular-nums text-text-muted">{{ pm.disposals }}</td>
+          <td v-for="col in postDisposalCols" :key="col.key" class="py-1 px-1 text-right">
+            <input
+              v-if="!readonly"
+              type="number"
+              :value="pm[col.key]"
+              min="0"
+              class="w-14 rounded bg-transparent px-1 py-1 text-right text-text tabular-nums hover:bg-control focus:bg-control focus:outline-none focus:ring-1 focus:ring-control-ring"
+              @change="onStatChange(pm, col.key, $event)"
+            />
+            <span v-else class="tabular-nums text-text px-1">{{ pm[col.key] }}</span>
+          </td>
           <td class="py-2 px-2 text-right tabular-nums text-text-muted">{{ pm.score }}</td>
         </tr>
       </tbody>
       <tfoot>
         <tr class="border-t border-border-strong font-semibold text-text-heading">
           <td class="py-2 pr-4">Totals</td>
-          <td v-for="col in statColumns" :key="col.key" class="py-2 px-2 text-right tabular-nums">
+          <td v-for="col in preDisposalCols" :key="col.key" class="py-2 px-2 text-right tabular-nums">
             {{ totals[col.key] }}
           </td>
           <td class="py-2 px-2 text-right tabular-nums">{{ totals.disposals }}</td>
+          <td v-for="col in postDisposalCols" :key="col.key" class="py-2 px-2 text-right tabular-nums">
+            {{ totals[col.key] }}
+          </td>
           <td class="py-2 px-2 text-right tabular-nums">{{ totals.score }}</td>
         </tr>
       </tfoot>
@@ -88,15 +105,20 @@ const emit = defineEmits<{
   update: [input: { playerSeasonId: string; clubMatchId: string; [key: string]: unknown }]
 }>()
 
-const statColumns = [
+const preDisposalCols = [
   { key: 'kicks' as const, label: 'K' },
-  { key: 'handballs' as const, label: 'HB' },
+  { key: 'handballs' as const, label: 'H' },
+]
+
+const postDisposalCols = [
   { key: 'marks' as const, label: 'M' },
-  { key: 'hitouts' as const, label: 'HO' },
+  { key: 'hitouts' as const, label: 'R' },
   { key: 'tackles' as const, label: 'T' },
   { key: 'goals' as const, label: 'G' },
   { key: 'behinds' as const, label: 'B' },
 ]
+
+const statColumns = [...preDisposalCols, ...postDisposalCols]
 
 type StatKey = typeof statColumns[number]['key']
 

--- a/frontend/web/src/features/afl/components/PlayerStatsTable.vue
+++ b/frontend/web/src/features/afl/components/PlayerStatsTable.vue
@@ -18,7 +18,9 @@
         <tr
           v-for="pm in clubMatch.playerMatches"
           :key="pm.id"
+          :id="`pm-${pm.id}`"
           class="border-b border-border-subtle hover:bg-surface-hover"
+          :class="{ 'highlight-pulse': pm.id === props.highlightPmId }"
         >
           <td class="py-2 pr-4 font-medium">
             <router-link
@@ -97,8 +99,10 @@ interface ClubMatch {
 const props = withDefaults(defineProps<{
   clubMatch: ClubMatch
   readonly?: boolean
+  highlightPmId?: string | null
 }>(), {
   readonly: false,
+  highlightPmId: null,
 })
 
 const emit = defineEmits<{
@@ -144,3 +148,13 @@ function onStatChange(pm: PlayerMatch, key: StatKey, event: Event) {
   })
 }
 </script>
+
+<style scoped>
+@keyframes highlight-pulse {
+  0%, 30% { background-color: rgb(34 197 94 / 0.3); }
+  100% { background-color: transparent; }
+}
+.highlight-pulse {
+  animation: highlight-pulse 7.3s ease-out forwards;
+}
+</style>

--- a/frontend/web/src/features/afl/components/TopPlayers.vue
+++ b/frontend/web/src/features/afl/components/TopPlayers.vue
@@ -5,23 +5,31 @@
       <li
         v-for="(entry, index) in players"
         :key="index"
-        class="flex items-center justify-between text-sm"
+        class="flex items-center justify-between text-sm gap-2"
       >
-        <span>
-          <span class="font-medium">{{ entry.name }}</span>
-          <span class="text-text-muted ml-1">({{ entry.club }})</span>
+        <span class="flex items-center gap-1.5 min-w-0">
+          <img :src="clubLogoUrl(entry.club)" :alt="entry.club" class="w-4 h-4 object-contain shrink-0" />
+          <router-link
+            v-if="entry.matchId"
+            :to="{ name: 'afl-match', params: { matchId: entry.matchId } }"
+            class="font-medium hover:text-text-muted transition-colors truncate"
+          >{{ entry.name }}</router-link>
+          <span v-else class="font-medium truncate">{{ entry.name }}</span>
         </span>
-        <span class="tabular-nums font-semibold">{{ entry.value }}</span>
+        <span class="tabular-nums font-semibold shrink-0">{{ entry.value }}</span>
       </li>
     </ol>
   </div>
 </template>
 
 <script setup lang="ts">
+import { clubLogoUrl } from '../utils/clubLogos'
+
 interface PlayerEntry {
   name: string
   club: string
   value: number
+  matchId?: string
 }
 
 defineProps<{

--- a/frontend/web/src/features/afl/components/TopPlayers.vue
+++ b/frontend/web/src/features/afl/components/TopPlayers.vue
@@ -11,7 +11,7 @@
           <img :src="clubLogoUrl(entry.club)" :alt="entry.club" class="w-4 h-4 object-contain shrink-0" />
           <router-link
             v-if="entry.matchId"
-            :to="{ name: 'afl-match', params: { matchId: entry.matchId } }"
+            :to="{ name: 'afl-match', params: { matchId: entry.matchId }, query: entry.pmId ? { highlight: entry.pmId } : undefined }"
             class="font-medium hover:text-text-muted transition-colors truncate"
           >{{ entry.name }}</router-link>
           <span v-else class="font-medium truncate">{{ entry.name }}</span>
@@ -30,6 +30,7 @@ interface PlayerEntry {
   club: string
   value: number
   matchId?: string
+  pmId?: string
 }
 
 defineProps<{

--- a/frontend/web/src/features/afl/composables/useAflState.ts
+++ b/frontend/web/src/features/afl/composables/useAflState.ts
@@ -1,4 +1,5 @@
 import { ref, readonly, computed } from 'vue'
+import { getCookie, setCookie } from '@/utils/cookie'
 
 interface AflState {
   seasonId: string
@@ -8,13 +9,8 @@ interface AflState {
 
 const COOKIE_NAME = 'xffl_afl'
 
-function getCookieRaw(name: string): string {
-  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'))
-  return match ? decodeURIComponent(match[2]) : ''
-}
-
 function readCookie(): AflState {
-  const raw = getCookieRaw(COOKIE_NAME)
+  const raw = getCookie(COOKIE_NAME)
   if (!raw) return { seasonId: '', roundId: '', startDate: '' }
   try {
     const parsed = JSON.parse(raw)
@@ -28,12 +24,6 @@ function readCookie(): AflState {
   }
 }
 
-function writeCookie(state: AflState) {
-  const expires = new Date()
-  expires.setHours(24, 0, 0, 0)
-  document.cookie = `${COOKIE_NAME}=${encodeURIComponent(JSON.stringify(state))};expires=${expires.toUTCString()};path=/`
-}
-
 // Module-level singletons — shared across all component instances
 const stored = readCookie()
 const liveSeasonId = ref<string>(stored.seasonId)
@@ -44,7 +34,7 @@ function setLiveRound(seasonId: string, roundId: string, startDate: string) {
   liveSeasonId.value = seasonId
   liveRoundId.value = roundId
   liveStartDate.value = startDate
-  writeCookie({ seasonId, roundId, startDate })
+  setCookie(COOKIE_NAME, JSON.stringify({ seasonId, roundId, startDate }))
 }
 
 // In-memory only (not persisted) — sticks to whichever round the user last

--- a/frontend/web/src/features/afl/views/ClubSeasonView.vue
+++ b/frontend/web/src/features/afl/views/ClubSeasonView.vue
@@ -18,7 +18,7 @@
               <th class="py-2 pr-4 font-medium">Player</th>
               <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right">{{ col.label }}</th>
               <th class="py-2 pl-2 pr-3 font-medium text-right text-yellow-400">★</th>
-              <th class="py-2 pl-3 pr-3 font-medium bg-white/[0.03] border-l border-border whitespace-nowrap w-px">FFL Club</th>
+              <th class="py-2 pl-3 pr-3 font-medium bg-white/[0.03] border-l border-border whitespace-nowrap">FFL Club</th>
             </tr>
           </thead>
           <tbody>
@@ -33,11 +33,11 @@
                   class="hover:text-text-muted transition-colors"
                 >{{ row.playerName }}</router-link>
               </td>
-              <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums text-text-muted">
+              <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums" :style="statHeat(row.stats?.[col.key], col.key)">
                 {{ fmtStat(row.stats?.[col.key]) }}
               </td>
-              <td class="py-2 pl-2 pr-3 text-right tabular-nums text-yellow-400">{{ starStr(row.stats) }}</td>
-              <td class="py-2 pl-3 pr-3 bg-white/[0.03] border-l border-border w-px whitespace-nowrap">
+              <td class="py-2 pl-2 pr-3 text-right tabular-nums" :style="statHeat(row.stats ? starScore(row.stats) : null, 'star')">{{ starStr(row.stats) }}</td>
+              <td class="py-2 pl-3 pr-3 bg-white/[0.03] border-l border-border whitespace-nowrap">
                 <router-link
                   v-if="row.fflClubSeasonId"
                   :to="{ name: 'ffl-club-season', params: { clubSeasonId: row.fflClubSeasonId } }"
@@ -68,6 +68,8 @@ import { GET_AFL_CLUB_SEASON } from '@/features/ffl/api/queries'
 import Breadcrumb from '@/features/ffl/components/Breadcrumb.vue'
 import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
 import { clubLogoUrl as fflClubLogoUrl } from '@/features/ffl/utils/clubLogos'
+import { useTheme } from '@/composables/useTheme'
+import { heatStyle } from '@/utils/heatmap'
 
 const props = defineProps<{ clubSeasonId: string }>()
 
@@ -112,6 +114,26 @@ const statCols = [
 
 type StatKey = typeof statCols[number]['key']
 
+const { isDark } = useTheme()
+
+const columnRange = computed(() => {
+  const range = {} as Record<StatKey | 'star', { min: number; max: number }>
+  for (const col of statCols) {
+    const vals = rows.value.map(r => r.stats?.[col.key]).filter((v): v is number => v != null)
+    if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  const starVals = rows.value.map(r => r.stats ? starScore(r.stats) : null).filter((v): v is number => v != null)
+  if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
+  return range
+})
+
+function statHeat(value: number | null | undefined, key: StatKey | 'star'): Record<string, string> {
+  if (value == null) return {}
+  const r = columnRange.value[key]
+  if (!r) return {}
+  return heatStyle(value, r.min, r.max, isDark.value)
+}
+
 const breadcrumbs = computed(() => {
   if (!clubSeason.value) return []
   return [
@@ -140,8 +162,12 @@ function fmtStat(val: number | null | undefined): string {
   return val.toFixed(1)
 }
 
+function starScore(s: StatSummary): number {
+  return s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4
+}
+
 function starStr(s: StatSummary | null | undefined): string {
   if (!s) return '—'
-  return (s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4).toFixed(1)
+  return starScore(s).toFixed(1)
 }
 </script>

--- a/frontend/web/src/features/afl/views/ClubSeasonView.vue
+++ b/frontend/web/src/features/afl/views/ClubSeasonView.vue
@@ -16,53 +16,41 @@
           <thead>
             <tr class="border-b border-border text-left text-text-muted">
               <th class="py-2 pr-4 font-medium">Player</th>
-              <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right w-10">{{ col.label }}</th>
-              <th class="py-2 pl-2 pr-3 font-medium text-right w-10 text-yellow-400">★</th>
-              <th class="py-2 w-5"></th>
-              <th class="py-2 pl-5 pr-3 font-medium bg-white/[0.03] border-l border-border whitespace-nowrap">FFL Club</th>
-              <th class="py-2 w-5 bg-white/[0.03]"></th>
+              <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right">{{ col.label }}</th>
+              <th class="py-2 pl-2 pr-3 font-medium text-right text-yellow-400">★</th>
+              <th class="py-2 pl-3 pr-3 font-medium bg-white/[0.03] border-l border-border whitespace-nowrap w-px">FFL Club</th>
             </tr>
           </thead>
           <tbody>
             <tr
               v-for="row in rows"
               :key="row.id"
-              class="border-b border-border-subtle hover:bg-surface-hover group"
+              class="border-b border-border-subtle hover:bg-surface-hover"
             >
-              <td class="py-2 pr-4 font-medium">{{ row.playerName }}</td>
+              <td class="py-2 pr-4 font-medium">
+                <router-link
+                  :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
+                  class="hover:text-text-muted transition-colors"
+                >{{ row.playerName }}</router-link>
+              </td>
               <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums text-text-muted">
                 {{ fmtStat(row.stats?.[col.key]) }}
               </td>
               <td class="py-2 pl-2 pr-3 text-right tabular-nums text-yellow-400">{{ starStr(row.stats) }}</td>
-              <td class="py-2 pr-2 w-5">
+              <td class="py-2 pl-3 pr-3 bg-white/[0.03] border-l border-border w-px whitespace-nowrap">
                 <router-link
-                  :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
-                  class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
-                  title="View AFL player"
+                  v-if="row.fflClubSeasonId"
+                  :to="{ name: 'ffl-club-season', params: { clubSeasonId: row.fflClubSeasonId } }"
+                  class="inline-flex items-center gap-1.5 hover:text-text-muted transition-colors"
                 >
-                  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>
-                  </svg>
+                  <img :src="fflClubLogoUrl(row.fflClub!)" class="w-4 h-4 object-contain" />
+                  <span>{{ row.fflClub }}</span>
                 </router-link>
-              </td>
-              <td class="py-2 pl-5 pr-3 bg-white/[0.03] border-l border-border">
-                <span v-if="row.fflClub" class="inline-flex items-center gap-1.5">
+                <span v-else-if="row.fflClub" class="inline-flex items-center gap-1.5">
                   <img :src="fflClubLogoUrl(row.fflClub)" class="w-4 h-4 object-contain" />
                   <span>{{ row.fflClub }}</span>
                 </span>
                 <span v-else class="text-text-faint">—</span>
-              </td>
-              <td class="py-2 pr-2 w-5 bg-white/[0.03]">
-                <router-link
-                  v-if="row.fflClubSeasonId"
-                  :to="{ name: 'ffl-club-season', params: { clubSeasonId: row.fflClubSeasonId } }"
-                  class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
-                  title="View FFL club"
-                >
-                  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>
-                  </svg>
-                </router-link>
               </td>
             </tr>
           </tbody>

--- a/frontend/web/src/features/afl/views/ClubSeasonView.vue
+++ b/frontend/web/src/features/afl/views/ClubSeasonView.vue
@@ -1,9 +1,159 @@
 <template>
   <div>
-    <p class="text-text-faint text-sm">AFL club season view — coming soon.</p>
+    <Breadcrumb v-if="clubSeason" :items="breadcrumbs" />
+
+    <div v-if="loading" class="text-text-faint">Loading...</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else-if="clubSeason">
+
+      <div class="mb-6 flex items-center gap-3">
+        <img :src="aflClubLogoUrl(clubSeason.club.name)" class="w-10 h-10 object-contain" />
+        <h1 class="text-2xl font-bold text-text">{{ clubSeason.club.name }}</h1>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-border text-left text-text-muted">
+              <th class="py-2 pr-4 font-medium">Player</th>
+              <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right w-10">{{ col.label }}</th>
+              <th class="py-2 pl-2 pr-3 font-medium text-right w-10 text-yellow-400">★</th>
+              <th class="py-2 w-5"></th>
+              <th class="py-2 pl-5 pr-3 font-medium bg-white/[0.03] border-l border-border whitespace-nowrap">FFL Club</th>
+              <th class="py-2 w-5 bg-white/[0.03]"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="row in rows"
+              :key="row.id"
+              class="border-b border-border-subtle hover:bg-surface-hover group"
+            >
+              <td class="py-2 pr-4 font-medium">{{ row.playerName }}</td>
+              <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums text-text-muted">
+                {{ fmtStat(row.stats?.[col.key]) }}
+              </td>
+              <td class="py-2 pl-2 pr-3 text-right tabular-nums text-yellow-400">{{ starStr(row.stats) }}</td>
+              <td class="py-2 pr-2 w-5">
+                <router-link
+                  :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
+                  class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
+                  title="View player season"
+                >
+                  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>
+                  </svg>
+                </router-link>
+              </td>
+              <td class="py-2 pl-5 pr-3 bg-white/[0.03] border-l border-border">
+                <span v-if="row.fflClub" class="inline-flex items-center gap-1.5">
+                  <img :src="fflClubLogoUrl(row.fflClub)" class="w-4 h-4 object-contain" />
+                  <span>{{ row.fflClub }}</span>
+                </span>
+                <span v-else class="text-text-faint">—</span>
+              </td>
+              <td class="py-2 pr-2 w-5 bg-white/[0.03]">
+                <router-link
+                  v-if="row.fflClubSeasonId"
+                  :to="{ name: 'ffl-club-season', params: { clubSeasonId: row.fflClubSeasonId } }"
+                  class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
+                  title="View FFL club"
+                >
+                  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>
+                  </svg>
+                </router-link>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps<{ clubSeasonId: string }>()
+import { computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { GET_AFL_CLUB_SEASON } from '@/features/ffl/api/queries'
+import Breadcrumb from '@/features/ffl/components/Breadcrumb.vue'
+import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
+import { clubLogoUrl as fflClubLogoUrl } from '@/features/ffl/utils/clubLogos'
+
+const props = defineProps<{ clubSeasonId: string }>()
+
+const { result, loading, error } = useQuery(GET_AFL_CLUB_SEASON, () => ({ id: props.clubSeasonId }))
+
+interface StatSummary {
+  goals: number; kicks: number; handballs: number
+  marks: number; tackles: number; hitouts: number
+}
+
+interface FFLPlayerSeasonStub {
+  id: string
+  clubSeasonId: string
+  club: { id: string; name: string }
+  toRoundId: string | null
+}
+
+interface PlayerSeasonStub {
+  id: string
+  player: { id: string; name: string }
+  stats: StatSummary | null
+  fflPlayerSeasons: FFLPlayerSeasonStub[]
+}
+
+interface ClubSeason {
+  id: string
+  club: { id: string; name: string }
+  season: { id: string; name: string }
+  playerSeasons: PlayerSeasonStub[]
+}
+
+const clubSeason = computed(() => result.value?.aflClubSeason as ClubSeason | null ?? null)
+
+const statCols = [
+  { key: 'kicks'     as const, label: 'K' },
+  { key: 'handballs' as const, label: 'H' },
+  { key: 'marks'     as const, label: 'M' },
+  { key: 'tackles'   as const, label: 'T' },
+  { key: 'hitouts'   as const, label: 'R' },
+  { key: 'goals'     as const, label: 'G' },
+]
+
+type StatKey = typeof statCols[number]['key']
+
+const breadcrumbs = computed(() => {
+  if (!clubSeason.value) return []
+  return [
+    { label: 'FFL', to: { name: 'home' } },
+    { label: clubSeason.value.season.name, to: { name: 'afl-home' } },
+    { label: clubSeason.value.club.name },
+  ]
+})
+
+const rows = computed(() => {
+  if (!clubSeason.value) return []
+  return clubSeason.value.playerSeasons.map(ps => {
+    const currentStint = ps.fflPlayerSeasons.find(s => s.toRoundId === null)
+    return {
+      id: ps.id,
+      playerName: ps.player.name,
+      stats: ps.stats,
+      fflClub: currentStint?.club.name ?? null,
+      fflClubSeasonId: currentStint?.clubSeasonId ?? null,
+    }
+  })
+})
+
+function fmtStat(val: number | null | undefined): string {
+  if (val == null) return '—'
+  return val.toFixed(1)
+}
+
+function starStr(s: StatSummary | null | undefined): string {
+  if (!s) return '—'
+  return (s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4).toFixed(1)
+}
 </script>

--- a/frontend/web/src/features/afl/views/ClubSeasonView.vue
+++ b/frontend/web/src/features/afl/views/ClubSeasonView.vue
@@ -38,7 +38,7 @@
                 <router-link
                   :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
                   class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
-                  title="View player season"
+                  title="View AFL player"
                 >
                   <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>

--- a/frontend/web/src/features/afl/views/ClubSeasonView.vue
+++ b/frontend/web/src/features/afl/views/ClubSeasonView.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <p class="text-text-faint text-sm">AFL club season view — coming soon.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ clubSeasonId: string }>()
+</script>

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -7,10 +7,12 @@
         <Breadcrumb v-if="matchData" :items="breadcrumbs" />
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
-          {{ match.homeClubMatch?.club.name ?? '—' }}
+          <router-link v-if="match.homeClubMatch" :to="{ name: 'afl-club-season', params: { clubSeasonId: match.homeClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.homeClubMatch.club.name }}</router-link>
+          <span v-else>—</span>
           <span class="text-text-faint mx-1">v</span>
           <img v-if="match.awayClubMatch" :src="clubLogoUrl(match.awayClubMatch.club.name)" :alt="match.awayClubMatch.club.name" class="w-10 h-10 object-contain" />
-          {{ match.awayClubMatch?.club.name ?? '—' }}
+          <router-link v-if="match.awayClubMatch" :to="{ name: 'afl-club-season', params: { clubSeasonId: match.awayClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.awayClubMatch.club.name }}</router-link>
+          <span v-else>—</span>
         </h1>
         <p v-if="match.venue" class="text-sm text-text-muted mt-1">{{ match.venue }}</p>
         <p v-if="match.result" class="text-lg font-semibold mt-2">
@@ -31,7 +33,10 @@
       </div>
 
       <div v-for="side in sides" :key="side.label" class="mb-10">
-        <h2 class="text-lg font-semibold mb-3">{{ side.label }}</h2>
+        <h2 class="text-lg font-semibold mb-3">
+          <router-link v-if="side.clubSeasonId" :to="{ name: 'afl-club-season', params: { clubSeasonId: side.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ side.label }}</router-link>
+          <span v-else>{{ side.label }}</span>
+        </h2>
         <PlayerStatsTable
           v-if="side.clubMatch"
           :club-match="side.clubMatch"
@@ -97,8 +102,8 @@ const match = computed(() => matchData.value?.match ?? null)
 const sides = computed(() => {
   if (!match.value) return []
   return [
-    { label: match.value.homeClubMatch?.club.name ?? 'Home', clubMatch: match.value.homeClubMatch },
-    { label: match.value.awayClubMatch?.club.name ?? 'Away', clubMatch: match.value.awayClubMatch },
+    { label: match.value.homeClubMatch?.club.name ?? 'Home', clubSeasonId: match.value.homeClubMatch?.clubSeasonId ?? null, clubMatch: match.value.homeClubMatch },
+    { label: match.value.awayClubMatch?.club.name ?? 'Away', clubSeasonId: match.value.awayClubMatch?.clubSeasonId ?? null, clubMatch: match.value.awayClubMatch },
   ]
 })
 

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -48,15 +48,6 @@
         </p>
       </div>
 
-      <div v-if="matchData" class="mt-8">
-        <router-link
-          :to="{ name: 'ffl-data-ops', query: { tab: 'afl-stats', round: matchData.roundId } }"
-          class="flex items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
-        >
-          <IconDataOps class="w-4 h-4" />
-          Data Ops
-        </router-link>
-      </div>
     </template>
   </div>
 </template>
@@ -69,7 +60,6 @@ import { UPDATE_PLAYER_MATCH } from '../api/mutations'
 import Breadcrumb from '../components/Breadcrumb.vue'
 import PlayerStatsTable from '../components/PlayerStatsTable.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
-import IconDataOps from '@/features/data-ops/components/icons/IconDataOps.vue'
 
 const props = defineProps<{ matchId: string }>()
 

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -7,11 +7,11 @@
         <Breadcrumb v-if="matchData" :items="breadcrumbs" />
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
-          <router-link v-if="match.homeClubMatch" :to="{ name: 'afl-club-season', params: { clubSeasonId: match.homeClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.homeClubMatch.club.name }}</router-link>
+          <router-link v-if="match.homeClubMatch" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: match.homeClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.homeClubMatch.club.name }}</router-link>
           <span v-else>—</span>
           <span class="text-text-faint mx-1">v</span>
           <img v-if="match.awayClubMatch" :src="clubLogoUrl(match.awayClubMatch.club.name)" :alt="match.awayClubMatch.club.name" class="w-10 h-10 object-contain" />
-          <router-link v-if="match.awayClubMatch" :to="{ name: 'afl-club-season', params: { clubSeasonId: match.awayClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.awayClubMatch.club.name }}</router-link>
+          <router-link v-if="match.awayClubMatch" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: match.awayClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.awayClubMatch.club.name }}</router-link>
           <span v-else>—</span>
         </h1>
         <p v-if="match.venue" class="text-sm text-text-muted mt-1">{{ match.venue }}</p>
@@ -34,7 +34,7 @@
 
       <div v-for="side in sides" :key="side.label" class="mb-10">
         <h2 class="text-lg font-semibold mb-3">
-          <router-link v-if="side.clubSeasonId" :to="{ name: 'afl-club-season', params: { clubSeasonId: side.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ side.label }}</router-link>
+          <router-link v-if="side.clubSeasonId" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: side.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ side.label }}</router-link>
           <span v-else>{{ side.label }}</span>
         </h2>
         <PlayerStatsTable

--- a/frontend/web/src/features/afl/views/MatchView.vue
+++ b/frontend/web/src/features/afl/views/MatchView.vue
@@ -41,6 +41,7 @@
           v-if="side.clubMatch"
           :club-match="side.clubMatch"
           :readonly="!managing"
+          :highlight-pm-id="highlightPmId"
           @update="handleUpdate"
         />
         <p v-if="side.clubMatch" class="text-sm text-text-muted mt-2">
@@ -53,7 +54,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useQuery, useMutation } from '@vue/apollo-composable'
 import { GET_AFL_MATCH } from '../api/queries'
 import { UPDATE_PLAYER_MATCH } from '../api/mutations'
@@ -63,6 +65,7 @@ import { clubLogoUrl } from '../utils/clubLogos'
 
 const props = defineProps<{ matchId: string }>()
 
+const route = useRoute()
 const managing = ref(false)
 
 const { result, loading, error } = useQuery(GET_AFL_MATCH, () => ({ matchId: props.matchId }))
@@ -88,6 +91,19 @@ const breadcrumbs = computed(() => {
 })
 
 const match = computed(() => matchData.value?.match ?? null)
+
+const highlightPmId = computed(() => (route.query.highlight as string) || null)
+
+let scrolledToHighlight = false
+watch(match, (m) => {
+  if (!m || !highlightPmId.value || scrolledToHighlight) return
+  scrolledToHighlight = true
+  const id = highlightPmId.value
+  setTimeout(() => {
+    const el = document.getElementById(`pm-${id}`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, 300)
+}, { immediate: true })
 
 const sides = computed(() => {
   if (!match.value) return []

--- a/frontend/web/src/features/afl/views/RoundView.vue
+++ b/frontend/web/src/features/afl/views/RoundView.vue
@@ -104,6 +104,7 @@ const statCategories = [
 ] as const
 
 interface PlayerMatch {
+  id: string
   player: { name: string }
   kicks: number
   handballs: number
@@ -142,12 +143,12 @@ const roundStartDate = computed(() => {
 const topPlayerStats = computed(() => {
   if (!data.value) return []
 
-  const allPlayers: { name: string; club: string; matchId: string; stats: PlayerMatch }[] = []
+  const allPlayers: { name: string; club: string; matchId: string; pmId: string; stats: PlayerMatch }[] = []
   for (const match of data.value.round.matches as Match[]) {
     for (const side of [match.homeClubMatch, match.awayClubMatch]) {
       if (!side) continue
       for (const pm of side.playerMatches) {
-        allPlayers.push({ name: pm.player.name, club: side.club.name, matchId: match.id, stats: pm })
+        allPlayers.push({ name: pm.player.name, club: side.club.name, matchId: match.id, pmId: pm.id, stats: pm })
       }
     }
   }
@@ -163,6 +164,7 @@ const topPlayerStats = computed(() => {
         name: p.name,
         club: p.club,
         matchId: p.matchId,
+        pmId: p.pmId,
         value: p.stats[cat.key] as number,
       })),
     }

--- a/frontend/web/src/features/afl/views/RoundView.vue
+++ b/frontend/web/src/features/afl/views/RoundView.vue
@@ -120,6 +120,7 @@ interface ClubMatch {
 }
 
 interface Match {
+  id: string
   homeClubMatch?: ClubMatch | null
   awayClubMatch?: ClubMatch | null
 }
@@ -141,12 +142,12 @@ const roundStartDate = computed(() => {
 const topPlayerStats = computed(() => {
   if (!data.value) return []
 
-  const allPlayers: { name: string; club: string; stats: PlayerMatch }[] = []
+  const allPlayers: { name: string; club: string; matchId: string; stats: PlayerMatch }[] = []
   for (const match of data.value.round.matches as Match[]) {
     for (const side of [match.homeClubMatch, match.awayClubMatch]) {
       if (!side) continue
       for (const pm of side.playerMatches) {
-        allPlayers.push({ name: pm.player.name, club: side.club.name, stats: pm })
+        allPlayers.push({ name: pm.player.name, club: side.club.name, matchId: match.id, stats: pm })
       }
     }
   }
@@ -161,6 +162,7 @@ const topPlayerStats = computed(() => {
       players: sorted.map(p => ({
         name: p.name,
         club: p.club,
+        matchId: p.matchId,
         value: p.stats[cat.key] as number,
       })),
     }

--- a/frontend/web/src/features/data-ops/views/DataOpsView.vue
+++ b/frontend/web/src/features/data-ops/views/DataOpsView.vue
@@ -60,19 +60,19 @@
                       class="inline-flex items-center gap-1.5 text-text hover:text-active transition-colors"
                     >
                       <img v-if="match.homeClubMatch?.club.name" :src="clubLogoUrl(match.homeClubMatch.club.name)" class="w-4 h-4 object-contain" />
-                      {{ abbrevClub(match.homeClubMatch?.club.name) }}
+                      {{ match.homeClubMatch?.club.name ?? '—' }}
                       <span class="font-normal text-text-faint text-xs mx-1">vs</span>
                       <img v-if="match.awayClubMatch?.club.name" :src="clubLogoUrl(match.awayClubMatch.club.name)" class="w-4 h-4 object-contain" />
-                      {{ abbrevClub(match.awayClubMatch?.club.name) }}
+                      {{ match.awayClubMatch?.club.name ?? '—' }}
                       <svg class="w-3 h-3 opacity-40 ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                     </router-link>
                     <template v-else>
                       <span class="inline-flex items-center gap-1.5">
                         <img v-if="match.homeClubMatch?.club.name" :src="clubLogoUrl(match.homeClubMatch.club.name)" class="w-4 h-4 object-contain" />
-                        {{ abbrevClub(match.homeClubMatch?.club.name) }}
+                        {{ match.homeClubMatch?.club.name ?? '—' }}
                         <span class="font-normal text-text-faint text-xs mx-1">vs</span>
                         <img v-if="match.awayClubMatch?.club.name" :src="clubLogoUrl(match.awayClubMatch.club.name)" class="w-4 h-4 object-contain" />
-                        {{ abbrevClub(match.awayClubMatch?.club.name) }}
+                        {{ match.awayClubMatch?.club.name ?? '—' }}
                       </span>
                     </template>
                   </td>
@@ -178,7 +178,7 @@
             <span class="text-sm text-border">·</span>
             <span class="flex items-center gap-1.5 opacity-70">
               <img :src="clubLogoUrl(bye.club.name)" :alt="bye.club.name" class="w-5 h-5 object-contain" />
-              <span class="text-sm text-text-faint">{{ abbrevClub(bye.club.name) }}</span>
+              <span class="text-sm text-text-faint">{{ bye.club.name }}</span>
             </span>
           </template>
         </div>
@@ -482,7 +482,6 @@ import { useFflState } from '@/features/ffl/composables/useFflState'
 import { useAflState } from '@/features/afl/composables/useAflState'
 import { GET_AFL_LIVE_ROUND } from '@/features/afl/api/queries'
 import { clubLogoUrl } from '@/features/afl/utils/clubLogos'
-import { clubAbbrev } from '@/features/afl/utils/clubAbbrev'
 import { clubLogoUrl as fflClubLogoUrl } from '@/features/ffl/utils/clubLogos'
 import { POSITION_COLORS, POSITION_LABEL, POSITION_SLOTS } from '@/features/ffl/utils/position'
 import PlayerSearchModal from '../components/PlayerSearchModal.vue'
@@ -629,10 +628,6 @@ async function onPlayerResolved() {
   await refetchRoundStats()
 }
 
-function abbrevClub(name: string | undefined): string {
-  if (!name) return '—'
-  return clubAbbrev(name)
-}
 
 function statusLabel(status: string): string {
   if (status === 'final') return 'Final'

--- a/frontend/web/src/features/data-ops/views/DataOpsView.vue
+++ b/frontend/web/src/features/data-ops/views/DataOpsView.vue
@@ -56,16 +56,14 @@
                     <router-link
                       v-if="match.id"
                       :to="{ name: 'afl-match', params: { matchId: match.id } }"
-                      target="_blank" rel="noopener noreferrer"
-                      class="inline-flex items-center gap-1.5 text-text hover:text-active transition-colors"
+                                            class="inline-flex items-center gap-1.5 text-text hover:text-active transition-colors"
                     >
                       <img v-if="match.homeClubMatch?.club.name" :src="clubLogoUrl(match.homeClubMatch.club.name)" class="w-4 h-4 object-contain" />
                       {{ match.homeClubMatch?.club.name ?? '—' }}
                       <span class="font-normal text-text-faint text-xs mx-1">vs</span>
                       <img v-if="match.awayClubMatch?.club.name" :src="clubLogoUrl(match.awayClubMatch.club.name)" class="w-4 h-4 object-contain" />
                       {{ match.awayClubMatch?.club.name ?? '—' }}
-                      <svg class="w-3 h-3 opacity-40 ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                    </router-link>
+                                          </router-link>
                     <template v-else>
                       <span class="inline-flex items-center gap-1.5">
                         <img v-if="match.homeClubMatch?.club.name" :src="clubLogoUrl(match.homeClubMatch.club.name)" class="w-4 h-4 object-contain" />
@@ -269,12 +267,10 @@
                   <td class="py-3 pr-4">
                     <router-link
                       :to="{ name: 'ffl-club-match-edit', params: { clubMatchId: row.clubMatchId } }"
-                      target="_blank" rel="noopener noreferrer"
-                      class="inline-flex items-center gap-1.5 text-sm font-semibold text-text hover:text-active transition-colors"
+                                            class="inline-flex items-center gap-1.5 text-sm font-semibold text-text hover:text-active transition-colors"
                     >
                       <img v-if="fflClubLogoUrl(row.clubName)" :src="fflClubLogoUrl(row.clubName)" :alt="row.clubName" class="w-5 h-5 object-contain" />
-                      {{ row.clubName }}<svg class="w-3 h-3 opacity-40 ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                    </router-link>
+                      {{ row.clubName }}                    </router-link>
                   </td>
                   <td class="py-3 pr-4 whitespace-nowrap">
                     <span

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -476,6 +476,7 @@ export const GET_AFL_PLAYER_SEASON_STATS = gql`
         clubMatch {
           club { id name }
           match {
+            id
             round { id name }
             homeClubMatch { club { id name } }
             awayClubMatch { club { id name } }
@@ -495,6 +496,7 @@ export const GET_FFL_PLAYER_STINTS = gql`
       toRoundId
       playerMatches {
         id
+        matchId
         position
         backupPositions
         interchangePosition
@@ -512,6 +514,14 @@ export const GET_FFL_PLAYER_STINTS = gql`
           }
         }
       }
+    }
+  }
+`
+
+export const GET_FFL_SEASON_ROUND_MAPPING = gql`
+  query GetFflSeasonRoundMapping($seasonId: ID!) {
+    fflSeason(id: $seasonId) {
+      rounds { id aflRoundId }
     }
   }
 `

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -26,6 +26,7 @@ export const GET_FFL_CLUB_SEASON = gql`
           aflPlayerSeason {
             id
             clubSeason {
+              id
               club { id name }
             }
           }
@@ -270,7 +271,8 @@ export const GET_FFL_MATCH = gql`
           score
           playerSeason {
             aflPlayerSeason {
-              clubSeason { club { name } }
+              id
+              clubSeason { id club { name } }
               stats { goals kicks handballs marks tackles hitouts games }
             }
           }
@@ -297,7 +299,8 @@ export const GET_FFL_MATCH = gql`
           score
           playerSeason {
             aflPlayerSeason {
-              clubSeason { club { name } }
+              id
+              clubSeason { id club { name } }
               stats { goals kicks handballs marks tackles hitouts games }
             }
           }
@@ -524,6 +527,29 @@ export const GET_FFL_SEASON_ROUND_MAPPING = gql`
   query GetFflSeasonRoundMapping($seasonId: ID!) {
     fflSeason(id: $seasonId) {
       rounds { id aflRoundId }
+    }
+  }
+`
+
+export const GET_AFL_CLUB_SEASON = gql`
+  query GetAFLClubSeason($id: ID!) {
+    aflClubSeason(id: $id) {
+      id
+      club { id name }
+      season { id name }
+      playerSeasons {
+        id
+        player { id name }
+        stats {
+          goals kicks handballs marks tackles hitouts
+        }
+        fflPlayerSeasons {
+          id
+          clubSeasonId
+          club { id name }
+          toRoundId
+        }
+      }
     }
   }
 `

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -450,6 +450,7 @@ export const GET_AFL_PLAYER_SEASON_STATS = gql`
       id
       player { id name }
       clubSeason {
+        id
         club { id name }
         season { id name }
       }
@@ -492,6 +493,7 @@ export const GET_FFL_PLAYER_STINTS = gql`
     fflPlayerSeasonsByAflPlayerSeason(aflPlayerSeasonId: $aflPlayerSeasonId) {
       id
       club { id name }
+      clubSeasonId
       fromRoundId
       toRoundId
       playerMatches {

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag'
+import { LAST_N } from '../utils/playerStats'
 
 
 export const GET_FFL_SEASON_CLUBS = gql`
@@ -32,7 +33,7 @@ export const GET_FFL_CLUB_SEASON = gql`
             statsAll: stats(method: MEAN) {
               goals kicks handballs marks tackles hitouts
             }
-            statsLast3: stats(lastN: 3, method: MEAN) {
+            statsLastN: stats(lastN: ${LAST_N}, method: MEAN) {
               goals kicks handballs marks tackles hitouts
             }
           }
@@ -466,7 +467,7 @@ export const GET_AFL_PLAYER_SEASON_STATS = gql`
       statsAll: stats(method: MEAN) {
         goals kicks handballs marks tackles hitouts games
       }
-      statsLast3: stats(lastN: 3, method: MEAN) {
+      statsLastN: stats(lastN: ${LAST_N}, method: MEAN) {
         goals kicks handballs marks tackles hitouts
       }
       statsMedian: stats(method: MEDIAN) {
@@ -577,12 +578,35 @@ export const SEARCH_AFL_PLAYERS = gql`
   }
 `
 
+export const GET_FREE_AGENTS = gql`
+  query GetFreeAgents($fflSeasonId: ID!) {
+    fflSeason(id: $fflSeasonId) {
+      aflSeason {
+        playerSeasons {
+          nodes {
+            id
+            player { id name }
+            clubSeason { id club { id name } }
+            statsAll: stats(method: MEAN) {
+              goals kicks handballs marks tackles hitouts games
+            }
+            statsLastN: stats(lastN: ${LAST_N}, method: MEAN) {
+              goals kicks handballs marks tackles hitouts
+            }
+            fflPlayerSeasons { toRoundId }
+          }
+        }
+      }
+    }
+  }
+`
+
 export const GET_PLAYER_STATS_CARD = gql`
   query GetPlayerStatsCard($id: ID!, $aflRoundId: ID) {
     aflPlayerSeason(id: $id) {
       id
       seasonAvg: stats(upToRoundId: $aflRoundId) { goals kicks handballs marks tackles hitouts games }
-      last3: stats(upToRoundId: $aflRoundId, lastN: 3) { goals kicks handballs marks tackles hitouts games }
+      lastN: stats(upToRoundId: $aflRoundId, lastN: ${LAST_N}) { goals kicks handballs marks tackles hitouts games }
     }
   }
 `

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -453,6 +453,15 @@ export const GET_AFL_PLAYER_SEASON_STATS = gql`
         club { id name }
         season { id name }
       }
+      statsAll: stats(method: MEAN) {
+        goals kicks handballs marks tackles hitouts games
+      }
+      statsLast3: stats(lastN: 3, method: MEAN) {
+        goals kicks handballs marks tackles hitouts
+      }
+      statsMedian: stats(method: MEDIAN) {
+        goals kicks handballs marks tackles hitouts
+      }
       matches {
         id
         status
@@ -487,6 +496,8 @@ export const GET_FFL_PLAYER_STINTS = gql`
       playerMatches {
         id
         position
+        backupPositions
+        interchangePosition
         status
         aflStatus
         score

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -607,6 +607,12 @@ export const GET_PLAYER_STATS_CARD = gql`
       id
       seasonAvg: stats(upToRoundId: $aflRoundId) { goals kicks handballs marks tackles hitouts games }
       lastN: stats(upToRoundId: $aflRoundId, lastN: ${LAST_N}) { goals kicks handballs marks tackles hitouts games }
+      matches {
+        id
+        status
+        goals kicks handballs marks tackles hitouts
+        clubMatch { match { id round { id name } } }
+      }
     }
   }
 `

--- a/frontend/web/src/features/ffl/api/queries.ts
+++ b/frontend/web/src/features/ffl/api/queries.ts
@@ -29,6 +29,12 @@ export const GET_FFL_CLUB_SEASON = gql`
               id
               club { id name }
             }
+            statsAll: stats(method: MEAN) {
+              goals kicks handballs marks tackles hitouts
+            }
+            statsLast3: stats(lastN: 3, method: MEAN) {
+              goals kicks handballs marks tackles hitouts
+            }
           }
           fromRoundId
           toRoundId

--- a/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
+++ b/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
@@ -1,10 +1,12 @@
 <template>
-  <div class="relative inline-block" @mouseenter="onEnter" @mouseleave="show = false">
+  <div ref="wrap" class="relative inline-block" @mouseenter="onEnter" @mouseleave="show = false">
     <slot />
     <Transition name="fade">
       <div
         v-if="show && aflPlayerSeasonId"
-        class="absolute z-50 left-0 top-full mt-1.5 w-96 rounded-2xl border border-border bg-surface shadow-lg pointer-events-none"
+        class="absolute z-50 left-0 w-96 rounded-2xl border border-border bg-surface shadow-lg pointer-events-none overflow-hidden"
+        :class="placeAbove ? 'bottom-full mb-1.5' : 'top-full mt-1.5'"
+        :style="maxH ? { maxHeight: `${maxH}px` } : {}"
       >
         <div v-if="loading" class="px-4 py-3 text-xs text-text-faint">Loading...</div>
         <template v-else-if="data">
@@ -81,6 +83,10 @@ const props = defineProps<{
 }>()
 
 const show = ref(false)
+const wrap = ref<HTMLElement | null>(null)
+// Open the card on whichever side of the trigger has more room, capped to that space.
+const placeAbove = ref(false)
+const maxH = ref<number | null>(null)
 
 const { result: data, loading } = useQuery(
   GET_PLAYER_STATS_CARD,
@@ -89,7 +95,15 @@ const { result: data, loading } = useQuery(
 )
 
 function onEnter() {
-  if (props.aflPlayerSeasonId) show.value = true
+  if (!props.aflPlayerSeasonId) return
+  const rect = wrap.value?.getBoundingClientRect()
+  if (rect) {
+    const below = window.innerHeight - rect.bottom
+    const above = rect.top
+    placeAbove.value = below < 440 && above > below
+    maxH.value = Math.max(160, (placeAbove.value ? above : below) - 24)
+  }
+  show.value = true
 }
 
 const cardCols = [...statCols, { key: 'star', label: '★' }] as const

--- a/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
+++ b/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
@@ -43,7 +43,7 @@
                     :key="col.key"
                     class="text-right py-1 px-2 whitespace-nowrap"
                     :class="col.key === 'star' ? 'text-yellow-400' : ''"
-                  ><span v-if="lastNTrend(col.key) === 'up'" class="text-[10px] font-normal text-green-400">↑</span><span v-else-if="lastNTrend(col.key) === 'down'" class="text-[10px] font-normal text-red-400">↓</span>{{ fmt(statOf(lastN, col.key)) }}</td>
+                  ><span v-if="lastNTrend(col.key) === 'up'" class="text-[10px] font-normal text-green-400 mr-0.5">↑</span><span v-else-if="lastNTrend(col.key) === 'down'" class="text-[10px] font-normal text-red-400 mr-0.5">↓</span>{{ fmt(statOf(lastN, col.key)) }}</td>
                 </tr>
                 <tr v-if="roundRows.length">
                   <td :colspan="cardCols.length + 1"><div class="h-px bg-border-subtle my-1" /></td>

--- a/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
+++ b/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
@@ -8,44 +8,52 @@
       >
         <div v-if="loading" class="px-4 py-3 text-xs text-text-faint">Loading...</div>
         <template v-else-if="data">
-          <div class="px-4 pt-3 pb-3">
-            <div class="flex items-center gap-2 mb-3">
-              <span class="text-sm font-medium text-text">{{ name }}</span>
-              <span v-if="aflStatus === 'bye'" class="text-xs rounded px-1.5 py-0.5 bg-violet-500/15 text-violet-400">Bye</span>
-            </div>
+          <div class="px-4 py-3">
             <table class="w-full tabular-nums text-xs">
               <thead>
                 <tr class="text-text-faint">
                   <th class="text-left font-normal pb-2 pr-4"></th>
-                  <th class="text-right font-normal pb-2 px-2">G</th>
-                  <th class="text-right font-normal pb-2 px-2">K</th>
-                  <th class="text-right font-normal pb-2 px-2">H</th>
-                  <th class="text-right font-normal pb-2 px-2">M</th>
-                  <th class="text-right font-normal pb-2 px-2">T</th>
-                  <th class="text-right font-normal pb-2 px-2">R</th>
-                  <th class="text-right font-normal pb-2 pl-4 text-yellow-400/70">★</th>
+                  <th
+                    v-for="col in cardCols"
+                    :key="col.key"
+                    class="text-right font-normal pb-2 px-2"
+                    :class="col.key === 'star' ? 'text-yellow-400/70' : ''"
+                  >{{ col.label }}</th>
                 </tr>
               </thead>
               <tbody>
-                <tr v-if="data.aflPlayerSeason?.seasonAvg" class="text-text-muted">
-                  <td class="text-text-faint py-1.5 pr-4">Season</td>
-                  <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.goals) }}</td>
-                  <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.kicks) }}</td>
-                  <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.handballs) }}</td>
-                  <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.marks) }}</td>
-                  <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.tackles) }}</td>
-                  <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.hitouts) }}</td>
-                  <td class="text-right py-1.5 pl-4 text-yellow-400/70">{{ fmt(starScore(data.aflPlayerSeason.seasonAvg)) }}</td>
+                <tr v-if="lastN" class="text-text font-medium">
+                  <td class="text-text-faint font-normal py-1 pr-4 whitespace-nowrap">Last {{ LAST_N }}</td>
+                  <td
+                    v-for="col in cardCols"
+                    :key="col.key"
+                    class="text-right py-1 px-2"
+                    :class="up(statOf(lastN, col.key), seasonAvg ? statOf(seasonAvg, col.key) : undefined) || (col.key === 'star' ? 'text-yellow-400' : '')"
+                  >{{ fmt(statOf(lastN, col.key)) }}</td>
                 </tr>
-                <tr v-if="data.aflPlayerSeason?.lastN" class="text-text font-medium">
-                  <td class="text-text-faint font-normal py-1.5 pr-4">Last {{ LAST_N }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.goals, data.aflPlayerSeason.seasonAvg?.goals)">{{ fmt(data.aflPlayerSeason.lastN.goals) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.kicks, data.aflPlayerSeason.seasonAvg?.kicks)">{{ fmt(data.aflPlayerSeason.lastN.kicks) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.handballs, data.aflPlayerSeason.seasonAvg?.handballs)">{{ fmt(data.aflPlayerSeason.lastN.handballs) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.marks, data.aflPlayerSeason.seasonAvg?.marks)">{{ fmt(data.aflPlayerSeason.lastN.marks) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.tackles, data.aflPlayerSeason.seasonAvg?.tackles)">{{ fmt(data.aflPlayerSeason.lastN.tackles) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.hitouts, data.aflPlayerSeason.seasonAvg?.hitouts)">{{ fmt(data.aflPlayerSeason.lastN.hitouts) }}</td>
-                  <td class="text-right py-1.5 pl-4" :class="up(starScore(data.aflPlayerSeason.lastN), data.aflPlayerSeason.seasonAvg ? starScore(data.aflPlayerSeason.seasonAvg) : undefined) || 'text-yellow-400'">{{ fmt(starScore(data.aflPlayerSeason.lastN)) }}</td>
+                <tr v-if="seasonAvg" class="text-text-muted">
+                  <td class="text-text-faint py-1 pr-4 whitespace-nowrap">Season ({{ seasonAvg.games }})</td>
+                  <td
+                    v-for="col in cardCols"
+                    :key="col.key"
+                    class="text-right py-1 px-2"
+                    :class="col.key === 'star' ? 'text-yellow-400/70' : ''"
+                  >{{ fmt(statOf(seasonAvg, col.key)) }}</td>
+                </tr>
+                <tr v-if="roundRows.length">
+                  <td :colspan="cardCols.length + 1"><div class="h-px bg-border-subtle my-1" /></td>
+                </tr>
+                <tr v-for="m in roundRows" :key="m.id" class="text-text-muted">
+                  <td class="text-text-faint py-0.5 pr-4 whitespace-nowrap">{{ m.clubMatch.match.round.name }}</td>
+                  <template v-if="m.status !== 'dnp'">
+                    <td
+                      v-for="col in cardCols"
+                      :key="col.key"
+                      class="text-right py-0.5 px-2"
+                      :style="roundHeat(m, col.key)"
+                    >{{ statOf(m, col.key) }}</td>
+                  </template>
+                  <td v-else :colspan="cardCols.length" class="text-right py-0.5 px-2 text-text-faint">DNP</td>
                 </tr>
               </tbody>
             </table>
@@ -57,10 +65,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_PLAYER_STATS_CARD } from '../api/queries'
-import { starScore, LAST_N } from '../utils/playerStats'
+import { starScore, statCols, LAST_N, type StatSummary } from '../utils/playerStats'
+import { heatStyle } from '@/utils/heatmap'
+import { useTheme } from '@/composables/useTheme'
 
 const props = defineProps<{
   name: string
@@ -82,7 +92,52 @@ function onEnter() {
   if (props.aflPlayerSeasonId) show.value = true
 }
 
+const cardCols = [...statCols, { key: 'star', label: '★' }] as const
+type CardKey = typeof cardCols[number]['key']
 
+interface CardMatch {
+  id: string
+  status: string | null
+  goals: number
+  kicks: number
+  handballs: number
+  marks: number
+  tackles: number
+  hitouts: number
+  clubMatch: { match: { id: string; round: { id: string; name: string } } }
+}
+
+const seasonAvg = computed<(StatSummary & { games: number }) | null>(() => data.value?.aflPlayerSeason?.seasonAvg ?? null)
+const lastN = computed<StatSummary | null>(() => data.value?.aflPlayerSeason?.lastN ?? null)
+
+// Most recent round first.
+const roundRows = computed<CardMatch[]>(() => {
+  const ms: CardMatch[] = data.value?.aflPlayerSeason?.matches ?? []
+  return [...ms].sort((a, b) => parseInt(b.clubMatch.match.round.id) - parseInt(a.clubMatch.match.round.id))
+})
+
+function statOf(s: StatSummary, key: CardKey): number {
+  return key === 'star' ? starScore(s) : s[key]
+}
+
+const { isDark } = useTheme()
+
+// Per-column heatmap across the played round rows.
+const roundHeatRanges = computed(() => {
+  const played = roundRows.value.filter(m => m.status !== 'dnp')
+  const range = {} as Record<CardKey, { min: number; max: number }>
+  for (const col of cardCols) {
+    const vals = played.map(m => statOf(m, col.key))
+    if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  return range
+})
+
+function roundHeat(m: CardMatch, key: CardKey): Record<string, string> {
+  const r = roundHeatRanges.value[key]
+  if (!r) return {}
+  return heatStyle(statOf(m, key), r.min, r.max, isDark.value)
+}
 
 function fmt(v: number): string {
   return v % 1 === 0 ? String(v) : v.toFixed(1)

--- a/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
+++ b/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
@@ -1,12 +1,14 @@
 <template>
   <div ref="wrap" class="relative inline-block" @mouseenter="onEnter" @mouseleave="show = false">
     <slot />
+    <!-- Teleported to body + fixed positioning so the card escapes both
+         overflow-clipping ancestors (overflow-x-auto wrappers) and stacking
+         contexts (sticky table columns). -->
+    <Teleport to="body">
     <Transition name="fade">
-      <!-- Fixed positioning so the card escapes any overflow-clipping ancestor
-           (e.g. overflow-x-auto table wrappers). -->
       <div
         v-if="show && aflPlayerSeasonId"
-        class="fixed z-50 w-96 rounded-2xl border border-border bg-surface shadow-lg pointer-events-none overflow-hidden"
+        class="fixed z-50 w-max min-w-72 rounded-2xl border border-border bg-surface shadow-lg pointer-events-none overflow-hidden"
         :style="cardStyle"
       >
         <div v-if="loading" class="px-4 py-3 text-xs text-text-faint">Loading...</div>
@@ -25,15 +27,6 @@
                 </tr>
               </thead>
               <tbody>
-                <tr v-if="lastN" class="text-text font-medium">
-                  <td class="text-text-faint font-normal py-1 pr-4 whitespace-nowrap">Last {{ LAST_N }}</td>
-                  <td
-                    v-for="col in cardCols"
-                    :key="col.key"
-                    class="text-right py-1 px-2"
-                    :class="up(statOf(lastN, col.key), seasonAvg ? statOf(seasonAvg, col.key) : undefined) || (col.key === 'star' ? 'text-yellow-400' : '')"
-                  >{{ fmt(statOf(lastN, col.key)) }}</td>
-                </tr>
                 <tr v-if="seasonAvg" class="text-text-muted">
                   <td class="text-text-faint py-1 pr-4 whitespace-nowrap">Season ({{ seasonAvg.games }})</td>
                   <td
@@ -42,6 +35,15 @@
                     class="text-right py-1 px-2"
                     :class="col.key === 'star' ? 'text-yellow-400/70' : ''"
                   >{{ fmt(statOf(seasonAvg, col.key)) }}</td>
+                </tr>
+                <tr v-if="lastN" class="text-text font-medium">
+                  <td class="text-text-faint font-normal py-1 pr-4 whitespace-nowrap">Last {{ LAST_N }}</td>
+                  <td
+                    v-for="col in cardCols"
+                    :key="col.key"
+                    class="text-right py-1 px-2 whitespace-nowrap"
+                    :class="col.key === 'star' ? 'text-yellow-400' : ''"
+                  ><span v-if="lastNTrend(col.key) === 'up'" class="text-[10px] font-normal text-green-400">↑</span><span v-else-if="lastNTrend(col.key) === 'down'" class="text-[10px] font-normal text-red-400">↓</span>{{ fmt(statOf(lastN, col.key)) }}</td>
                 </tr>
                 <tr v-if="roundRows.length">
                   <td :colspan="cardCols.length + 1"><div class="h-px bg-border-subtle my-1" /></td>
@@ -64,6 +66,7 @@
         </template>
       </div>
     </Transition>
+    </Teleport>
   </div>
 </template>
 
@@ -71,7 +74,7 @@
 import { ref, computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_PLAYER_STATS_CARD } from '../api/queries'
-import { starScore, statCols, LAST_N, type StatSummary } from '../utils/playerStats'
+import { starScore, statCols, trendDir, LAST_N, type StatSummary } from '../utils/playerStats'
 import { heatStyle } from '@/utils/heatmap'
 import { useTheme } from '@/composables/useTheme'
 
@@ -89,7 +92,9 @@ const wrap = ref<HTMLElement | null>(null)
 // trigger has more room, capped to that space, clamped inside the viewport.
 const cardStyle = ref<Record<string, string>>({})
 
-const CARD_W = 384 // w-96
+// Width estimate for horizontal clamping — the card sizes to its content
+// (w-max), so this errs generous to keep the right edge on screen.
+const CARD_W = 448
 
 const { result: data, loading } = useQuery(
   GET_PLAYER_STATS_CARD,
@@ -108,6 +113,7 @@ function onEnter() {
     const left = Math.max(8, Math.min(rect.left, window.innerWidth - CARD_W - 8))
     cardStyle.value = {
       left: `${left}px`,
+      maxWidth: `${window.innerWidth - left - 8}px`,
       maxHeight: `${maxH}px`,
       ...(placeAbove
         ? { bottom: `${window.innerHeight - rect.top + 6}px` }
@@ -164,12 +170,14 @@ function roundHeat(m: CardMatch, key: CardKey): Record<string, string> {
   return heatStyle(statOf(m, key), r.min, r.max, isDark.value)
 }
 
-function fmt(v: number): string {
-  return v % 1 === 0 ? String(v) : v.toFixed(1)
+// Shared trend semantics (utils/playerStats) for the Last N row's arrows.
+function lastNTrend(key: CardKey): 'up' | 'down' | null {
+  if (!lastN.value || !seasonAvg.value) return null
+  return trendDir(statOf(lastN.value, key), statOf(seasonAvg.value, key))
 }
 
-function up(a: number, b: number | undefined): string {
-  return b !== undefined && a > b ? 'text-green-400' : ''
+function fmt(v: number): string {
+  return v % 1 === 0 ? String(v) : v.toFixed(1)
 }
 </script>
 

--- a/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
+++ b/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
@@ -37,15 +37,15 @@
                   <td class="text-right py-1.5 px-2">{{ fmt(data.aflPlayerSeason.seasonAvg.hitouts) }}</td>
                   <td class="text-right py-1.5 pl-4 text-yellow-400/70">{{ fmt(starScore(data.aflPlayerSeason.seasonAvg)) }}</td>
                 </tr>
-                <tr v-if="data.aflPlayerSeason?.last3" class="text-text font-medium">
-                  <td class="text-text-faint font-normal py-1.5 pr-4">Last 3</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.last3.goals, data.aflPlayerSeason.seasonAvg?.goals)">{{ fmt(data.aflPlayerSeason.last3.goals) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.last3.kicks, data.aflPlayerSeason.seasonAvg?.kicks)">{{ fmt(data.aflPlayerSeason.last3.kicks) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.last3.handballs, data.aflPlayerSeason.seasonAvg?.handballs)">{{ fmt(data.aflPlayerSeason.last3.handballs) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.last3.marks, data.aflPlayerSeason.seasonAvg?.marks)">{{ fmt(data.aflPlayerSeason.last3.marks) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.last3.tackles, data.aflPlayerSeason.seasonAvg?.tackles)">{{ fmt(data.aflPlayerSeason.last3.tackles) }}</td>
-                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.last3.hitouts, data.aflPlayerSeason.seasonAvg?.hitouts)">{{ fmt(data.aflPlayerSeason.last3.hitouts) }}</td>
-                  <td class="text-right py-1.5 pl-4" :class="up(starScore(data.aflPlayerSeason.last3), data.aflPlayerSeason.seasonAvg ? starScore(data.aflPlayerSeason.seasonAvg) : undefined) || 'text-yellow-400'">{{ fmt(starScore(data.aflPlayerSeason.last3)) }}</td>
+                <tr v-if="data.aflPlayerSeason?.lastN" class="text-text font-medium">
+                  <td class="text-text-faint font-normal py-1.5 pr-4">Last {{ LAST_N }}</td>
+                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.goals, data.aflPlayerSeason.seasonAvg?.goals)">{{ fmt(data.aflPlayerSeason.lastN.goals) }}</td>
+                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.kicks, data.aflPlayerSeason.seasonAvg?.kicks)">{{ fmt(data.aflPlayerSeason.lastN.kicks) }}</td>
+                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.handballs, data.aflPlayerSeason.seasonAvg?.handballs)">{{ fmt(data.aflPlayerSeason.lastN.handballs) }}</td>
+                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.marks, data.aflPlayerSeason.seasonAvg?.marks)">{{ fmt(data.aflPlayerSeason.lastN.marks) }}</td>
+                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.tackles, data.aflPlayerSeason.seasonAvg?.tackles)">{{ fmt(data.aflPlayerSeason.lastN.tackles) }}</td>
+                  <td class="text-right py-1.5 px-2" :class="up(data.aflPlayerSeason.lastN.hitouts, data.aflPlayerSeason.seasonAvg?.hitouts)">{{ fmt(data.aflPlayerSeason.lastN.hitouts) }}</td>
+                  <td class="text-right py-1.5 pl-4" :class="up(starScore(data.aflPlayerSeason.lastN), data.aflPlayerSeason.seasonAvg ? starScore(data.aflPlayerSeason.seasonAvg) : undefined) || 'text-yellow-400'">{{ fmt(starScore(data.aflPlayerSeason.lastN)) }}</td>
                 </tr>
               </tbody>
             </table>
@@ -60,6 +60,7 @@
 import { ref } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_PLAYER_STATS_CARD } from '../api/queries'
+import { starScore, LAST_N } from '../utils/playerStats'
 
 const props = defineProps<{
   name: string
@@ -82,11 +83,6 @@ function onEnter() {
 }
 
 
-interface StatRow { goals: number; kicks: number; handballs: number; marks: number; tackles: number; hitouts: number }
-
-function starScore(s: StatRow): number {
-  return s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4
-}
 
 function fmt(v: number): string {
   return v % 1 === 0 ? String(v) : v.toFixed(1)

--- a/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
+++ b/frontend/web/src/features/ffl/components/PlayerStatsCard.vue
@@ -2,11 +2,12 @@
   <div ref="wrap" class="relative inline-block" @mouseenter="onEnter" @mouseleave="show = false">
     <slot />
     <Transition name="fade">
+      <!-- Fixed positioning so the card escapes any overflow-clipping ancestor
+           (e.g. overflow-x-auto table wrappers). -->
       <div
         v-if="show && aflPlayerSeasonId"
-        class="absolute z-50 left-0 w-96 rounded-2xl border border-border bg-surface shadow-lg pointer-events-none overflow-hidden"
-        :class="placeAbove ? 'bottom-full mb-1.5' : 'top-full mt-1.5'"
-        :style="maxH ? { maxHeight: `${maxH}px` } : {}"
+        class="fixed z-50 w-96 rounded-2xl border border-border bg-surface shadow-lg pointer-events-none overflow-hidden"
+        :style="cardStyle"
       >
         <div v-if="loading" class="px-4 py-3 text-xs text-text-faint">Loading...</div>
         <template v-else-if="data">
@@ -84,9 +85,11 @@ const props = defineProps<{
 
 const show = ref(false)
 const wrap = ref<HTMLElement | null>(null)
-// Open the card on whichever side of the trigger has more room, capped to that space.
-const placeAbove = ref(false)
-const maxH = ref<number | null>(null)
+// Viewport-fixed placement, computed on hover: open on whichever side of the
+// trigger has more room, capped to that space, clamped inside the viewport.
+const cardStyle = ref<Record<string, string>>({})
+
+const CARD_W = 384 // w-96
 
 const { result: data, loading } = useQuery(
   GET_PLAYER_STATS_CARD,
@@ -100,8 +103,16 @@ function onEnter() {
   if (rect) {
     const below = window.innerHeight - rect.bottom
     const above = rect.top
-    placeAbove.value = below < 440 && above > below
-    maxH.value = Math.max(160, (placeAbove.value ? above : below) - 24)
+    const placeAbove = below < 440 && above > below
+    const maxH = Math.max(160, (placeAbove ? above : below) - 24)
+    const left = Math.max(8, Math.min(rect.left, window.innerWidth - CARD_W - 8))
+    cardStyle.value = {
+      left: `${left}px`,
+      maxHeight: `${maxH}px`,
+      ...(placeAbove
+        ? { bottom: `${window.innerHeight - rect.top + 6}px` }
+        : { top: `${rect.bottom + 6}px` }),
+    }
   }
   show.value = true
 }

--- a/frontend/web/src/features/ffl/components/SquadTable.vue
+++ b/frontend/web/src/features/ffl/components/SquadTable.vue
@@ -89,14 +89,6 @@
           </tr>
         </template>
       </tbody>
-      <tfoot>
-        <tr class="border-t border-border font-semibold">
-          <td class="py-2 pr-4">Total</td>
-          <td></td>
-          <td></td>
-          <td class="py-2 px-2 text-right tabular-nums">{{ total }}</td>
-        </tr>
-      </tfoot>
     </table>
   </div>
 </template>
@@ -266,9 +258,6 @@ function benchScoreDisplay(pm: PlayerMatch): string {
   return positions.map(pos => { const s = benchPositionScore(pm, pos); return s !== null ? String(s) : '?' }).join('/')
 }
 
-const total = computed(() =>
-  props.playerMatches.reduce((sum, pm) => sum + (pmShowScore(pm) ? pm.score : 0), 0)
-)
 </script>
 
 <style scoped>

--- a/frontend/web/src/features/ffl/components/SquadTable.vue
+++ b/frontend/web/src/features/ffl/components/SquadTable.vue
@@ -26,14 +26,14 @@
               <div>
                 <router-link v-if="pmAflPlayerSeasonId(pm)" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pmAflPlayerSeasonId(pm) } }" class="font-medium hover:text-text-muted transition-colors" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pm.player.aflPlayer.name }}</router-link>
                 <span v-else class="font-medium" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pm.player.aflPlayer.name }}</span>
-                <router-link v-if="pmAflClub(pm) && pmAflClubSeasonId(pm)" :to="{ name: 'afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(pm) } }" class="ml-2 text-xs text-text-muted hover:text-text transition-colors" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pmAflClub(pm) }}</router-link>
+                <router-link v-if="pmAflClub(pm) && pmAflClubSeasonId(pm)" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(pm) } }" class="ml-2 text-xs text-text-muted hover:text-text transition-colors" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pmAflClub(pm) }}</router-link>
                 <span v-else-if="pmAflClub(pm)" class="ml-2 text-xs text-text-muted" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pmAflClub(pm) }}</span>
               </div>
               <div v-if="coveringMap.get(pm.id)" class="text-sky-400">
                 <span class="text-xs mr-1">↑</span>
                 <router-link v-if="pmAflPlayerSeasonId(coveringMap.get(pm.id)!)" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pmAflPlayerSeasonId(coveringMap.get(pm.id)!) } }" class="font-medium hover:opacity-75 transition-opacity">{{ coveringMap.get(pm.id)!.player.aflPlayer.name }}</router-link>
                 <span v-else class="font-medium">{{ coveringMap.get(pm.id)!.player.aflPlayer.name }}</span>
-                <router-link v-if="pmAflClub(coveringMap.get(pm.id)!) && pmAflClubSeasonId(coveringMap.get(pm.id)!)" :to="{ name: 'afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(coveringMap.get(pm.id)!) } }" class="ml-2 text-xs hover:opacity-75 transition-opacity">{{ pmAflClub(coveringMap.get(pm.id)!) }}</router-link>
+                <router-link v-if="pmAflClub(coveringMap.get(pm.id)!) && pmAflClubSeasonId(coveringMap.get(pm.id)!)" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(coveringMap.get(pm.id)!) } }" class="ml-2 text-xs hover:opacity-75 transition-opacity">{{ pmAflClub(coveringMap.get(pm.id)!) }}</router-link>
                 <span v-else-if="pmAflClub(coveringMap.get(pm.id)!)" class="ml-2 text-xs">{{ pmAflClub(coveringMap.get(pm.id)!) }}</span>
               </div>
             </td>
@@ -62,7 +62,7 @@
               <span v-if="coveredStarterMap.get(pm.id)" class="text-xs mr-1 text-sky-400">↑</span>
               <router-link v-if="pmAflPlayerSeasonId(pm)" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pmAflPlayerSeasonId(pm) } }" class="font-medium hover:opacity-75 transition-opacity" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pm.player.aflPlayer.name }}</router-link>
               <span v-else class="font-medium" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pm.player.aflPlayer.name }}</span>
-              <router-link v-if="pmAflClub(pm) && pmAflClubSeasonId(pm)" :to="{ name: 'afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(pm) } }" class="ml-2 text-xs hover:opacity-75 transition-opacity" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pmAflClub(pm) }}</router-link>
+              <router-link v-if="pmAflClub(pm) && pmAflClubSeasonId(pm)" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(pm) } }" class="ml-2 text-xs hover:opacity-75 transition-opacity" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pmAflClub(pm) }}</router-link>
               <span v-else-if="pmAflClub(pm)" class="ml-2 text-xs" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pmAflClub(pm) }}</span>
             </td>
             <td class="py-2 px-2">

--- a/frontend/web/src/features/ffl/components/SquadTable.vue
+++ b/frontend/web/src/features/ffl/components/SquadTable.vue
@@ -20,7 +20,9 @@
           <tr
             v-for="pm in group.players"
             :key="pm.id"
+            :id="`pm-${pm.id}`"
             class="border-b border-border-subtle hover:bg-surface-hover"
+            :class="{ 'highlight-pulse': pm.id === props.highlightPmId }"
           >
             <td class="py-2 pr-4">
               <div>
@@ -56,7 +58,9 @@
           <tr
             v-for="pm in bench"
             :key="pm.id"
+            :id="`pm-${pm.id}`"
             class="border-b border-border-subtle hover:bg-surface-hover"
+            :class="{ 'highlight-pulse': pm.id === props.highlightPmId }"
           >
             <td class="py-2 pr-4">
               <span v-if="coveredStarterMap.get(pm.id)" class="text-xs mr-1 text-sky-400">↑</span>
@@ -127,6 +131,7 @@ interface PlayerMatch {
 
 const props = defineProps<{
   playerMatches: PlayerMatch[]
+  highlightPmId?: string | null
 }>()
 
 const POSITION_ORDER = ['goals', 'kicks', 'handballs', 'marks', 'tackles', 'hitouts', 'star'] as const
@@ -265,3 +270,13 @@ const total = computed(() =>
   props.playerMatches.reduce((sum, pm) => sum + (pmShowScore(pm) ? pm.score : 0), 0)
 )
 </script>
+
+<style scoped>
+@keyframes highlight-pulse {
+  0%, 30% { background-color: rgb(34 197 94 / 0.3); }
+  100% { background-color: transparent; }
+}
+.highlight-pulse {
+  animation: highlight-pulse 7.3s ease-out forwards;
+}
+</style>

--- a/frontend/web/src/features/ffl/components/SquadTable.vue
+++ b/frontend/web/src/features/ffl/components/SquadTable.vue
@@ -24,13 +24,17 @@
           >
             <td class="py-2 pr-4">
               <div>
-                <span class="font-medium" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pm.player.aflPlayer.name }}</span>
-                <span v-if="pmAflClub(pm)" class="ml-2 text-xs text-text-muted" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pmAflClub(pm) }}</span>
+                <router-link v-if="pmAflPlayerSeasonId(pm)" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pmAflPlayerSeasonId(pm) } }" class="font-medium hover:text-text-muted transition-colors" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pm.player.aflPlayer.name }}</router-link>
+                <span v-else class="font-medium" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pm.player.aflPlayer.name }}</span>
+                <router-link v-if="pmAflClub(pm) && pmAflClubSeasonId(pm)" :to="{ name: 'afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(pm) } }" class="ml-2 text-xs text-text-muted hover:text-text transition-colors" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pmAflClub(pm) }}</router-link>
+                <span v-else-if="pmAflClub(pm)" class="ml-2 text-xs text-text-muted" :class="{ 'line-through': coveringMap.get(pm.id) }">{{ pmAflClub(pm) }}</span>
               </div>
               <div v-if="coveringMap.get(pm.id)" class="text-sky-400">
                 <span class="text-xs mr-1">↑</span>
-                <span class="font-medium">{{ coveringMap.get(pm.id)!.player.aflPlayer.name }}</span>
-                <span v-if="pmAflClub(coveringMap.get(pm.id)!)" class="ml-2 text-xs">{{ pmAflClub(coveringMap.get(pm.id)!) }}</span>
+                <router-link v-if="pmAflPlayerSeasonId(coveringMap.get(pm.id)!)" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pmAflPlayerSeasonId(coveringMap.get(pm.id)!) } }" class="font-medium hover:opacity-75 transition-opacity">{{ coveringMap.get(pm.id)!.player.aflPlayer.name }}</router-link>
+                <span v-else class="font-medium">{{ coveringMap.get(pm.id)!.player.aflPlayer.name }}</span>
+                <router-link v-if="pmAflClub(coveringMap.get(pm.id)!) && pmAflClubSeasonId(coveringMap.get(pm.id)!)" :to="{ name: 'afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(coveringMap.get(pm.id)!) } }" class="ml-2 text-xs hover:opacity-75 transition-opacity">{{ pmAflClub(coveringMap.get(pm.id)!) }}</router-link>
+                <span v-else-if="pmAflClub(coveringMap.get(pm.id)!)" class="ml-2 text-xs">{{ pmAflClub(coveringMap.get(pm.id)!) }}</span>
               </div>
             </td>
             <td class="py-2 px-2"></td>
@@ -56,15 +60,10 @@
           >
             <td class="py-2 pr-4">
               <span v-if="coveredStarterMap.get(pm.id)" class="text-xs mr-1 text-sky-400">↑</span>
-              <span
-                class="font-medium"
-                :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'"
-              >{{ pm.player.aflPlayer.name }}</span>
-              <span
-                v-if="pmAflClub(pm)"
-                class="ml-2 text-xs"
-                :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'"
-              >{{ pmAflClub(pm) }}</span>
+              <router-link v-if="pmAflPlayerSeasonId(pm)" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: pmAflPlayerSeasonId(pm) } }" class="font-medium hover:opacity-75 transition-opacity" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pm.player.aflPlayer.name }}</router-link>
+              <span v-else class="font-medium" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pm.player.aflPlayer.name }}</span>
+              <router-link v-if="pmAflClub(pm) && pmAflClubSeasonId(pm)" :to="{ name: 'afl-club-season', params: { clubSeasonId: pmAflClubSeasonId(pm) } }" class="ml-2 text-xs hover:opacity-75 transition-opacity" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pmAflClub(pm) }}</router-link>
+              <span v-else-if="pmAflClub(pm)" class="ml-2 text-xs" :class="coveredStarterMap.get(pm.id) ? 'text-sky-400' : 'text-text-muted'">{{ pmAflClub(pm) }}</span>
             </td>
             <td class="py-2 px-2">
               <div class="flex items-center gap-1">
@@ -115,7 +114,8 @@ interface PlayerMatch {
   score: number
   playerSeason?: {
     aflPlayerSeason?: {
-      clubSeason?: { club?: { name: string } | null } | null
+      id?: string | null
+      clubSeason?: { id?: string | null; club?: { name: string } | null } | null
       stats?: { goals: number; kicks: number; handballs: number; marks: number; tackles: number; hitouts: number; games: number } | null
     } | null
   } | null
@@ -193,6 +193,14 @@ function starterFormula(pm: PlayerMatch): string | null {
 
 function pmAflClub(pm: PlayerMatch): string | null {
   return pm.playerSeason?.aflPlayerSeason?.clubSeason?.club?.name ?? null
+}
+
+function pmAflPlayerSeasonId(pm: PlayerMatch): string | null {
+  return pm.playerSeason?.aflPlayerSeason?.id ?? null
+}
+
+function pmAflClubSeasonId(pm: PlayerMatch): string | null {
+  return pm.playerSeason?.aflPlayerSeason?.clubSeason?.id ?? null
 }
 
 function pmStatus(pm: PlayerMatch): string | null {

--- a/frontend/web/src/features/ffl/components/StatCell.vue
+++ b/frontend/web/src/features/ffl/components/StatCell.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flex items-end justify-end gap-1">
+    <span class="text-xs" :style="avgStyle">{{ fmtStat(avg) }}</span>
+    <template v-if="last3 != null">
+      <span v-if="trendIndicator" class="text-[10px]" :class="trendIndicatorCls">{{ trendIndicator }}</span>
+      <span :style="last3Style">{{ fmtStat(last3) }}</span>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { fmtStat } from '../utils/playerStats'
+
+const props = defineProps<{
+  avg: number | null | undefined
+  last3: number | null | undefined
+  avgStyle?: Record<string, string>
+  last3Style?: Record<string, string>
+}>()
+
+const trendIndicator = computed(() => {
+  if (props.last3 == null || props.avg == null) return ''
+  if (props.last3 === props.avg) return '='
+  return props.last3 > props.avg ? '↑' : '↓'
+})
+
+const trendIndicatorCls = computed(() => {
+  if (props.last3 == null || props.avg == null) return ''
+  if (props.last3 === props.avg) return 'text-blue-400'
+  return props.last3 > props.avg ? 'text-green-400' : 'text-red-400'
+})
+</script>

--- a/frontend/web/src/features/ffl/components/StatCell.vue
+++ b/frontend/web/src/features/ffl/components/StatCell.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
   last3Style?: Record<string, string>
 }>()
 
-// Shared trend semantics (utils/playerStats): '=' when within thresholds.
+// Shared trend semantics (utils/playerStats): '~' when within thresholds.
 const trend = computed(() => {
   if (props.last3 == null || props.avg == null) return null
   return trendDir(props.last3, props.avg)
@@ -29,7 +29,7 @@ const trendIndicator = computed(() => {
   if (props.last3 == null || props.avg == null) return ''
   if (trend.value === 'up') return '↑'
   if (trend.value === 'down') return '↓'
-  return '='
+  return '~'
 })
 
 const trendIndicatorCls = computed(() => {

--- a/frontend/web/src/features/ffl/components/StatCell.vue
+++ b/frontend/web/src/features/ffl/components/StatCell.vue
@@ -10,7 +10,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { fmtStat } from '../utils/playerStats'
+import { fmtStat, trendDir } from '../utils/playerStats'
 
 const props = defineProps<{
   avg: number | null | undefined
@@ -19,15 +19,22 @@ const props = defineProps<{
   last3Style?: Record<string, string>
 }>()
 
+// Shared trend semantics (utils/playerStats): '=' when within thresholds.
+const trend = computed(() => {
+  if (props.last3 == null || props.avg == null) return null
+  return trendDir(props.last3, props.avg)
+})
+
 const trendIndicator = computed(() => {
   if (props.last3 == null || props.avg == null) return ''
-  if (props.last3 === props.avg) return '='
-  return props.last3 > props.avg ? '↑' : '↓'
+  if (trend.value === 'up') return '↑'
+  if (trend.value === 'down') return '↓'
+  return '='
 })
 
 const trendIndicatorCls = computed(() => {
-  if (props.last3 == null || props.avg == null) return ''
-  if (props.last3 === props.avg) return 'text-blue-400'
-  return props.last3 > props.avg ? 'text-green-400' : 'text-red-400'
+  if (trend.value === 'up') return 'text-green-400'
+  if (trend.value === 'down') return 'text-red-400'
+  return 'text-blue-400'
 })
 </script>

--- a/frontend/web/src/features/ffl/components/StatCell.vue
+++ b/frontend/web/src/features/ffl/components/StatCell.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex items-end justify-end gap-1">
-    <span class="text-xs" :style="avgStyle">{{ fmtStat(avg) }}</span>
+    <span :class="statSource === 'season' ? '' : 'text-xs'" :style="avgStyle">{{ fmtStat(avg) }}</span>
     <template v-if="last3 != null">
       <span v-if="trendIndicator" class="text-[10px]" :class="trendIndicatorCls">{{ trendIndicator }}</span>
-      <span :style="last3Style">{{ fmtStat(last3) }}</span>
+      <span :class="statSource === 'form' ? '' : 'text-xs'" :style="last3Style">{{ fmtStat(last3) }}</span>
     </template>
   </div>
 </template>
@@ -11,6 +11,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { fmtStat, trendDir } from '../utils/playerStats'
+import { useStatSource } from '../composables/useStatSource'
 
 const props = defineProps<{
   avg: number | null | undefined
@@ -18,6 +19,9 @@ const props = defineProps<{
   avgStyle?: Record<string, string>
   last3Style?: Record<string, string>
 }>()
+
+// The active source (global toggle) renders at full size, the other small.
+const { statSource } = useStatSource()
 
 // Shared trend semantics (utils/playerStats): '~' when within thresholds.
 const trend = computed(() => {

--- a/frontend/web/src/features/ffl/components/StatSourceToggle.vue
+++ b/frontend/web/src/features/ffl/components/StatSourceToggle.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="flex items-center gap-3">
+    <span
+      class="text-xs text-text-faint whitespace-nowrap"
+      :title="`↑/↓ = last ${LAST_N} form at least ${TREND_PCT * 100}% above/below season average`"
+    >
+      <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = Last {{ LAST_N }} form
+    </span>
+    <div class="flex items-center rounded border border-border overflow-hidden text-[10px] text-text-faint">
+      <button
+        class="px-1.5 py-0.5 transition-colors"
+        :class="statSource === 'season' ? 'bg-control text-text' : 'hover:text-text'"
+        title="Use season averages"
+        @click="setStatSource('season')"
+      >Season</button>
+      <button
+        class="px-1.5 py-0.5 transition-colors"
+        :class="statSource === 'form' ? 'bg-control text-text' : 'hover:text-text'"
+        :title="`Use last ${LAST_N} averages`"
+        @click="setStatSource('form')"
+      >Last {{ LAST_N }}</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { LAST_N, TREND_PCT } from '../utils/playerStats'
+import { useStatSource } from '../composables/useStatSource'
+
+const { statSource, setStatSource } = useStatSource()
+</script>

--- a/frontend/web/src/features/ffl/components/icons/IconFreeAgents.vue
+++ b/frontend/web/src/features/ffl/components/icons/IconFreeAgents.vue
@@ -1,0 +1,7 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="9" cy="7" r="3.5"/>
+    <path d="M2 21v-1a7 7 0 0 1 7-7h2"/>
+    <path d="M18 12v6M15 15h6"/>
+  </svg>
+</template>

--- a/frontend/web/src/features/ffl/components/icons/IconLock.vue
+++ b/frontend/web/src/features/ffl/components/icons/IconLock.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+    <path v-if="!open" d="M7 11V7a5 5 0 0 1 10 0v4"/>
+    <path v-else d="M7 11V7a5 5 0 0 1 9.9-1"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+defineProps<{ open?: boolean }>()
+</script>

--- a/frontend/web/src/features/ffl/components/icons/IconMenu.vue
+++ b/frontend/web/src/features/ffl/components/icons/IconMenu.vue
@@ -1,0 +1,7 @@
+<template>
+  <svg viewBox="0 0 14 14" fill="currentColor">
+    <circle cx="3" cy="7" r="1.1"/>
+    <circle cx="7" cy="7" r="1.1"/>
+    <circle cx="11" cy="7" r="1.1"/>
+  </svg>
+</template>

--- a/frontend/web/src/features/ffl/composables/useFflState.ts
+++ b/frontend/web/src/features/ffl/composables/useFflState.ts
@@ -1,4 +1,5 @@
 import { ref, readonly, computed } from 'vue'
+import { getCookie, setCookie } from '@/utils/cookie'
 
 const FFL_COOKIE = 'xffl_ffl'
 
@@ -6,17 +7,6 @@ interface FflState {
   seasonId: string
   roundId: string
   startDate: string
-}
-
-function getCookie(name: string): string {
-  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'))
-  return match ? decodeURIComponent(match[2]) : ''
-}
-
-function setCookie(name: string, value: string) {
-  const expires = new Date()
-  expires.setHours(24, 0, 0, 0)
-  document.cookie = `${name}=${encodeURIComponent(value)};expires=${expires.toUTCString()};path=/`
 }
 
 function readFflCookie(): FflState {

--- a/frontend/web/src/features/ffl/composables/useStatSource.ts
+++ b/frontend/web/src/features/ffl/composables/useStatSource.ts
@@ -1,0 +1,19 @@
+import { ref } from 'vue'
+import { getCookie, setCookie } from '@/utils/cookie'
+
+export type StatSource = 'form' | 'season'
+
+const COOKIE = 'xffl_stat_source'
+
+// Module-level singleton — one switch shared by every stats surface, so
+// flipping it on any page changes them all. Persisted across sessions.
+const statSource = ref<StatSource>(getCookie(COOKIE) === 'season' ? 'season' : 'form')
+
+function setStatSource(source: StatSource) {
+  statSource.value = source
+  setCookie(COOKIE, source, 365)
+}
+
+export function useStatSource() {
+  return { statSource, setStatSource }
+}

--- a/frontend/web/src/features/ffl/utils/bestTeam.test.ts
+++ b/frontend/web/src/features/ffl/utils/bestTeam.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { solveBestAssignment } from './bestTeam'
+
+// Total value of an assignment against its value matrix.
+function totalValue(values: number[][], assignment: number[]): number {
+  return assignment.reduce((sum, p, slot) => sum + (p >= 0 ? values[slot][p] : 0), 0)
+}
+
+// Exhaustive optimal total for small matrices — brute-force all permutations.
+function bruteForceBest(values: number[][]): number {
+  const nSlots = values.length
+  const nPlayers = values[0]?.length ?? 0
+  let best = 0
+  const used = new Array<boolean>(nPlayers).fill(false)
+  const walk = (slot: number, acc: number) => {
+    if (slot === nSlots) { best = Math.max(best, acc); return }
+    // leave slot empty only when players can run out
+    if (nPlayers < nSlots) walk(slot + 1, acc)
+    for (let p = 0; p < nPlayers; p++) {
+      if (used[p]) continue
+      used[p] = true
+      walk(slot + 1, acc + values[slot][p])
+      used[p] = false
+    }
+  }
+  walk(0, 0)
+  return best
+}
+
+describe('solveBestAssignment', () => {
+  it('assigns each slot its player in the trivial diagonal case', () => {
+    const values = [
+      [5, 0, 0],
+      [0, 5, 0],
+      [0, 0, 5],
+    ]
+    expect(solveBestAssignment(values)).toEqual([0, 1, 2])
+  })
+
+  it('uses each player at most once', () => {
+    const values = [
+      [9, 8],
+      [9, 1],
+    ]
+    const assignment = solveBestAssignment(values)
+    const used = assignment.filter(p => p >= 0)
+    expect(new Set(used).size).toBe(used.length)
+  })
+
+  it('beats greedy: the shared-best player goes where the alternative is worst', () => {
+    // Player 0 is best at both slots. Greedy gives slot 0 player 0 (10) and
+    // slot 1 player 1 (1) = 11. Optimal is player 1 on slot 0 (8) and player 0
+    // on slot 1 (9) = 17.
+    const values = [
+      [10, 8],
+      [9, 1],
+    ]
+    const assignment = solveBestAssignment(values)
+    expect(totalValue(values, assignment)).toBe(17)
+  })
+
+  it('matches brute force on a dense 4×6 matrix', () => {
+    const values = [
+      [7, 3, 9, 2, 4, 8],
+      [5, 8, 1, 9, 2, 3],
+      [6, 6, 6, 1, 9, 2],
+      [2, 9, 4, 8, 3, 7],
+    ]
+    const assignment = solveBestAssignment(values)
+    expect(totalValue(values, assignment)).toBe(bruteForceBest(values))
+  })
+
+  it('leaves slots empty when there are fewer players than slots, still optimally', () => {
+    const values = [
+      [9, 1],
+      [8, 7],
+      [1, 6],
+    ]
+    const assignment = solveBestAssignment(values)
+    expect(assignment.filter(p => p === -1)).toHaveLength(1)
+    expect(totalValue(values, assignment)).toBe(bruteForceBest(values))
+  })
+
+  it('handles empty inputs', () => {
+    expect(solveBestAssignment([])).toEqual([])
+    expect(solveBestAssignment([[]])).toEqual([-1])
+  })
+
+  it('is stable on the team-shaped case: 18 slots from 30 players', () => {
+    // Deterministic pseudo-random matrix; assert validity + local optimality
+    // (no single swap or unused-player substitution improves the total).
+    const nSlots = 18
+    const nPlayers = 30
+    let seed = 42
+    const rand = () => (seed = (seed * 1103515245 + 12345) % 2147483648) / 2147483648
+    const values = Array.from({ length: nSlots }, () =>
+      Array.from({ length: nPlayers }, () => Math.round(rand() * 50)),
+    )
+    const assignment = solveBestAssignment(values)
+
+    expect(assignment).toHaveLength(nSlots)
+    const used = assignment.filter(p => p >= 0)
+    expect(used).toHaveLength(nSlots)
+    expect(new Set(used).size).toBe(nSlots)
+
+    const total = totalValue(values, assignment)
+    const unused = Array.from({ length: nPlayers }, (_, p) => p).filter(p => !used.includes(p))
+    for (let a = 0; a < nSlots; a++) {
+      // swapping any two slots' players must not improve the total
+      for (let b = a + 1; b < nSlots; b++) {
+        const swapped = [...assignment]
+        ;[swapped[a], swapped[b]] = [swapped[b], swapped[a]]
+        expect(totalValue(values, swapped)).toBeLessThanOrEqual(total)
+      }
+      // substituting any unused player must not improve the total
+      for (const p of unused) {
+        const subbed = [...assignment]
+        subbed[a] = p
+        expect(totalValue(values, subbed)).toBeLessThanOrEqual(total)
+      }
+    }
+  })
+})

--- a/frontend/web/src/features/ffl/utils/bestTeam.ts
+++ b/frontend/web/src/features/ffl/utils/bestTeam.ts
@@ -1,0 +1,86 @@
+// Optimal team assignment via the Hungarian algorithm (Kuhn–Munkres with
+// potentials, O(n²m)). Sizes here are tiny (18 slots × ~30 players), so the
+// exact solution is effectively instant.
+
+// Classic assignment solver: cost matrix with rows ≤ cols, returns for each
+// row the column it is matched to, minimising total cost.
+function hungarian(cost: number[][]): number[] {
+  const n = cost.length
+  const m = cost[0]?.length ?? 0
+  const INF = Number.POSITIVE_INFINITY
+  const u = new Array<number>(n + 1).fill(0)
+  const v = new Array<number>(m + 1).fill(0)
+  const p = new Array<number>(m + 1).fill(0) // p[j] = row matched to column j (1-based)
+  const way = new Array<number>(m + 1).fill(0)
+
+  for (let i = 1; i <= n; i++) {
+    p[0] = i
+    let j0 = 0
+    const minv = new Array<number>(m + 1).fill(INF)
+    const used = new Array<boolean>(m + 1).fill(false)
+    do {
+      used[j0] = true
+      const i0 = p[j0]
+      let delta = INF
+      let j1 = 0
+      for (let j = 1; j <= m; j++) {
+        if (used[j]) continue
+        const cur = cost[i0 - 1][j - 1] - u[i0] - v[j]
+        if (cur < minv[j]) {
+          minv[j] = cur
+          way[j] = j0
+        }
+        if (minv[j] < delta) {
+          delta = minv[j]
+          j1 = j
+        }
+      }
+      for (let j = 0; j <= m; j++) {
+        if (used[j]) {
+          u[p[j]] += delta
+          v[j] -= delta
+        } else {
+          minv[j] -= delta
+        }
+      }
+      j0 = j1
+    } while (p[j0] !== 0)
+    do {
+      const j1 = way[j0]
+      p[j0] = p[j1]
+      j0 = j1
+    } while (j0)
+  }
+
+  const ans = new Array<number>(n).fill(-1)
+  for (let j = 1; j <= m; j++) {
+    if (p[j] > 0) ans[p[j] - 1] = j - 1
+  }
+  return ans
+}
+
+// Maximises total value over a [slot][player] value matrix. Returns for each
+// slot the chosen player index, or -1 when there are fewer players than slots
+// and the slot stays empty. Each player is used at most once.
+export function solveBestAssignment(values: number[][]): number[] {
+  const nSlots = values.length
+  const nPlayers = values[0]?.length ?? 0
+  if (nSlots === 0 || nPlayers === 0) return new Array<number>(nSlots).fill(-1)
+
+  if (nSlots <= nPlayers) {
+    return hungarian(values.map(row => row.map(v => -v)))
+  }
+
+  // Fewer players than slots: solve the transposed problem (every player gets
+  // their best slot), then map back.
+  const costT: number[][] = []
+  for (let pIdx = 0; pIdx < nPlayers; pIdx++) {
+    costT.push(values.map(row => -row[pIdx]))
+  }
+  const playerToSlot = hungarian(costT)
+  const ans = new Array<number>(nSlots).fill(-1)
+  playerToSlot.forEach((slot, player) => {
+    if (slot >= 0) ans[slot] = player
+  })
+  return ans
+}

--- a/frontend/web/src/features/ffl/utils/playerStats.test.ts
+++ b/frontend/web/src/features/ffl/utils/playerStats.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { starScore, trendDir, TREND_PCT, TREND_MIN_ABS, type StatSummary } from './playerStats'
+import { POSITION_MULTIPLIERS } from './position'
+
+describe('starScore', () => {
+  const s = (over: Partial<StatSummary>): StatSummary => ({
+    goals: 0, kicks: 0, handballs: 0, marks: 0, tackles: 0, hitouts: 0, ...over,
+  })
+
+  it('weights each stat by its position multiplier', () => {
+    expect(starScore(s({ goals: 2 }))).toBe(2 * POSITION_MULTIPLIERS.goals)
+    expect(starScore(s({ kicks: 10 }))).toBe(10 * POSITION_MULTIPLIERS.kicks)
+    expect(starScore(s({ handballs: 4 }))).toBe(4 * POSITION_MULTIPLIERS.handballs)
+    expect(starScore(s({ marks: 3 }))).toBe(3 * POSITION_MULTIPLIERS.marks)
+    expect(starScore(s({ tackles: 5 }))).toBe(5 * POSITION_MULTIPLIERS.tackles)
+  })
+
+  it('excludes hitouts', () => {
+    expect(starScore(s({ hitouts: 40 }))).toBe(0)
+  })
+
+  it('sums a full stat line', () => {
+    // 2*5 + 10 + 4 + 3*2 + 5*4 = 50
+    expect(starScore(s({ goals: 2, kicks: 10, handballs: 4, marks: 3, tackles: 5, hitouts: 40 }))).toBe(50)
+  })
+})
+
+describe('trendDir', () => {
+  it('is null when form equals season', () => {
+    expect(trendDir(10, 10)).toBeNull()
+  })
+
+  it('fires up exactly at the percentage threshold', () => {
+    const season = 10
+    const atThreshold = season + season * TREND_PCT
+    expect(trendDir(atThreshold, season)).toBe('up')
+    expect(trendDir(atThreshold - 0.01, season)).toBeNull()
+  })
+
+  it('fires down exactly at the percentage threshold', () => {
+    const season = 10
+    const atThreshold = season - season * TREND_PCT
+    expect(trendDir(atThreshold, season)).toBe('down')
+    expect(trendDir(atThreshold + 0.01, season)).toBeNull()
+  })
+
+  it('requires the absolute minimum for small season values', () => {
+    // 10% of 2 is 0.2, below TREND_MIN_ABS — deviation must reach the absolute floor
+    const season = 2
+    expect(trendDir(season + TREND_MIN_ABS - 0.01, season)).toBeNull()
+    expect(trendDir(season + TREND_MIN_ABS, season)).toBe('up')
+    expect(trendDir(season - TREND_MIN_ABS, season)).toBe('down')
+  })
+
+  it('is null for zero season and zero form', () => {
+    expect(trendDir(0, 0)).toBeNull()
+  })
+
+  it('fires on a zero season average once the absolute floor is met', () => {
+    expect(trendDir(TREND_MIN_ABS, 0)).toBe('up')
+    expect(trendDir(TREND_MIN_ABS - 0.01, 0)).toBeNull()
+  })
+})

--- a/frontend/web/src/features/ffl/utils/playerStats.ts
+++ b/frontend/web/src/features/ffl/utils/playerStats.ts
@@ -22,8 +22,13 @@ export const statCols: { key: StatKey; label: string }[] = [
   { key: 'goals',     label: 'G' },
 ]
 
+// Star position excludes hitouts: goals×5 + kicks + handballs + marks×2 + tackles×4
 export function starScore(s: StatSummary): number {
-  return statCols.reduce((sum, col) => sum + s[col.key] * (POSITION_MULTIPLIERS[col.key] ?? 1), 0)
+  return s.goals * POSITION_MULTIPLIERS.goals +
+    s.kicks * POSITION_MULTIPLIERS.kicks +
+    s.handballs * POSITION_MULTIPLIERS.handballs +
+    s.marks * POSITION_MULTIPLIERS.marks +
+    s.tackles * POSITION_MULTIPLIERS.tackles
 }
 
 export function fmtStat(val: number | null | undefined): string {

--- a/frontend/web/src/features/ffl/utils/playerStats.ts
+++ b/frontend/web/src/features/ffl/utils/playerStats.ts
@@ -35,3 +35,16 @@ export function fmtStat(val: number | null | undefined): string {
   if (val == null) return '—'
   return val.toFixed(1)
 }
+
+// Trend thresholds: form must deviate from season by at least TREND_PCT of the
+// season value, and by at least TREND_MIN_ABS absolute, to count as a trend.
+export const TREND_PCT = 0.15
+export const TREND_MIN_ABS = 0.5
+
+// Direction of form (last-N) vs season average, or null when within thresholds.
+export function trendDir(form: number, season: number): 'up' | 'down' | null {
+  const threshold = Math.max(TREND_MIN_ABS, TREND_PCT * Math.abs(season))
+  if (form - season >= threshold) return 'up'
+  if (season - form >= threshold) return 'down'
+  return null
+}

--- a/frontend/web/src/features/ffl/utils/playerStats.ts
+++ b/frontend/web/src/features/ffl/utils/playerStats.ts
@@ -1,0 +1,32 @@
+import { POSITION_MULTIPLIERS } from './position'
+
+export const LAST_N = 3
+
+export interface StatSummary {
+  goals: number
+  kicks: number
+  handballs: number
+  marks: number
+  tackles: number
+  hitouts: number
+}
+
+export type StatKey = 'kicks' | 'handballs' | 'marks' | 'tackles' | 'hitouts' | 'goals'
+
+export const statCols: { key: StatKey; label: string }[] = [
+  { key: 'kicks',     label: 'K' },
+  { key: 'handballs', label: 'H' },
+  { key: 'marks',     label: 'M' },
+  { key: 'tackles',   label: 'T' },
+  { key: 'hitouts',   label: 'R' },
+  { key: 'goals',     label: 'G' },
+]
+
+export function starScore(s: StatSummary): number {
+  return statCols.reduce((sum, col) => sum + s[col.key] * (POSITION_MULTIPLIERS[col.key] ?? 1), 0)
+}
+
+export function fmtStat(val: number | null | undefined): string {
+  if (val == null) return '—'
+  return val.toFixed(1)
+}

--- a/frontend/web/src/features/ffl/utils/playerStats.ts
+++ b/frontend/web/src/features/ffl/utils/playerStats.ts
@@ -1,6 +1,6 @@
 import { POSITION_MULTIPLIERS } from './position'
 
-export const LAST_N = 3
+export const LAST_N = 5
 
 export interface StatSummary {
   goals: number

--- a/frontend/web/src/features/ffl/utils/playerStats.ts
+++ b/frontend/web/src/features/ffl/utils/playerStats.ts
@@ -38,7 +38,7 @@ export function fmtStat(val: number | null | undefined): string {
 
 // Trend thresholds: form must deviate from season by at least TREND_PCT of the
 // season value, and by at least TREND_MIN_ABS absolute, to count as a trend.
-export const TREND_PCT = 0.15
+export const TREND_PCT = 0.10
 export const TREND_MIN_ABS = 0.5
 
 // Direction of form (last-N) vs season average, or null when within thresholds.

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -48,9 +48,15 @@
                 <td class="px-2 py-2 text-right tabular-nums text-base font-bold text-yellow-400">{{ starSeasonAvg }}</td>
               </tr>
               <tr class="border-b border-border-subtle">
-                <td class="py-2 text-xs text-text-faint whitespace-nowrap">Last 3 avg</td>
-                <td v-for="col in statCols" :key="col.key" class="px-2 py-2 text-right tabular-nums text-base font-bold" :class="statLast3Up(col.key)">{{ statLast3Avg(col.key) }}</td>
-                <td class="px-2 py-2 text-right tabular-nums text-base font-bold" :class="starLast3Up">{{ starLast3Avg }}</td>
+                <td class="py-2 text-xs text-text-faint whitespace-nowrap">Last {{ LAST_N }} avg</td>
+                <td v-for="col in statCols" :key="col.key" class="px-2 py-2 text-right tabular-nums text-base font-bold">
+                  <span v-if="statLastNTrend(col.key) === 'up'" class="text-xs font-normal text-green-400">↑ </span>
+                  <span v-else-if="statLastNTrend(col.key) === 'down'" class="text-xs font-normal text-red-400">↓ </span>{{ statLastNAvg(col.key) }}
+                </td>
+                <td class="px-2 py-2 text-right tabular-nums text-base font-bold text-yellow-400">
+                  <span v-if="starLastNTrend === 'up'" class="text-xs font-normal text-green-400">↑ </span>
+                  <span v-else-if="starLastNTrend === 'down'" class="text-xs font-normal text-red-400">↓ </span>{{ starLastNAvg }}
+                </td>
               </tr>
               <tr>
                 <td class="py-2 text-xs text-text-faint whitespace-nowrap">Median</td>
@@ -174,7 +180,7 @@ import { GET_AFL_PLAYER_SEASON_STATS, GET_FFL_PLAYER_STINTS } from '../api/queri
 import Breadcrumb from '../components/Breadcrumb.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import { POSITION_LETTERS, POSITION_COLORS } from '../utils/position'
-import { fmtStat } from '../utils/playerStats'
+import { fmtStat, statCols, starScore, trendDir, LAST_N, type StatKey } from '../utils/playerStats'
 import { heatStyle } from '@/utils/heatmap'
 import { useTheme } from '@/composables/useTheme'
 import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
@@ -284,17 +290,6 @@ interface MergedRow extends AFLPlayerMatch {
 
 // ── Data ─────────────────────────────────────────────────────────────────────
 
-const statCols = [
-  { key: 'kicks' as const,     label: 'K'  },
-  { key: 'handballs' as const, label: 'H'  },
-  { key: 'marks' as const,     label: 'M'  },
-  { key: 'hitouts' as const,   label: 'R'  },
-  { key: 'tackles' as const,   label: 'T'  },
-  { key: 'goals' as const,     label: 'G'  },
-]
-
-type StatKey = typeof statCols[number]['key']
-
 const sortedMatches = computed((): AFLPlayerMatch[] => {
   const ms = playerSeason.value?.matches ?? []
   return [...ms].sort((a, b) => parseInt(a.clubMatch.match.round.id) - parseInt(b.clubMatch.match.round.id))
@@ -338,7 +333,7 @@ const mergedRows = computed((): MergedRow[] =>
     const ffl = fflByAflMatchId.value.get(m.id) ?? null
     return {
       ...m,
-      starScore: fflStar(m),
+      starScore: starScore(m),
       aflMatchId: m.clubMatch.match.id,
       fflMatchId: ffl?.matchId ?? null,
       fflClubName: ffl?.clubName ?? null,
@@ -353,43 +348,36 @@ const mergedRows = computed((): MergedRow[] =>
 
 // ── Analysis ─────────────────────────────────────────────────────────────────
 
-function fflStar(m: AFLPlayerMatch): number {
-  return m.goals * 5 + m.kicks + m.handballs + m.marks * 2 + m.tackles * 4
-}
-
 function starFromSummary(s: AFLStatSummary | null): string {
   if (!s) return '—'
-  return (s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4).toFixed(1)
+  return starScore(s).toFixed(1)
 }
-
 
 function statAvg(key: StatKey): string {
   return fmtStat(playerSeason.value?.statsAll?.[key])
 }
 
-function statLast3Avg(key: StatKey): string {
+function statLastNAvg(key: StatKey): string {
   return fmtStat(playerSeason.value?.statsLastN?.[key])
 }
 
-function statLast3Up(key: StatKey): string {
+// Same trend semantics as the team builder: ↑/↓ when form deviates ≥15% from season.
+function statLastNTrend(key: StatKey): 'up' | 'down' | null {
   const all = playerSeason.value?.statsAll?.[key]
-  const lastN  = playerSeason.value?.statsLastN?.[key]
-  return all != null && lastN != null && lastN > all ? 'text-green-400' : ''
+  const lastN = playerSeason.value?.statsLastN?.[key]
+  if (all == null || lastN == null) return null
+  return trendDir(lastN, all)
 }
 
 const starSeasonAvg = computed(() => starFromSummary(playerSeason.value?.statsAll ?? null))
-const starLast3Avg  = computed(() => starFromSummary(playerSeason.value?.statsLastN ?? null))
+const starLastNAvg  = computed(() => starFromSummary(playerSeason.value?.statsLastN ?? null))
 
-function starFromSummaryNum(s: AFLStatSummary | null | undefined): number | null {
-  if (!s) return null
-  return s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4
-}
-const starLast3Up = computed(() => {
-  const all = starFromSummaryNum(playerSeason.value?.statsAll)
-  const lastN  = starFromSummaryNum(playerSeason.value?.statsLastN)
-  return all != null && lastN != null && lastN > all ? 'text-green-400' : 'text-yellow-400'
+const starLastNTrend = computed((): 'up' | 'down' | null => {
+  const all = playerSeason.value?.statsAll
+  const lastN = playerSeason.value?.statsLastN
+  if (!all || !lastN) return null
+  return trendDir(starScore(lastN), starScore(all))
 })
-
 
 const starMedian = computed(() => starFromSummary(playerSeason.value?.statsMedian ?? null))
 

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -11,12 +11,12 @@
         <img :src="aflClubLogoUrl(playerSeason.clubSeason.club.name)" class="w-12 h-12 object-contain mt-0.5 flex-shrink-0" />
         <div>
           <h1 class="text-2xl font-bold text-text">{{ playerSeason.player.name }}</h1>
-          <p class="text-sm text-text-muted mt-0.5">{{ playerSeason.clubSeason.club.name }} · {{ playerSeason.clubSeason.season.name }}</p>
-          <div v-if="stintEvents.length > 0" class="flex flex-wrap gap-4 mt-2">
-            <div v-for="(event, i) in stintEvents" :key="i" class="flex items-center gap-1.5">
-              <img :src="fflClubLogoUrl(event.clubName)" class="w-4 h-4 object-contain" />
-              <span class="text-sm text-text font-medium">{{ event.clubName }}</span>
-              <span v-if="event.from" class="text-xs text-text-faint">{{ event.from }} – {{ event.to }}</span>
+          <p class="text-sm text-text-muted mt-0.5">{{ playerSeason.clubSeason.club.name }}</p>
+          <div v-if="stintEvents.length > 0" class="flex flex-wrap gap-5 mt-2">
+            <div v-for="(event, i) in stintEvents" :key="i" class="flex items-center gap-2">
+              <img :src="fflClubLogoUrl(event.clubName)" class="w-5 h-5 object-contain" />
+              <span class="text-base text-text font-semibold">{{ event.clubName }}</span>
+              <span v-if="event.from" class="text-sm text-text-faint">{{ event.from }} – {{ event.to }}</span>
             </div>
           </div>
         </div>
@@ -64,20 +64,22 @@
               <th class="py-2 pr-3 font-medium whitespace-nowrap">Round</th>
               <th class="py-2 pr-4 font-medium">Vs</th>
               <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right w-10">{{ col.label }}</th>
-              <th class="py-2 pl-2 pr-5 font-medium text-right w-10 text-yellow-400">★</th>
+              <th class="py-2 pl-2 pr-3 font-medium text-right w-10 text-yellow-400">★</th>
+              <th class="py-2 w-5"></th>
               <th class="py-2 pl-5 pr-3 font-medium bg-white/[0.03] border-l border-border">FFL Club</th>
               <th class="py-2 px-2 font-medium bg-white/[0.03]">Position</th>
               <th class="py-2 px-2 font-medium bg-white/[0.03]">Bench</th>
               <th class="py-2 px-2 font-medium bg-white/[0.03]">IC</th>
               <th class="py-2 px-2 font-medium bg-white/[0.03]">Status</th>
-              <th class="py-2 pl-2 font-medium text-right bg-white/[0.03]">Score</th>
+              <th class="py-2 pl-2 pr-1 font-medium text-right bg-white/[0.03]">Score</th>
+              <th class="py-2 w-5 bg-white/[0.03]"></th>
             </tr>
           </thead>
           <tbody>
             <tr
               v-for="(row, i) in mergedRows"
               :key="row.id"
-              class="border-b border-border-subtle"
+              class="border-b border-border-subtle group"
               :class="row.status === 'dnp' ? 'opacity-40' : 'hover:bg-surface-hover'"
             >
               <td class="py-2 pr-3 tabular-nums text-text-muted text-xs whitespace-nowrap">{{ shortRound(row.clubMatch.match.round.name) }}</td>
@@ -91,9 +93,20 @@
                 <span v-if="row.status !== 'dnp'" :class="statColor(col.key, row.fflPosition)">{{ row[col.key] }}</span>
                 <span v-else class="text-text-faint">—</span>
               </td>
-              <td class="py-2 pl-2 pr-5 text-right tabular-nums font-medium">
-                <span v-if="row.status !== 'dnp'">{{ row.starScore }}</span>
+              <td class="py-2 pl-2 pr-3 text-right tabular-nums font-medium">
+                <span v-if="row.status !== 'dnp'" :class="row.fflPosition === 'star' ? 'text-yellow-400' : ''">{{ row.starScore }}</span>
                 <span v-else class="text-text-faint">—</span>
+              </td>
+              <td class="py-2 pr-2 w-5">
+                <router-link
+                  :to="{ name: 'afl-match', params: { matchId: row.aflMatchId } }"
+                  class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
+                  title="View AFL match"
+                >
+                  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>
+                  </svg>
+                </router-link>
               </td>
               <td class="py-2 pl-5 pr-3 whitespace-nowrap border-l border-border bg-white/[0.03]">
                 <span v-if="row.fflClubName" class="inline-flex items-center gap-1.5">
@@ -123,9 +136,21 @@
               <td class="py-2 px-2 bg-white/[0.03]">
                 <StatusBadge v-if="row.fflClubName" :status="row.fflAflStatus" />
               </td>
-              <td class="py-2 pl-2 text-right tabular-nums font-medium bg-white/[0.03]">
+              <td class="py-2 pl-2 pr-1 text-right tabular-nums font-medium bg-white/[0.03]">
                 <span v-if="row.fflScore !== null" class="text-active">{{ row.fflScore }}</span>
                 <span v-else class="text-text-faint">—</span>
+              </td>
+              <td class="py-2 pr-2 w-5 bg-white/[0.03]">
+                <router-link
+                  v-if="row.fflMatchId"
+                  :to="{ name: 'ffl-match', params: { matchId: row.fflMatchId } }"
+                  class="opacity-0 group-hover:opacity-100 transition-opacity text-text-faint hover:text-text"
+                  title="View FFL match"
+                >
+                  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3M9 2h5m0 0v5m0-5L7 9"/>
+                  </svg>
+                </router-link>
               </td>
             </tr>
           </tbody>
@@ -199,6 +224,7 @@ interface AFLPlayerMatch {
   clubMatch: {
     club: { id: string; name: string }
     match: {
+      id: string
       round: { id: string; name: string }
       homeClubMatch: { club: { id: string; name: string } }
       awayClubMatch: { club: { id: string; name: string } }
@@ -214,6 +240,7 @@ interface AFLMatchRef {
 
 interface FFLPlayerMatchData {
   id: string
+  matchId: string | null
   position: string | null
   backupPositions: string | null
   interchangePosition: string | null
@@ -233,6 +260,8 @@ interface FFLStint {
 
 interface MergedRow extends AFLPlayerMatch {
   starScore: number
+  aflMatchId: string
+  fflMatchId: string | null
   fflClubName: string | null
   fflPosition: string | null
   fflScore: number | null
@@ -266,6 +295,7 @@ const playedMatches = computed(() =>
 // Build lookup: AFL player match ID → FFL data + club name
 const fflByAflMatchId = computed(() => {
   const map = new Map<string, {
+    matchId: string | null
     clubName: string
     position: string | null
     score: number
@@ -277,6 +307,7 @@ const fflByAflMatchId = computed(() => {
     for (const pm of stint.playerMatches) {
       if (pm.aflPlayerMatch) {
         map.set(pm.aflPlayerMatch.id, {
+          matchId: pm.matchId,
           clubName: stint.club.name,
           position: pm.position,
           score: pm.score,
@@ -296,6 +327,8 @@ const mergedRows = computed((): MergedRow[] =>
     return {
       ...m,
       starScore: fflStar(m),
+      aflMatchId: m.clubMatch.match.id,
+      fflMatchId: ffl?.matchId ?? null,
       fflClubName: ffl?.clubName ?? null,
       fflPosition: ffl?.position ?? null,
       fflScore: ffl !== null ? ffl.score : null,

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -174,6 +174,7 @@ import { GET_AFL_PLAYER_SEASON_STATS, GET_FFL_PLAYER_STINTS } from '../api/queri
 import Breadcrumb from '../components/Breadcrumb.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import { POSITION_LETTERS, POSITION_COLORS } from '../utils/position'
+import { fmtStat } from '../utils/playerStats'
 import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
 import { clubAbbrev as aflClubAbbrev } from '@/features/afl/utils/clubAbbrev'
 import { clubLogoUrl as fflClubLogoUrl } from '../utils/clubLogos'
@@ -196,7 +197,7 @@ const playerSeason = computed(() => aflResult.value?.aflPlayerSeason as {
   clubSeason: { id: string; club: { id: string; name: string }; season: { id: string; name: string } }
   matches: AFLPlayerMatch[]
   statsAll: AFLStatSummary | null
-  statsLast3: AFLStatSummary | null
+  statsLastN: AFLStatSummary | null
   statsMedian: AFLStatSummary | null
 } | null)
 const stints = computed(() => fflResult.value?.fflPlayerSeasonsByAflPlayerSeason ?? [])
@@ -357,27 +358,23 @@ function starFromSummary(s: AFLStatSummary | null): string {
   return (s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4).toFixed(1)
 }
 
-function fmtStat(val: number | null | undefined): string {
-  if (val == null) return '—'
-  return val.toFixed(1)
-}
 
 function statAvg(key: StatKey): string {
   return fmtStat(playerSeason.value?.statsAll?.[key])
 }
 
 function statLast3Avg(key: StatKey): string {
-  return fmtStat(playerSeason.value?.statsLast3?.[key])
+  return fmtStat(playerSeason.value?.statsLastN?.[key])
 }
 
 function statLast3Up(key: StatKey): string {
   const all = playerSeason.value?.statsAll?.[key]
-  const l3  = playerSeason.value?.statsLast3?.[key]
-  return all != null && l3 != null && l3 > all ? 'text-green-400' : ''
+  const lastN  = playerSeason.value?.statsLastN?.[key]
+  return all != null && lastN != null && lastN > all ? 'text-green-400' : ''
 }
 
 const starSeasonAvg = computed(() => starFromSummary(playerSeason.value?.statsAll ?? null))
-const starLast3Avg  = computed(() => starFromSummary(playerSeason.value?.statsLast3 ?? null))
+const starLast3Avg  = computed(() => starFromSummary(playerSeason.value?.statsLastN ?? null))
 
 function starFromSummaryNum(s: AFLStatSummary | null | undefined): number | null {
   if (!s) return null
@@ -385,13 +382,10 @@ function starFromSummaryNum(s: AFLStatSummary | null | undefined): number | null
 }
 const starLast3Up = computed(() => {
   const all = starFromSummaryNum(playerSeason.value?.statsAll)
-  const l3  = starFromSummaryNum(playerSeason.value?.statsLast3)
-  return all != null && l3 != null && l3 > all ? 'text-green-400' : 'text-yellow-400'
+  const lastN  = starFromSummaryNum(playerSeason.value?.statsLastN)
+  return all != null && lastN != null && lastN > all ? 'text-green-400' : 'text-yellow-400'
 })
 
-const starScores = computed(() =>
-  playedMatches.value.map(m => fflStar(m)),
-)
 
 const starMedian = computed(() => starFromSummary(playerSeason.value?.statsMedian ?? null))
 

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -12,7 +12,7 @@
         <div>
           <h1 class="text-2xl font-bold text-text">{{ playerSeason.player.name }}</h1>
           <router-link
-            :to="{ name: 'afl-club-season', params: { clubSeasonId: playerSeason.clubSeason.id } }"
+            :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: playerSeason.clubSeason.id } }"
             class="text-sm text-text-muted mt-0.5 hover:text-text transition-colors"
           >{{ playerSeason.clubSeason.club.name }}</router-link>
           <div v-if="stintEvents.length > 0" class="flex flex-wrap gap-5 mt-2">

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -7,118 +7,130 @@
     <template v-else-if="playerSeason">
 
       <!-- Header -->
-      <div class="mb-6">
-        <h1 class="text-2xl font-bold text-text">{{ playerSeason.player.name }}</h1>
-        <p class="text-sm text-text-muted mt-0.5">{{ playerSeason.clubSeason.club.name }} · {{ playerSeason.clubSeason.season.name }}</p>
-      </div>
-
-      <!-- Averages bar -->
-      <div v-if="playedMatches.length > 0" class="mb-6 flex flex-wrap gap-4">
-        <div v-for="col in statCols" :key="col.key" class="flex flex-col items-center gap-0.5">
-          <span class="text-[10px] uppercase tracking-wide text-text-faint font-medium">{{ col.label }}</span>
-          <span class="text-lg font-semibold tabular-nums text-text">{{ avg(col.key) }}</span>
-        </div>
-        <div class="flex flex-col items-center gap-0.5">
-          <span class="text-[10px] uppercase tracking-wide text-text-faint font-medium">★</span>
-          <span class="text-lg font-semibold tabular-nums text-active">{{ fflStarAvg() }}</span>
-        </div>
-        <div class="flex flex-col items-center gap-0.5 ml-2 pl-2 border-l border-border">
-          <span class="text-[10px] uppercase tracking-wide text-text-faint font-medium">Games</span>
-          <span class="text-lg font-semibold tabular-nums text-text">{{ playedMatches.length }}</span>
-        </div>
-      </div>
-
-      <!-- AFL stats table -->
-      <section class="mb-8">
-        <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">AFL Stats</h2>
-        <div v-if="sortedMatches.length === 0" class="text-text-faint text-sm">No matches recorded.</div>
-        <div v-else class="overflow-x-auto">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-border text-left text-text-muted">
-                <th class="py-2 pr-3 font-medium">Round</th>
-                <th class="py-2 pr-4 font-medium">Vs</th>
-                <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right w-10">{{ col.label }}</th>
-                <th class="py-2 px-2 font-medium text-right w-10">★</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="m in sortedMatches"
-                :key="m.id"
-                class="border-b border-border-subtle"
-                :class="m.status === 'dnp' ? 'opacity-40' : 'hover:bg-surface-hover'"
-              >
-                <td class="py-2 pr-3 tabular-nums text-text-muted text-xs">{{ m.clubMatch.match.round.name }}</td>
-                <td class="py-2 pr-4 text-sm">{{ opponent(m) }}</td>
-                <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums">
-                  <span v-if="m.status !== 'dnp'">{{ m[col.key] }}</span>
-                  <span v-else class="text-text-faint">—</span>
-                </td>
-                <td class="py-2 px-2 text-right tabular-nums font-medium text-active">
-                  <span v-if="m.status !== 'dnp'">{{ fflStar(m) }}</span>
-                  <span v-else class="text-text-faint">—</span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <!-- FFL history -->
-      <section>
-        <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">FFL History</h2>
-        <div v-if="stintsLoading" class="text-text-faint text-sm">Loading...</div>
-        <div v-else-if="stints.length === 0" class="text-text-faint text-sm">Not in any FFL squad this season.</div>
-        <div v-else class="flex flex-col gap-6">
-          <div v-for="stint in stints" :key="stint.id">
-            <div class="flex items-center gap-2 mb-2">
-              <span class="font-semibold text-text">{{ stint.club.name }}</span>
-              <span v-if="stintRoundRange(stint)" class="text-xs text-text-muted">{{ stintRoundRange(stint) }}</span>
-            </div>
-            <div class="overflow-x-auto">
-              <table class="w-full text-sm">
-                <thead>
-                  <tr class="border-b border-border text-left text-text-muted">
-                    <th class="py-1.5 pr-3 font-medium">Round</th>
-                    <th class="py-1.5 px-2 font-medium">Pos</th>
-                    <th class="py-1.5 px-2 font-medium text-right">*</th>
-                    <th class="py-1.5 px-2 font-medium text-text-faint text-xs">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    v-for="pm in sortedStintMatches(stint)"
-                    :key="pm.id"
-                    class="border-b border-border-subtle"
-                    :class="pm.aflStatus === 'dnp' ? 'opacity-40' : 'hover:bg-surface-hover'"
-                  >
-                    <td class="py-1.5 pr-3 text-xs text-text-muted tabular-nums">{{ fflMatchRound(pm) }}</td>
-                    <td class="py-1.5 px-2">
-                      <span v-if="pm.position" :class="positionColor(pm.position)" class="font-medium text-xs">
-                        {{ positionLetter(pm.position) }}
-                      </span>
-                      <span v-else class="text-text-faint">—</span>
-                    </td>
-                    <td class="py-1.5 px-2 text-right tabular-nums font-medium text-active">
-                      <span v-if="pm.aflStatus !== 'dnp'">{{ pm.score }}</span>
-                      <span v-else class="text-text-faint">—</span>
-                    </td>
-                    <td class="py-1.5 px-2 text-xs text-text-faint">{{ pm.aflStatus ?? pm.status ?? '—' }}</td>
-                  </tr>
-                </tbody>
-                <tfoot v-if="stintPlayedCount(stint) > 0">
-                  <tr class="border-t border-border text-text-muted text-xs">
-                    <td class="py-1.5 pr-3" colspan="2">avg</td>
-                    <td class="py-1.5 px-2 text-right tabular-nums font-medium text-active">{{ stintAvg(stint) }}</td>
-                    <td></td>
-                  </tr>
-                </tfoot>
-              </table>
+      <div class="mb-8 flex items-start gap-4">
+        <img :src="aflClubLogoUrl(playerSeason.clubSeason.club.name)" class="w-12 h-12 object-contain mt-0.5 flex-shrink-0" />
+        <div>
+          <h1 class="text-2xl font-bold text-text">{{ playerSeason.player.name }}</h1>
+          <p class="text-sm text-text-muted mt-0.5">{{ playerSeason.clubSeason.club.name }} · {{ playerSeason.clubSeason.season.name }}</p>
+          <div v-if="stintEvents.length > 0" class="flex flex-wrap gap-4 mt-2">
+            <div v-for="(event, i) in stintEvents" :key="i" class="flex items-center gap-1.5">
+              <img :src="fflClubLogoUrl(event.clubName)" class="w-4 h-4 object-contain" />
+              <span class="text-sm text-text font-medium">{{ event.clubName }}</span>
+              <span v-if="event.from" class="text-xs text-text-faint">{{ event.from }} – {{ event.to }}</span>
             </div>
           </div>
         </div>
-      </section>
+      </div>
+
+      <!-- Analysis -->
+      <div v-if="playerSeason?.statsAll" class="mb-8">
+        <p class="text-[10px] font-semibold uppercase tracking-widest text-text-faint mb-2">Season Stats</p>
+          <table class="w-full table-fixed text-sm">
+            <thead>
+              <tr class="border-b border-border">
+                <th class="py-1 text-left text-xs font-normal text-text-faint">
+                  {{ playerSeason.statsAll.games }} games
+                </th>
+                <th v-for="col in statCols" :key="col.key" class="px-2 py-1 text-right font-medium text-text-muted">{{ col.label }}</th>
+                <th class="px-2 py-1 text-right font-medium text-yellow-400">★</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-border-subtle">
+                <td class="py-2 text-xs text-text-faint whitespace-nowrap">Season avg</td>
+                <td v-for="col in statCols" :key="col.key" class="px-2 py-2 text-right tabular-nums text-base font-bold">{{ statAvg(col.key) }}</td>
+                <td class="px-2 py-2 text-right tabular-nums text-base font-bold text-yellow-400">{{ starSeasonAvg }}</td>
+              </tr>
+              <tr class="border-b border-border-subtle">
+                <td class="py-2 text-xs text-text-faint whitespace-nowrap">Last 3 avg</td>
+                <td v-for="col in statCols" :key="col.key" class="px-2 py-2 text-right tabular-nums text-base font-bold" :class="statLast3Up(col.key)">{{ statLast3Avg(col.key) }}</td>
+                <td class="px-2 py-2 text-right tabular-nums text-base font-bold" :class="starLast3Up">{{ starLast3Avg }}</td>
+              </tr>
+              <tr>
+                <td class="py-2 text-xs text-text-faint whitespace-nowrap">Median</td>
+                <td v-for="col in statCols" :key="col.key" class="px-2 py-2 text-right tabular-nums text-base font-bold">{{ statMedian(col.key) }}</td>
+                <td class="px-2 py-2 text-right tabular-nums text-base font-bold text-yellow-400">{{ starMedian }}</td>
+              </tr>
+            </tbody>
+          </table>
+      </div>
+
+      <!-- Merged table -->
+      <p class="text-[10px] font-semibold uppercase tracking-widest text-text-faint mb-3">Match by Match</p>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-border text-left text-text-muted">
+              <th class="py-2 pr-3 font-medium whitespace-nowrap">Round</th>
+              <th class="py-2 pr-4 font-medium">Vs</th>
+              <th v-for="col in statCols" :key="col.key" class="py-2 px-2 font-medium text-right w-10">{{ col.label }}</th>
+              <th class="py-2 pl-2 pr-5 font-medium text-right w-10 text-yellow-400">★</th>
+              <th class="py-2 pl-5 pr-3 font-medium bg-white/[0.03] border-l border-border">FFL Club</th>
+              <th class="py-2 px-2 font-medium bg-white/[0.03]">Position</th>
+              <th class="py-2 px-2 font-medium bg-white/[0.03]">Bench</th>
+              <th class="py-2 px-2 font-medium bg-white/[0.03]">IC</th>
+              <th class="py-2 px-2 font-medium bg-white/[0.03]">Status</th>
+              <th class="py-2 pl-2 font-medium text-right bg-white/[0.03]">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, i) in mergedRows"
+              :key="row.id"
+              class="border-b border-border-subtle"
+              :class="row.status === 'dnp' ? 'opacity-40' : 'hover:bg-surface-hover'"
+            >
+              <td class="py-2 pr-3 tabular-nums text-text-muted text-xs whitespace-nowrap">{{ shortRound(row.clubMatch.match.round.name) }}</td>
+              <td class="py-2 pr-4">
+                <span class="inline-flex items-center gap-1.5">
+                  <img :src="aflClubLogoUrl(opponentName(row))" class="w-4 h-4 object-contain" />
+                  <span class="text-xs text-text-muted">{{ aflClubAbbrev(opponentName(row)) }}</span>
+                </span>
+              </td>
+              <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums">
+                <span v-if="row.status !== 'dnp'" :class="statColor(col.key, row.fflPosition)">{{ row[col.key] }}</span>
+                <span v-else class="text-text-faint">—</span>
+              </td>
+              <td class="py-2 pl-2 pr-5 text-right tabular-nums font-medium">
+                <span v-if="row.status !== 'dnp'">{{ row.starScore }}</span>
+                <span v-else class="text-text-faint">—</span>
+              </td>
+              <td class="py-2 pl-5 pr-3 whitespace-nowrap border-l border-border bg-white/[0.03]">
+                <span v-if="row.fflClubName" class="inline-flex items-center gap-1.5">
+                  <img :src="fflClubLogoUrl(row.fflClubName)" class="w-4 h-4 object-contain" />
+                  <span v-if="i === 0 || mergedRows[i - 1].fflClubName !== row.fflClubName" class="text-xs text-text-muted">{{ row.fflClubName }}</span>
+                </span>
+                <span v-else class="text-text-faint text-xs">—</span>
+              </td>
+              <td class="py-2 px-2 bg-white/[0.03]">
+                <span v-if="row.fflPosition" :class="POSITION_COLORS[row.fflPosition]" class="text-xs font-medium">
+                  {{ POSITION_LETTERS[row.fflPosition] }}
+                </span>
+                <span v-else class="text-text-faint text-xs">—</span>
+              </td>
+              <td class="py-2 px-2 bg-white/[0.03]">
+                <span v-if="row.fflBackupPositions" class="text-xs font-medium text-text-muted">
+                  {{ posLetters(row.fflBackupPositions) }}
+                </span>
+                <span v-else class="text-text-faint text-xs">—</span>
+              </td>
+              <td class="py-2 px-2 bg-white/[0.03]">
+                <span v-if="row.fflInterchangePosition" :class="POSITION_COLORS[row.fflInterchangePosition]" class="text-xs font-medium">
+                  {{ posLetters(row.fflInterchangePosition) }}
+                </span>
+                <span v-else class="text-text-faint text-xs">—</span>
+              </td>
+              <td class="py-2 px-2 bg-white/[0.03]">
+                <StatusBadge v-if="row.fflClubName" :status="row.fflAflStatus" />
+              </td>
+              <td class="py-2 pl-2 text-right tabular-nums font-medium bg-white/[0.03]">
+                <span v-if="row.fflScore !== null" class="text-active">{{ row.fflScore }}</span>
+                <span v-else class="text-text-faint">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
     </template>
   </div>
@@ -129,29 +141,34 @@ import { computed } from 'vue'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_AFL_PLAYER_SEASON_STATS, GET_FFL_PLAYER_STINTS } from '../api/queries'
 import Breadcrumb from '../components/Breadcrumb.vue'
+import StatusBadge from '../components/StatusBadge.vue'
 import { POSITION_LETTERS, POSITION_COLORS } from '../utils/position'
+import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
+import { clubAbbrev as aflClubAbbrev } from '@/features/afl/utils/clubAbbrev'
+import { clubLogoUrl as fflClubLogoUrl } from '../utils/clubLogos'
 
 const props = defineProps<{ aflPlayerSeasonId: string }>()
-
-// --- AFL stats query ---
 
 const { result: aflResult, loading, error } = useQuery(
   GET_AFL_PLAYER_SEASON_STATS,
   () => ({ id: props.aflPlayerSeasonId }),
 )
 
-const playerSeason = computed(() => aflResult.value?.aflPlayerSeason ?? null)
-
-// --- FFL stints query ---
-
-const { result: fflResult, loading: stintsLoading } = useQuery(
+const { result: fflResult } = useQuery(
   GET_FFL_PLAYER_STINTS,
   () => ({ aflPlayerSeasonId: props.aflPlayerSeasonId }),
 )
 
+const playerSeason = computed(() => aflResult.value?.aflPlayerSeason as {
+  id: string
+  player: { id: string; name: string }
+  clubSeason: { club: { id: string; name: string }; season: { id: string; name: string } }
+  matches: AFLPlayerMatch[]
+  statsAll: AFLStatSummary | null
+  statsLast3: AFLStatSummary | null
+  statsMedian: AFLStatSummary | null
+} | null)
 const stints = computed(() => fflResult.value?.fflPlayerSeasonsByAflPlayerSeason ?? [])
-
-// --- Breadcrumb ---
 
 const breadcrumbs = computed(() => {
   if (!playerSeason.value) return []
@@ -162,7 +179,13 @@ const breadcrumbs = computed(() => {
   ]
 })
 
-// --- AFL stats ---
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface AFLStatSummary {
+  goals: number; kicks: number; handballs: number
+  marks: number; tackles: number; hitouts: number
+  games?: number
+}
 
 interface AFLPlayerMatch {
   id: string
@@ -173,8 +196,6 @@ interface AFLPlayerMatch {
   tackles: number
   hitouts: number
   goals: number
-  behinds: number
-  score: number
   clubMatch: {
     club: { id: string; name: string }
     match: {
@@ -185,14 +206,50 @@ interface AFLPlayerMatch {
   }
 }
 
+interface AFLMatchRef {
+  round: { id: string; name: string }
+  homeClubMatch: { club: { id: string; name: string } }
+  awayClubMatch: { club: { id: string; name: string } }
+}
+
+interface FFLPlayerMatchData {
+  id: string
+  position: string | null
+  backupPositions: string | null
+  interchangePosition: string | null
+  status: string | null
+  aflStatus: string | null
+  score: number
+  aflPlayerMatch: { id: string; clubMatch?: { match?: AFLMatchRef } } | null
+}
+
+interface FFLStint {
+  id: string
+  club: { id: string; name: string }
+  fromRoundId: string | null
+  toRoundId: string | null
+  playerMatches: FFLPlayerMatchData[]
+}
+
+interface MergedRow extends AFLPlayerMatch {
+  starScore: number
+  fflClubName: string | null
+  fflPosition: string | null
+  fflScore: number | null
+  fflAflStatus: string | null
+  fflBackupPositions: string | null
+  fflInterchangePosition: string | null
+}
+
+// ── Data ─────────────────────────────────────────────────────────────────────
+
 const statCols = [
-  { key: 'kicks' as const,    label: 'K' },
+  { key: 'kicks' as const,     label: 'K'  },
   { key: 'handballs' as const, label: 'HB' },
-  { key: 'marks' as const,    label: 'M' },
-  { key: 'hitouts' as const,  label: 'HO' },
-  { key: 'tackles' as const,  label: 'T' },
-  { key: 'goals' as const,    label: 'G' },
-  { key: 'behinds' as const,  label: 'B' },
+  { key: 'marks' as const,     label: 'M'  },
+  { key: 'hitouts' as const,   label: 'HO' },
+  { key: 'tackles' as const,   label: 'T'  },
+  { key: 'goals' as const,     label: 'G'  },
 ]
 
 type StatKey = typeof statCols[number]['key']
@@ -206,98 +263,138 @@ const playedMatches = computed(() =>
   sortedMatches.value.filter(m => m.status === 'played' || m.status === 'playing'),
 )
 
-function avg(key: StatKey): string {
-  const n = playedMatches.value.length
-  if (n === 0) return '—'
-  const sum = playedMatches.value.reduce((s, m) => s + m[key], 0)
-  return (sum / n).toFixed(1)
-}
+// Build lookup: AFL player match ID → FFL data + club name
+const fflByAflMatchId = computed(() => {
+  const map = new Map<string, {
+    clubName: string
+    position: string | null
+    score: number
+    aflStatus: string | null
+    backupPositions: string | null
+    interchangePosition: string | null
+  }>()
+  for (const stint of stints.value as FFLStint[]) {
+    for (const pm of stint.playerMatches) {
+      if (pm.aflPlayerMatch) {
+        map.set(pm.aflPlayerMatch.id, {
+          clubName: stint.club.name,
+          position: pm.position,
+          score: pm.score,
+          aflStatus: pm.aflStatus,
+          backupPositions: pm.backupPositions,
+          interchangePosition: pm.interchangePosition,
+        })
+      }
+    }
+  }
+  return map
+})
+
+const mergedRows = computed((): MergedRow[] =>
+  sortedMatches.value.map(m => {
+    const ffl = fflByAflMatchId.value.get(m.id) ?? null
+    return {
+      ...m,
+      starScore: fflStar(m),
+      fflClubName: ffl?.clubName ?? null,
+      fflPosition: ffl?.position ?? null,
+      fflScore: ffl !== null ? ffl.score : null,
+      fflAflStatus: ffl?.aflStatus ?? null,
+      fflBackupPositions: ffl?.backupPositions ?? null,
+      fflInterchangePosition: ffl?.interchangePosition ?? null,
+    }
+  }),
+)
+
+// ── Analysis ─────────────────────────────────────────────────────────────────
 
 function fflStar(m: AFLPlayerMatch): number {
   return m.goals * 5 + m.kicks + m.handballs + m.marks * 2 + m.tackles * 4
 }
 
-function fflStarAvg(): string {
-  const n = playedMatches.value.length
-  if (n === 0) return '—'
-  const sum = playedMatches.value.reduce((s, m) => s + fflStar(m), 0)
-  return (sum / n).toFixed(1)
+function starFromSummary(s: AFLStatSummary | null): string {
+  if (!s) return '—'
+  return (s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4).toFixed(1)
 }
 
-function opponent(m: AFLPlayerMatch): string {
+function fmtStat(val: number | null | undefined): string {
+  if (val == null) return '—'
+  return val.toFixed(1)
+}
+
+function statAvg(key: StatKey): string {
+  return fmtStat(playerSeason.value?.statsAll?.[key])
+}
+
+function statLast3Avg(key: StatKey): string {
+  return fmtStat(playerSeason.value?.statsLast3?.[key])
+}
+
+function statLast3Up(key: StatKey): string {
+  const all = playerSeason.value?.statsAll?.[key]
+  const l3  = playerSeason.value?.statsLast3?.[key]
+  return all != null && l3 != null && l3 > all ? 'text-green-400' : ''
+}
+
+const starSeasonAvg = computed(() => starFromSummary(playerSeason.value?.statsAll ?? null))
+const starLast3Avg  = computed(() => starFromSummary(playerSeason.value?.statsLast3 ?? null))
+
+function starFromSummaryNum(s: AFLStatSummary | null | undefined): number | null {
+  if (!s) return null
+  return s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4
+}
+const starLast3Up = computed(() => {
+  const all = starFromSummaryNum(playerSeason.value?.statsAll)
+  const l3  = starFromSummaryNum(playerSeason.value?.statsLast3)
+  return all != null && l3 != null && l3 > all ? 'text-green-400' : 'text-yellow-400'
+})
+
+const starScores = computed(() =>
+  playedMatches.value.map(m => fflStar(m)),
+)
+
+const starMedian = computed(() => starFromSummary(playerSeason.value?.statsMedian ?? null))
+
+function statMedian(key: StatKey): string {
+  return fmtStat(playerSeason.value?.statsMedian?.[key])
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function opponentName(m: AFLPlayerMatch): string {
   const myId = playerSeason.value?.clubSeason.club.id
   const home = m.clubMatch.match.homeClubMatch.club
   const away = m.clubMatch.match.awayClubMatch.club
   return home.id === myId ? away.name : home.name
 }
 
-// --- FFL stints ---
+function shortRound(name: string): string {
+  return name.replace(/^Round\s+/i, 'R')
+}
 
-interface FFLPlayerMatchData {
-  id: string
-  position: string | null
-  status: string | null
-  aflStatus: string | null
-  score: number
-  aflPlayerMatch: {
-    id: string
-    clubMatch: {
-      match: {
-        round: { id: string; name: string }
-      }
+function statColor(statKey: string, position: string | null): string {
+  if (!position || position === 'star') return ''
+  return statKey === position ? (POSITION_COLORS[position] ?? '') : ''
+}
+
+
+function posLetters(pos: string | null): string {
+  if (!pos) return ''
+  return pos.split(',').map(p => POSITION_LETTERS[p.trim()] ?? p.trim()).join('')
+}
+
+const stintEvents = computed(() =>
+  (stints.value as FFLStint[]).map(stint => {
+    const sorted = [...stint.playerMatches]
+      .filter(pm => pm.aflPlayerMatch?.clubMatch?.match?.round)
+      .sort((a, b) => parseInt(a.aflPlayerMatch!.clubMatch!.match!.round!.id) - parseInt(b.aflPlayerMatch!.clubMatch!.match!.round!.id))
+    const first = sorted[0]?.aflPlayerMatch?.clubMatch?.match?.round
+    const last = sorted[sorted.length - 1]?.aflPlayerMatch?.clubMatch?.match?.round
+    return {
+      clubName: stint.club.name,
+      from: first ? shortRound(first.name) : null,
+      to: stint.toRoundId === null ? 'present' : (last ? shortRound(last.name) : null),
     }
-  } | null
-}
-
-interface FFLStint {
-  id: string
-  club: { id: string; name: string }
-  fromRoundId: string | null
-  toRoundId: string | null
-  playerMatches: FFLPlayerMatchData[]
-}
-
-function fflMatchRound(pm: FFLPlayerMatchData): string {
-  if (pm.aflPlayerMatch) return pm.aflPlayerMatch.clubMatch.match.round.name
-  if (pm.aflStatus === 'bye') return 'Bye'
-  return '—'
-}
-
-function fflMatchRoundId(pm: FFLPlayerMatchData): number {
-  if (pm.aflPlayerMatch) return parseInt(pm.aflPlayerMatch.clubMatch.match.round.id)
-  return 0
-}
-
-function sortedStintMatches(stint: FFLStint): FFLPlayerMatchData[] {
-  return [...stint.playerMatches].sort((a, b) => fflMatchRoundId(a) - fflMatchRoundId(b))
-}
-
-function stintRoundRange(stint: FFLStint): string {
-  const sorted = sortedStintMatches(stint)
-  const first = sorted.find(pm => fflMatchRound(pm) !== '—')
-  const last = [...sorted].reverse().find(pm => fflMatchRound(pm) !== '—')
-  if (!first) return ''
-  const from = fflMatchRound(first)
-  const to = last ? fflMatchRound(last) : from
-  return from === to ? from : `${from} – ${to}`
-}
-
-function stintPlayedCount(stint: FFLStint): number {
-  return stint.playerMatches.filter(pm => pm.aflStatus !== 'dnp').length
-}
-
-function stintAvg(stint: FFLStint): string {
-  const played = stint.playerMatches.filter(pm => pm.aflStatus !== 'dnp')
-  if (played.length === 0) return '—'
-  const sum = played.reduce((s, pm) => s + pm.score, 0)
-  return (sum / played.length).toFixed(1)
-}
-
-function positionLetter(pos: string): string {
-  return POSITION_LETTERS[pos] ?? pos
-}
-
-function positionColor(pos: string): string {
-  return POSITION_COLORS[pos] ?? 'text-text'
-}
+  })
+)
 </script>

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -11,11 +11,17 @@
         <img :src="aflClubLogoUrl(playerSeason.clubSeason.club.name)" class="w-12 h-12 object-contain mt-0.5 flex-shrink-0" />
         <div>
           <h1 class="text-2xl font-bold text-text">{{ playerSeason.player.name }}</h1>
-          <p class="text-sm text-text-muted mt-0.5">{{ playerSeason.clubSeason.club.name }}</p>
+          <router-link
+            :to="{ name: 'afl-club-season', params: { clubSeasonId: playerSeason.clubSeason.id } }"
+            class="text-sm text-text-muted mt-0.5 hover:text-text transition-colors"
+          >{{ playerSeason.clubSeason.club.name }}</router-link>
           <div v-if="stintEvents.length > 0" class="flex flex-wrap gap-5 mt-2">
             <div v-for="(event, i) in stintEvents" :key="i" class="flex items-center gap-2">
               <img :src="fflClubLogoUrl(event.clubName)" class="w-5 h-5 object-contain" />
-              <span class="text-base text-text font-semibold">{{ event.clubName }}</span>
+              <router-link
+                :to="{ name: 'ffl-club-season', params: { clubSeasonId: event.clubSeasonId } }"
+                class="text-base text-text font-semibold hover:text-text-muted transition-colors"
+              >{{ event.clubName }}</router-link>
               <span v-if="event.from" class="text-sm text-text-faint">{{ event.from }} – {{ event.to }}</span>
             </div>
           </div>
@@ -187,7 +193,7 @@ const { result: fflResult } = useQuery(
 const playerSeason = computed(() => aflResult.value?.aflPlayerSeason as {
   id: string
   player: { id: string; name: string }
-  clubSeason: { club: { id: string; name: string }; season: { id: string; name: string } }
+  clubSeason: { id: string; club: { id: string; name: string }; season: { id: string; name: string } }
   matches: AFLPlayerMatch[]
   statsAll: AFLStatSummary | null
   statsLast3: AFLStatSummary | null
@@ -199,7 +205,7 @@ const breadcrumbs = computed(() => {
   if (!playerSeason.value) return []
   return [
     { label: 'FFL', to: { name: 'home' } },
-    { label: playerSeason.value.clubSeason.season.name },
+    { label: playerSeason.value.clubSeason.season.name, to: { name: 'afl-home' } },
     { label: playerSeason.value.player.name },
   ]
 })
@@ -253,6 +259,7 @@ interface FFLPlayerMatchData {
 interface FFLStint {
   id: string
   club: { id: string; name: string }
+  clubSeasonId: string
   fromRoundId: string | null
   toRoundId: string | null
   playerMatches: FFLPlayerMatchData[]
@@ -274,9 +281,9 @@ interface MergedRow extends AFLPlayerMatch {
 
 const statCols = [
   { key: 'kicks' as const,     label: 'K'  },
-  { key: 'handballs' as const, label: 'HB' },
+  { key: 'handballs' as const, label: 'H'  },
   { key: 'marks' as const,     label: 'M'  },
-  { key: 'hitouts' as const,   label: 'HO' },
+  { key: 'hitouts' as const,   label: 'R'  },
   { key: 'tackles' as const,   label: 'T'  },
   { key: 'goals' as const,     label: 'G'  },
 ]
@@ -425,6 +432,7 @@ const stintEvents = computed(() =>
     const last = sorted[sorted.length - 1]?.aflPlayerMatch?.clubMatch?.match?.round
     return {
       clubName: stint.club.name,
+      clubSeasonId: stint.clubSeasonId,
       from: first ? shortRound(first.name) : null,
       to: stint.toRoundId === null ? 'present' : (last ? shortRound(last.name) : null),
     }

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -361,7 +361,7 @@ function statLastNAvg(key: StatKey): string {
   return fmtStat(playerSeason.value?.statsLastN?.[key])
 }
 
-// Same trend semantics as the team builder: ↑/↓ when form deviates ≥15% from season.
+// Same trend semantics as the team builder: ↑/↓ per trendDir thresholds.
 function statLastNTrend(key: StatKey): 'up' | 'down' | null {
   const all = playerSeason.value?.statsAll?.[key]
   const lastN = playerSeason.value?.statsLastN?.[key]

--- a/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
+++ b/frontend/web/src/features/ffl/views/AFLPlayerSeasonView.vue
@@ -96,11 +96,11 @@
                 </span>
               </td>
               <td v-for="col in statCols" :key="col.key" class="py-2 px-2 text-right tabular-nums">
-                <span v-if="row.status !== 'dnp'" :class="statColor(col.key, row.fflPosition)">{{ row[col.key] }}</span>
+                <span v-if="row.status !== 'dnp'" :class="statColor(col.key, row.fflPosition)" :style="roundHeat(row[col.key], col.key)">{{ row[col.key] }}</span>
                 <span v-else class="text-text-faint">—</span>
               </td>
               <td class="py-2 pl-2 pr-3 text-right tabular-nums font-medium">
-                <span v-if="row.status !== 'dnp'" :class="row.fflPosition === 'star' ? 'text-yellow-400' : ''">{{ row.starScore }}</span>
+                <span v-if="row.status !== 'dnp'" :style="roundHeat(row.starScore, 'star')">{{ row.starScore }}</span>
                 <span v-else class="text-text-faint">—</span>
               </td>
               <td class="py-2 pr-2 w-5">
@@ -175,11 +175,15 @@ import Breadcrumb from '../components/Breadcrumb.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import { POSITION_LETTERS, POSITION_COLORS } from '../utils/position'
 import { fmtStat } from '../utils/playerStats'
+import { heatStyle } from '@/utils/heatmap'
+import { useTheme } from '@/composables/useTheme'
 import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
 import { clubAbbrev as aflClubAbbrev } from '@/features/afl/utils/clubAbbrev'
 import { clubLogoUrl as fflClubLogoUrl } from '../utils/clubLogos'
 
 const props = defineProps<{ aflPlayerSeasonId: string }>()
+
+const { isDark } = useTheme()
 
 const { result: aflResult, loading, error } = useQuery(
   GET_AFL_PLAYER_SEASON_STATS,
@@ -409,6 +413,27 @@ function shortRound(name: string): string {
 function statColor(statKey: string, position: string | null): string {
   if (!position || position === 'star') return ''
   return statKey === position ? (POSITION_COLORS[position] ?? '') : ''
+}
+
+type HeatKey = typeof statCols[number]['key'] | 'star'
+
+const roundHeatRanges = computed(() => {
+  const played = mergedRows.value.filter(r => r.status !== 'dnp')
+  const range = {} as Record<HeatKey, { min: number; max: number }>
+  for (const col of statCols) {
+    const vals = played.map(r => r[col.key]).filter((v): v is number => v != null)
+    if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  const starVals = played.map(r => r.starScore)
+  if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
+  return range
+})
+
+function roundHeat(value: number | null | undefined, key: HeatKey): Record<string, string> {
+  if (value == null) return {}
+  const r = roundHeatRanges.value[key]
+  if (!r || r.min === r.max) return {}
+  return heatStyle(value, r.min, r.max, isDark.value)
 }
 
 

--- a/frontend/web/src/features/ffl/views/FreeAgentsView.vue
+++ b/frontend/web/src/features/ffl/views/FreeAgentsView.vue
@@ -2,27 +2,7 @@
   <div>
     <div class="mb-6 flex items-center justify-between">
       <h1 class="text-2xl font-bold text-text">Free Agents</h1>
-      <span
-        class="text-xs text-text-faint whitespace-nowrap"
-        :title="`Cells show season avg then last ${LAST_N} avg. ↑/↓ = last ${LAST_N} form at least 15% above/below season average`"
-      >
-        <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = last {{ LAST_N }} form
-      </span>
-      <!-- Rank basis toggle: which average ranks the top-20 cut -->
-      <div class="flex items-center rounded border border-border overflow-hidden text-[10px] text-text-faint">
-        <button
-          class="px-1.5 py-0.5 transition-colors"
-          :class="statSource === 'form' ? 'bg-control text-text' : 'hover:text-text'"
-          :title="`Rank the top 20 by last ${LAST_N} averages`"
-          @click="statSource = 'form'"
-        >Last {{ LAST_N }}</button>
-        <button
-          class="px-1.5 py-0.5 transition-colors"
-          :class="statSource === 'season' ? 'bg-control text-text' : 'hover:text-text'"
-          title="Rank the top 20 by season averages"
-          @click="statSource = 'season'"
-        >Season</button>
-      </div>
+      <StatSourceToggle />
     </div>
 
     <div v-if="loading" class="text-text-faint">Loading...</div>
@@ -115,6 +95,8 @@ import { statCols, starScore, type StatSummary, type StatKey, LAST_N } from '../
 import { POSITION_LABEL } from '../utils/position'
 import StatCell from '../components/StatCell.vue'
 import PlayerStatsCard from '../components/PlayerStatsCard.vue'
+import StatSourceToggle from '../components/StatSourceToggle.vue'
+import { useStatSource } from '../composables/useStatSource'
 import { GET_FREE_AGENTS } from '../api/queries'
 import { useFflState } from '../composables/useFflState'
 import { clubLogoUrl } from '@/features/afl/utils/clubLogos'
@@ -133,8 +115,9 @@ type SectionKey = StatKey | 'star'
 // Stat that ranks the top-20 cut — set by clicking a column header.
 const activeKey = ref<SectionKey>('kicks')
 
-// Which average ranks the cut (and scales the heatmap): last-N form or season.
-const statSource = ref<'form' | 'season'>('form')
+// Which average ranks the cut (and scales the heatmap) — global toggle shared
+// with the other stats pages.
+const { statSource } = useStatSource()
 
 const rankBasisLabel = computed(() => statSource.value === 'form' ? `last ${LAST_N}` : 'season')
 

--- a/frontend/web/src/features/ffl/views/FreeAgentsView.vue
+++ b/frontend/web/src/features/ffl/views/FreeAgentsView.vue
@@ -1,0 +1,192 @@
+<template>
+  <div>
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-text">Free Agents</h1>
+    </div>
+
+    <div v-if="loading" class="text-text-faint">Loading...</div>
+    <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
+    <template v-else>
+      <!-- Tab navigation -->
+      <div class="flex gap-1 mb-6 border-b border-border">
+        <button
+          v-for="sec in sections"
+          :key="sec.key"
+          @click="activeTab = sec.key"
+          class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
+          :class="activeTab === sec.key
+            ? 'border-active text-active'
+            : 'border-transparent text-text-muted hover:text-text'"
+        >{{ sec.title }}</button>
+      </div>
+
+      <!-- Tab content -->
+      <template v-for="sec in sections" :key="sec.key">
+        <div v-if="activeTab === sec.key">
+          <p class="mb-3 text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> Last {{ LAST_N }} avg — top 20</p>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-border text-text-muted">
+                  <th class="py-2 pr-4 text-left font-medium">Player</th>
+                  <th class="py-2 pr-4 text-left font-medium whitespace-nowrap">Club</th>
+                  <th class="py-2 px-2 text-right font-medium">Gms</th>
+                  <th
+                    v-for="col in statCols" :key="col.key"
+                    class="py-2 px-2 text-right font-medium"
+                    :class="col.key === sec.key ? 'text-text' : ''"
+                  >{{ col.label }}</th>
+                  <th
+                    class="py-2 pl-2 pr-3 text-right font-medium"
+                    :class="sec.key === 'star' ? 'text-yellow-400' : 'text-text-muted opacity-60'"
+                  >★</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="row in sec.rows"
+                  :key="row.id"
+                  class="border-b border-border-subtle hover:bg-surface-hover"
+                >
+                  <td class="py-2 pr-4 font-medium">
+                    <router-link
+                      :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
+                      class="hover:text-text-muted transition-colors"
+                    >{{ row.playerName }}</router-link>
+                  </td>
+                  <td class="py-2 pr-4 text-xs text-text-muted whitespace-nowrap">
+                    <router-link
+                      v-if="row.clubSeasonId"
+                      :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.clubSeasonId } }"
+                      class="inline-flex items-center gap-1.5 hover:text-text transition-colors"
+                    >
+                      <img :src="clubLogoUrl(row.clubName)" class="w-4 h-4 object-contain" />
+                      {{ row.clubName }}
+                    </router-link>
+                    <span v-else>{{ row.clubName ?? '—' }}</span>
+                  </td>
+                  <td class="py-2 px-2 text-right tabular-nums text-text-muted text-xs">{{ row.games ?? '—' }}</td>
+                  <td v-for="col in statCols" :key="col.key" class="py-2 px-2 tabular-nums">
+                    <StatCell
+                      :avg="row.statsAll?.[col.key]"
+                      :last3="row.statsLastN?.[col.key]"
+                      :avg-style="statHeat(row.statsAll?.[col.key], col.key)"
+                      :last3-style="statHeat(row.statsLastN?.[col.key], col.key)"
+                    />
+                  </td>
+                  <td class="py-2 pl-2 pr-3 tabular-nums">
+                    <StatCell
+                      :avg="row.statsAll ? starScore(row.statsAll) : null"
+                      :last3="row.statsLastN ? starScore(row.statsLastN) : null"
+                      :avg-style="statHeat(row.statsAll ? starScore(row.statsAll) : null, 'star')"
+                      :last3-style="statHeat(row.statsLastN ? starScore(row.statsLastN) : null, 'star')"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useQuery } from '@vue/apollo-composable'
+import { useTheme } from '@/composables/useTheme'
+import { heatStyle } from '@/utils/heatmap'
+import { statCols, starScore, type StatSummary, type StatKey, LAST_N } from '../utils/playerStats'
+import { POSITION_LABEL } from '../utils/position'
+import StatCell from '../components/StatCell.vue'
+import { GET_FREE_AGENTS } from '../api/queries'
+import { useFflState } from '../composables/useFflState'
+import { clubLogoUrl } from '@/features/afl/utils/clubLogos'
+
+const { liveSeasonId } = useFflState()
+const { isDark } = useTheme()
+
+const { result, loading, error } = useQuery(
+  GET_FREE_AGENTS,
+  () => ({ fflSeasonId: liveSeasonId.value }),
+  () => ({ enabled: !!liveSeasonId.value }),
+)
+
+type SectionKey = StatKey | 'star'
+
+const activeTab = ref<SectionKey>('kicks')
+
+interface PlayerSeasonRaw {
+  id: string
+  player: { id: string; name: string }
+  clubSeason: { id: string; club: { id: string; name: string } } | null
+  statsAll: (StatSummary & { games?: number }) | null
+  statsLastN: StatSummary | null
+  fflPlayerSeasons: { toRoundId: string | null }[]
+}
+
+interface MappedRow {
+  id: string
+  playerName: string
+  clubName: string | null
+  clubSeasonId: string | null
+  games: number | null
+  statsAll: StatSummary | null
+  statsLastN: StatSummary | null
+}
+
+const rows = computed((): MappedRow[] => {
+  const nodes: PlayerSeasonRaw[] = result.value?.fflSeason?.aflSeason?.playerSeasons?.nodes ?? []
+  return nodes
+    .filter(n => n.fflPlayerSeasons.length === 0 || !n.fflPlayerSeasons.some(s => s.toRoundId === null))
+    .map(n => ({
+      id: n.id,
+      playerName: n.player.name,
+      clubName: n.clubSeason?.club.name ?? null,
+      clubSeasonId: n.clubSeason?.id ?? null,
+      games: n.statsAll?.games ?? null,
+      statsAll: n.statsAll,
+      statsLastN: n.statsLastN,
+    }))
+})
+
+// Global heatmap ranges — consistent colours across all tabs
+const columnRange = computed(() => {
+  const range = {} as Record<SectionKey, { min: number; max: number }>
+  for (const col of statCols) {
+    const vals = rows.value.map(r => r.statsLastN?.[col.key]).filter((v): v is number => v != null)
+    if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  const starVals = rows.value.map(r => r.statsLastN ? starScore(r.statsLastN) : null).filter((v): v is number => v != null)
+  if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
+  return range
+})
+
+function statHeat(value: number | null | undefined, key: SectionKey): Record<string, string> {
+  if (value == null) return {}
+  const r = columnRange.value[key]
+  if (!r) return {}
+  return heatStyle(value, r.min, r.max, isDark.value)
+}
+
+function sortVal(row: MappedRow, key: SectionKey): number {
+  if (key === 'star') {
+    return row.statsLastN ? starScore(row.statsLastN) : row.statsAll ? starScore(row.statsAll) : -1
+  }
+  return row.statsLastN?.[key] ?? row.statsAll?.[key] ?? -1
+}
+
+const sections = computed(() => {
+  const defs: { key: SectionKey; title: string }[] = [
+    ...statCols.map(c => ({ key: c.key as SectionKey, title: POSITION_LABEL[c.key] ?? c.label })),
+    { key: 'star', title: POSITION_LABEL['star'] ?? 'Star' },
+  ]
+  return defs.map(def => ({
+    ...def,
+    rows: [...rows.value]
+      .sort((a, b) => sortVal(b, def.key) - sortVal(a, def.key))
+      .slice(0, 20),
+  }))
+})
+</script>

--- a/frontend/web/src/features/ffl/views/FreeAgentsView.vue
+++ b/frontend/web/src/features/ffl/views/FreeAgentsView.vue
@@ -49,10 +49,12 @@
                   class="border-b border-border-subtle hover:bg-surface-hover"
                 >
                   <td class="py-2 pr-4 font-medium">
-                    <router-link
-                      :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
-                      class="hover:text-text-muted transition-colors"
-                    >{{ row.playerName }}</router-link>
+                    <PlayerStatsCard :name="row.playerName" :club="row.clubName" :afl-status="null" :afl-player-season-id="row.id" :afl-round-id="null">
+                      <router-link
+                        :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.id } }"
+                        class="hover:text-text-muted transition-colors"
+                      >{{ row.playerName }}</router-link>
+                    </PlayerStatsCard>
                   </td>
                   <td class="py-2 pr-4 text-xs text-text-muted whitespace-nowrap">
                     <router-link
@@ -100,6 +102,7 @@ import { heatStyle } from '@/utils/heatmap'
 import { statCols, starScore, type StatSummary, type StatKey, LAST_N } from '../utils/playerStats'
 import { POSITION_LABEL } from '../utils/position'
 import StatCell from '../components/StatCell.vue'
+import PlayerStatsCard from '../components/PlayerStatsCard.vue'
 import { GET_FREE_AGENTS } from '../api/queries'
 import { useFflState } from '../composables/useFflState'
 import { clubLogoUrl } from '@/features/afl/utils/clubLogos'

--- a/frontend/web/src/features/ffl/views/FreeAgentsView.vue
+++ b/frontend/web/src/features/ffl/views/FreeAgentsView.vue
@@ -1,53 +1,67 @@
 <template>
   <div>
-    <div class="mb-6">
+    <div class="mb-6 flex items-center justify-between">
       <h1 class="text-2xl font-bold text-text">Free Agents</h1>
+      <span
+        class="text-xs text-text-faint whitespace-nowrap"
+        :title="`Cells show season avg then last ${LAST_N} avg. ↑/↓ = last ${LAST_N} form at least 15% above/below season average`"
+      >
+        <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = last {{ LAST_N }} form
+      </span>
+      <!-- Rank basis toggle: which average ranks the top-20 cut -->
+      <div class="flex items-center rounded border border-border overflow-hidden text-[10px] text-text-faint">
+        <button
+          class="px-1.5 py-0.5 transition-colors"
+          :class="statSource === 'form' ? 'bg-control text-text' : 'hover:text-text'"
+          :title="`Rank the top 20 by last ${LAST_N} averages`"
+          @click="statSource = 'form'"
+        >Last {{ LAST_N }}</button>
+        <button
+          class="px-1.5 py-0.5 transition-colors"
+          :class="statSource === 'season' ? 'bg-control text-text' : 'hover:text-text'"
+          title="Rank the top 20 by season averages"
+          @click="statSource = 'season'"
+        >Season</button>
+      </div>
     </div>
 
     <div v-if="loading" class="text-text-faint">Loading...</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else>
-      <!-- Tab navigation -->
-      <div class="flex gap-1 mb-6 border-b border-border">
-        <button
-          v-for="sec in sections"
-          :key="sec.key"
-          @click="activeTab = sec.key"
-          class="px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
-          :class="activeTab === sec.key
-            ? 'border-active text-active'
-            : 'border-transparent text-text-muted hover:text-text'"
-        >{{ sec.title }}</button>
-      </div>
-
-      <!-- Tab content -->
-      <template v-for="sec in sections" :key="sec.key">
-        <div v-if="activeTab === sec.key">
-          <p class="mb-3 text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> Last {{ LAST_N }} avg — top 20</p>
-          <div class="overflow-x-auto">
-            <table class="w-full text-sm">
-              <thead>
-                <tr class="border-b border-border text-text-muted">
-                  <th class="py-2 pr-4 text-left font-medium">Player</th>
-                  <th class="py-2 pr-4 text-left font-medium whitespace-nowrap">Club</th>
-                  <th class="py-2 px-2 text-right font-medium">Gms</th>
-                  <th
-                    v-for="col in statCols" :key="col.key"
-                    class="py-2 px-2 text-right font-medium"
-                    :class="col.key === sec.key ? 'text-text' : ''"
-                  >{{ col.label }}</th>
-                  <th
-                    class="py-2 pl-2 pr-3 text-right font-medium"
-                    :class="sec.key === 'star' ? 'text-yellow-400' : 'text-text-muted opacity-60'"
-                  >★</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  v-for="row in sec.rows"
-                  :key="row.id"
-                  class="border-b border-border-subtle hover:bg-surface-hover"
-                >
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-border text-text-muted">
+              <th class="py-2 pr-4 text-left font-medium">Player</th>
+              <th class="py-2 pr-4 text-left font-medium whitespace-nowrap">Club</th>
+              <th class="py-2 px-2 text-right font-medium">Gms</th>
+              <th
+                v-for="col in statCols" :key="col.key"
+                class="py-2 px-2 text-right font-medium"
+              >
+                <button
+                  class="transition-colors"
+                  :class="col.key === activeKey ? 'text-sky-400' : 'hover:text-text'"
+                  :title="`Top 20 by ${POSITION_LABEL[col.key]}, ranked on ${rankBasisLabel} average`"
+                  @click="activeKey = col.key"
+                >{{ POSITION_LABEL[col.key] }}</button>
+              </th>
+              <th class="py-2 pl-2 pr-3 text-right font-medium">
+                <button
+                  class="transition-colors"
+                  :class="activeKey === 'star' ? 'text-sky-400' : 'text-text-muted hover:text-text'"
+                  :title="`Top 20 by Star score, ranked on ${rankBasisLabel} average`"
+                  @click="activeKey = 'star'"
+                >Star <span class="text-yellow-400">★</span></button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="row in topRows"
+              :key="row.id"
+              class="border-b border-border-subtle hover:bg-surface-hover"
+            >
                   <td class="py-2 pr-4 font-medium">
                     <PlayerStatsCard :name="row.playerName" :club="row.clubName" :afl-status="null" :afl-player-season-id="row.id" :afl-round-id="null">
                       <router-link
@@ -84,12 +98,10 @@
                       :last3-style="statHeat(row.statsLastN ? starScore(row.statsLastN) : null, 'star')"
                     />
                   </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </template>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </template>
   </div>
 </template>
@@ -118,7 +130,13 @@ const { result, loading, error } = useQuery(
 
 type SectionKey = StatKey | 'star'
 
-const activeTab = ref<SectionKey>('kicks')
+// Stat that ranks the top-20 cut — set by clicking a column header.
+const activeKey = ref<SectionKey>('kicks')
+
+// Which average ranks the cut (and scales the heatmap): last-N form or season.
+const statSource = ref<'form' | 'season'>('form')
+
+const rankBasisLabel = computed(() => statSource.value === 'form' ? `last ${LAST_N}` : 'season')
 
 interface PlayerSeasonRaw {
   id: string
@@ -154,14 +172,16 @@ const rows = computed((): MappedRow[] => {
     }))
 })
 
-// Global heatmap ranges — consistent colours across all tabs
+// Global heatmap ranges — consistent colours across all columns, scaled to the
+// active rank basis.
 const columnRange = computed(() => {
+  const src = (r: MappedRow) => statSource.value === 'form' ? r.statsLastN : r.statsAll
   const range = {} as Record<SectionKey, { min: number; max: number }>
   for (const col of statCols) {
-    const vals = rows.value.map(r => r.statsLastN?.[col.key]).filter((v): v is number => v != null)
+    const vals = rows.value.map(r => src(r)?.[col.key]).filter((v): v is number => v != null)
     if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
   }
-  const starVals = rows.value.map(r => r.statsLastN ? starScore(r.statsLastN) : null).filter((v): v is number => v != null)
+  const starVals = rows.value.map(r => { const s = src(r); return s ? starScore(s) : null }).filter((v): v is number => v != null)
   if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
   return range
 })
@@ -174,22 +194,18 @@ function statHeat(value: number | null | undefined, key: SectionKey): Record<str
 }
 
 function sortVal(row: MappedRow, key: SectionKey): number {
+  const [primary, fallback] = statSource.value === 'form'
+    ? [row.statsLastN, row.statsAll]
+    : [row.statsAll, row.statsLastN]
   if (key === 'star') {
-    return row.statsLastN ? starScore(row.statsLastN) : row.statsAll ? starScore(row.statsAll) : -1
+    return primary ? starScore(primary) : fallback ? starScore(fallback) : -1
   }
-  return row.statsLastN?.[key] ?? row.statsAll?.[key] ?? -1
+  return primary?.[key] ?? fallback?.[key] ?? -1
 }
 
-const sections = computed(() => {
-  const defs: { key: SectionKey; title: string }[] = [
-    ...statCols.map(c => ({ key: c.key as SectionKey, title: POSITION_LABEL[c.key] ?? c.label })),
-    { key: 'star', title: POSITION_LABEL['star'] ?? 'Star' },
-  ]
-  return defs.map(def => ({
-    ...def,
-    rows: [...rows.value]
-      .sort((a, b) => sortVal(b, def.key) - sortVal(a, def.key))
-      .slice(0, 20),
-  }))
-})
+const topRows = computed(() =>
+  [...rows.value]
+    .sort((a, b) => sortVal(b, activeKey.value) - sortVal(a, activeKey.value))
+    .slice(0, 20),
+)
 </script>

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -7,10 +7,12 @@
         <Breadcrumb v-if="round" :items="breadcrumbs" />
         <h1 class="text-2xl font-bold flex items-center gap-3">
           <img v-if="match.homeClubMatch" :src="clubLogoUrl(match.homeClubMatch.club.name)" :alt="match.homeClubMatch.club.name" class="w-10 h-10 object-contain" />
-          {{ match.homeClubMatch?.club.name ?? '—' }}
+          <router-link v-if="match.homeClubMatch" :to="{ name: 'ffl-club-season', params: { clubSeasonId: match.homeClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.homeClubMatch.club.name }}</router-link>
+          <span v-else>—</span>
           <span class="text-text-faint mx-1">v</span>
           <img v-if="match.awayClubMatch" :src="clubLogoUrl(match.awayClubMatch.club.name)" :alt="match.awayClubMatch.club.name" class="w-10 h-10 object-contain" />
-          {{ match.awayClubMatch?.club.name ?? '—' }}
+          <router-link v-if="match.awayClubMatch" :to="{ name: 'ffl-club-season', params: { clubSeasonId: match.awayClubMatch.clubSeasonId } }" class="hover:text-text-muted transition-colors">{{ match.awayClubMatch.club.name }}</router-link>
+          <span v-else>—</span>
         </h1>
         <p v-if="match.venue" class="text-sm text-text-muted mt-1">{{ match.venue }}</p>
         <p v-if="match.result" class="text-lg font-semibold mt-2">
@@ -18,8 +20,9 @@
         </p>
       </div>
 
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <div v-for="side in sides" :key="side.label">
+      <!-- Headers row: both cells share the same row height, so SquadTables below always align -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 mb-0">
+        <div v-for="side in sides" :key="side.label + '-hd'" class="mb-3">
           <div class="flex items-center gap-2 mb-1">
             <img v-if="side.clubMatch" :src="clubLogoUrl(side.clubMatch.club.name)" :alt="side.clubMatch.club.name" class="w-8 h-8 object-contain" />
             <h2 class="text-lg font-semibold">
@@ -39,7 +42,7 @@
           </p>
           <div
             v-if="side.clubMatch?.club.id === selectedClubId && (side.clubMatch?.suggestedSubstitutions?.length ?? 0) > 0"
-            class="mb-3 rounded-lg border border-sky-500/30 bg-sky-500/10 px-4 py-3"
+            class="rounded-lg border border-sky-500/30 bg-sky-500/10 px-4 py-3"
           >
             <p class="text-xs font-semibold text-sky-400 mb-1">Improve your score:</p>
             <ul class="space-y-0.5">
@@ -53,6 +56,12 @@
               </li>
             </ul>
           </div>
+        </div>
+      </div>
+
+      <!-- Tables row: starts at the same Y for both columns -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-8">
+        <div v-for="side in sides" :key="side.label + '-tbl'">
           <SquadTable v-if="side.clubMatch" :player-matches="side.clubMatch.playerMatches" />
         </div>
       </div>

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -62,7 +62,7 @@
       <!-- Tables row: starts at the same Y for both columns -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-8">
         <div v-for="side in sides" :key="side.label + '-tbl'">
-          <SquadTable v-if="side.clubMatch" :player-matches="side.clubMatch.playerMatches" />
+          <SquadTable v-if="side.clubMatch" :player-matches="side.clubMatch.playerMatches" :highlight-pm-id="highlightPmId" />
         </div>
       </div>
 
@@ -71,7 +71,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useQuery } from '@vue/apollo-composable'
 import { GET_FFL_MATCH } from '../api/queries'
 import Breadcrumb from '../components/Breadcrumb.vue'
@@ -82,11 +83,25 @@ import IconTeamBuilder from '../components/icons/IconTeamBuilder.vue'
 
 const props = defineProps<{ matchId: string }>()
 
+const route = useRoute()
 const { selectedClubId } = useFflState()
 const { result, loading, error } = useQuery(GET_FFL_MATCH, () => ({ id: props.matchId }))
 
 const match = computed(() => result.value?.fflMatch ?? null)
 const round = computed(() => match.value?.round ?? null)
+
+const highlightPmId = computed(() => (route.query.highlight as string) || null)
+
+let scrolledToHighlight = false
+watch(match, (m) => {
+  if (!m || !highlightPmId.value || scrolledToHighlight) return
+  scrolledToHighlight = true
+  const id = highlightPmId.value
+  setTimeout(() => {
+    const el = document.getElementById(`pm-${id}`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, 300)
+}, { immediate: true })
 
 const breadcrumbs = computed(() => {
   if (!match.value || !round.value) return []

--- a/frontend/web/src/features/ffl/views/MatchView.vue
+++ b/frontend/web/src/features/ffl/views/MatchView.vue
@@ -25,19 +25,14 @@
             <h2 class="text-lg font-semibold">
               <router-link
                 v-if="side.clubMatch"
-                :to="{ name: 'ffl-club-season', params: { clubSeasonId: side.clubMatch.clubSeasonId } }"
-                class="hover:text-active transition-colors"
-              >{{ side.label }}</router-link>
+                :to="{ name: side.clubMatch.club.id === selectedClubId ? 'ffl-club-match-edit' : 'ffl-club-match', params: { clubMatchId: side.clubMatch.id } }"
+                class="inline-flex items-center gap-1.5 hover:text-active transition-colors"
+              >
+                {{ side.label }}
+                <IconTeamBuilder v-if="side.clubMatch.club.id === selectedClubId" class="w-4 h-4" />
+              </router-link>
               <span v-else>{{ side.label }}</span>
             </h2>
-            <router-link
-              v-if="myClubMatchId && side.clubMatch?.club.id === selectedClubId"
-              :to="{ name: 'ffl-club-match-edit', params: { clubMatchId: myClubMatchId } }"
-              title="Team Builder"
-              class="rounded p-1 text-active hover:bg-active/10 transition-colors"
-            >
-              <IconTeamBuilder class="w-4 h-4" />
-            </router-link>
           </div>
           <p class="text-sm text-text-muted mb-3">
             Score: <span class="font-semibold text-text">{{ side.clubMatch?.score ?? 0 }}</span>
@@ -91,14 +86,6 @@ const breadcrumbs = computed(() => {
     { label: round.value.season.name, to: { name: 'home' } },
     { label: round.value.name, to: { name: 'ffl-round', params: { roundId: round.value.id } } },
   ]
-})
-
-const myClubMatchId = computed(() => {
-  if (!match.value || !selectedClubId.value) return null
-  const clubId = selectedClubId.value
-  if (match.value.homeClubMatch?.club.id === clubId) return match.value.homeClubMatch.id
-  if (match.value.awayClubMatch?.club.id === clubId) return match.value.awayClubMatch.id
-  return null
 })
 
 const sides = computed(() => {

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -47,7 +47,7 @@
                 >
                   <div class="flex items-center gap-2 min-w-0">
                     <img :src="clubLogoUrl(player.club)" :alt="player.club" class="w-5 h-5 object-contain shrink-0" />
-                    <span class="text-sm font-medium truncate">{{ player.name }}</span>
+                    <router-link :to="{ name: 'ffl-match', params: { matchId: player.matchId } }" class="text-sm font-medium truncate hover:text-text-muted transition-colors">{{ player.name }}</router-link>
                   </div>
                   <span class="text-sm tabular-nums font-semibold shrink-0">{{ player.score }}</span>
                 </div>
@@ -144,6 +144,7 @@ interface ClubMatch {
 }
 
 interface Match {
+  id: string
   homeClubMatch?: ClubMatch | null
   awayClubMatch?: ClubMatch | null
 }
@@ -155,7 +156,7 @@ const POSITION_LABELS: Record<string, string> = {
 
 const TOP_SCORERS_POSITIONS = ['goals', 'kicks', 'handballs', 'marks', 'tackles', 'hitouts', 'star'] as const
 
-type ScorerEntry = { name: string; club: string; score: number; position: string }
+type ScorerEntry = { name: string; club: string; score: number; position: string; matchId: string }
 
 const topScorersByPosition = computed(() => {
   if (!round.value) return {} as Record<string, { label: string; players: ScorerEntry[] }>
@@ -166,7 +167,7 @@ const topScorersByPosition = computed(() => {
       if (!side) continue
       for (const pm of side.playerMatches) {
         if (pm.aflStatus === 'played' && pm.position) {
-          ;(grouped[pm.position] ??= []).push({ name: pm.player.aflPlayer.name, club: side.club.name, score: pm.score, position: pm.position })
+          ;(grouped[pm.position] ??= []).push({ name: pm.player.aflPlayer.name, club: side.club.name, score: pm.score, position: pm.position, matchId: match.id })
         }
       }
     }

--- a/frontend/web/src/features/ffl/views/RoundView.vue
+++ b/frontend/web/src/features/ffl/views/RoundView.vue
@@ -47,7 +47,7 @@
                 >
                   <div class="flex items-center gap-2 min-w-0">
                     <img :src="clubLogoUrl(player.club)" :alt="player.club" class="w-5 h-5 object-contain shrink-0" />
-                    <router-link :to="{ name: 'ffl-match', params: { matchId: player.matchId } }" class="text-sm font-medium truncate hover:text-text-muted transition-colors">{{ player.name }}</router-link>
+                    <router-link :to="{ name: 'ffl-match', params: { matchId: player.matchId }, query: { highlight: player.pmId } }" class="text-sm font-medium truncate hover:text-text-muted transition-colors">{{ player.name }}</router-link>
                   </div>
                   <span class="text-sm tabular-nums font-semibold shrink-0">{{ player.score }}</span>
                 </div>
@@ -132,9 +132,11 @@ const myClubMatchId = computed(() => {
 })
 
 interface PlayerMatch {
+  id: string
   player: { aflPlayer: { name: string } }
   position: string | null
   status: string | null
+  aflStatus: string | null
   score: number
 }
 
@@ -156,7 +158,7 @@ const POSITION_LABELS: Record<string, string> = {
 
 const TOP_SCORERS_POSITIONS = ['goals', 'kicks', 'handballs', 'marks', 'tackles', 'hitouts', 'star'] as const
 
-type ScorerEntry = { name: string; club: string; score: number; position: string; matchId: string }
+type ScorerEntry = { name: string; club: string; score: number; position: string; matchId: string; pmId: string }
 
 const topScorersByPosition = computed(() => {
   if (!round.value) return {} as Record<string, { label: string; players: ScorerEntry[] }>
@@ -167,7 +169,7 @@ const topScorersByPosition = computed(() => {
       if (!side) continue
       for (const pm of side.playerMatches) {
         if (pm.aflStatus === 'played' && pm.position) {
-          ;(grouped[pm.position] ??= []).push({ name: pm.player.aflPlayer.name, club: side.club.name, score: pm.score, position: pm.position, matchId: match.id })
+          ;(grouped[pm.position] ??= []).push({ name: pm.player.aflPlayer.name, club: side.club.name, score: pm.score, position: pm.position, matchId: match.id, pmId: pm.id })
         }
       }
     }

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -55,7 +55,7 @@
                 : 'border-transparent text-text-muted hover:text-text hover:border-border'"
             >{{ seg.label }}</button>
           </div>
-          <p v-show="statsView === 'stats'" class="text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> Last 3 avg</p>
+          <p v-show="statsView === 'stats'" class="text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> Last {{ LAST_N }} avg</p>
         </div>
 
         <div class="overflow-x-auto">
@@ -115,23 +115,21 @@
                   <!-- Stats cells -->
                   <template v-for="col in statCols" :key="col.key">
                   <td v-show="statsView === 'stats'" class="py-2 px-2 tabular-nums">
-                    <div class="flex items-end justify-end gap-1">
-                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll?.[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
-                      <template v-if="row.aflPlayerSeason?.statsLast3?.[col.key] != null">
-                        <span v-if="trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])" class="text-[10px]" :class="trendCls(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])">{{ trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
-                        <span :style="statHeat(row.aflPlayerSeason.statsLast3[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason.statsLast3[col.key]) }}</span>
-                      </template>
-                    </div>
+                    <StatCell
+                      :avg="row.aflPlayerSeason?.statsAll?.[col.key]"
+                      :last3="row.aflPlayerSeason?.statsLastN?.[col.key]"
+                      :avg-style="statHeat(row.aflPlayerSeason?.statsAll?.[col.key], col.key)"
+                      :last3-style="statHeat(row.aflPlayerSeason?.statsLastN?.[col.key], col.key)"
+                    />
                   </td>
                   </template>
                   <td v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 tabular-nums">
-                    <div class="flex items-end justify-end gap-1">
-                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null, 'star')">{{ row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll).toFixed(1) : '—' }}</span>
-                      <template v-if="row.aflPlayerSeason?.statsLast3">
-                        <span v-if="trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)" class="text-[10px]" :class="trendCls(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)">{{ trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null) }}</span>
-                        <span :style="statHeat(starScore(row.aflPlayerSeason.statsLast3), 'star')">{{ starScore(row.aflPlayerSeason.statsLast3).toFixed(1) }}</span>
-                      </template>
-                    </div>
+                    <StatCell
+                      :avg="row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null"
+                      :last3="row.aflPlayerSeason?.statsLastN ? starScore(row.aflPlayerSeason.statsLastN) : null"
+                      :avg-style="statHeat(row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null, 'star')"
+                      :last3-style="statHeat(row.aflPlayerSeason?.statsLastN ? starScore(row.aflPlayerSeason.statsLastN) : null, 'star')"
+                    />
                   </td>
                 </tr>
                 <tr v-if="expandedId === row.id && statsView === 'squad'" class="border-b border-border-subtle">
@@ -188,23 +186,21 @@
                   <td v-show="statsView === 'squad' && isMyClub && managing" class="py-2 px-2"></td>
                   <template v-for="col in statCols" :key="col.key">
                   <td v-show="statsView === 'stats'" class="py-2 px-2 tabular-nums">
-                    <div class="flex items-end justify-end gap-1">
-                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll?.[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
-                      <template v-if="row.aflPlayerSeason?.statsLast3?.[col.key] != null">
-                        <span v-if="trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])" class="text-[10px]" :class="trendCls(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])">{{ trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
-                        <span :style="statHeat(row.aflPlayerSeason.statsLast3[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason.statsLast3[col.key]) }}</span>
-                      </template>
-                    </div>
+                    <StatCell
+                      :avg="row.aflPlayerSeason?.statsAll?.[col.key]"
+                      :last3="row.aflPlayerSeason?.statsLastN?.[col.key]"
+                      :avg-style="statHeat(row.aflPlayerSeason?.statsAll?.[col.key], col.key)"
+                      :last3-style="statHeat(row.aflPlayerSeason?.statsLastN?.[col.key], col.key)"
+                    />
                   </td>
                   </template>
                   <td v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 tabular-nums">
-                    <div class="flex items-end justify-end gap-1">
-                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null, 'star')">{{ row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll).toFixed(1) : '—' }}</span>
-                      <template v-if="row.aflPlayerSeason?.statsLast3">
-                        <span v-if="trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)" class="text-[10px]" :class="trendCls(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)">{{ trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null) }}</span>
-                        <span :style="statHeat(starScore(row.aflPlayerSeason.statsLast3), 'star')">{{ starScore(row.aflPlayerSeason.statsLast3).toFixed(1) }}</span>
-                      </template>
-                    </div>
+                    <StatCell
+                      :avg="row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null"
+                      :last3="row.aflPlayerSeason?.statsLastN ? starScore(row.aflPlayerSeason.statsLastN) : null"
+                      :avg-style="statHeat(row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null, 'star')"
+                      :last3-style="statHeat(row.aflPlayerSeason?.statsLastN ? starScore(row.aflPlayerSeason.statsLastN) : null, 'star')"
+                    />
                   </td>
                 </tr>
                 <tr v-if="expandedId === row.id && statsView === 'squad'" class="border-b border-border-subtle opacity-40">
@@ -280,6 +276,8 @@ import { ref, computed, watch } from 'vue'
 import { useQuery, useMutation } from '@vue/apollo-composable'
 import { useTheme } from '@/composables/useTheme'
 import { heatStyle } from '@/utils/heatmap'
+import { statCols, starScore, type StatSummary, type StatKey, LAST_N } from '../utils/playerStats'
+import StatCell from '../components/StatCell.vue'
 import { GET_FFL_CLUB_SEASON, GET_FFL_SEASON_POSITIONS, GET_FFL_ROUND_CLUB_MATCHES } from '../api/queries'
 import { REMOVE_FFL_PLAYER_FROM_SEASON, UPDATE_FFL_PLAYER_SEASON } from '../api/mutations'
 import { useFflState } from '../composables/useFflState'
@@ -481,10 +479,6 @@ async function onPlayerAdded() {
 }
 
 // Inline row expansion
-interface StatSummary {
-  goals: number; kicks: number; handballs: number
-  marks: number; tackles: number; hitouts: number
-}
 
 interface PlayerSeasonRow {
   id: string
@@ -493,46 +487,12 @@ interface PlayerSeasonRow {
     id: string
     clubSeason?: { id: string; club?: { name: string } } | null
     statsAll?: StatSummary | null
-    statsLast3?: StatSummary | null
+    statsLastN?: StatSummary | null
   } | null
   fromRoundId?: string | null
   toRoundId?: string | null
   notes?: string | null
   costCents?: number | null
-}
-
-// --- Stats view ---
-
-const statCols = [
-  { key: 'kicks'     as const, label: 'K' },
-  { key: 'handballs' as const, label: 'H' },
-  { key: 'marks'     as const, label: 'M' },
-  { key: 'tackles'   as const, label: 'T' },
-  { key: 'hitouts'   as const, label: 'R' },
-  { key: 'goals'     as const, label: 'G' },
-]
-
-type StatKey = typeof statCols[number]['key']
-
-function starScore(s: StatSummary): number {
-  return s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4
-}
-
-function fmtStat(val: number | null | undefined): string {
-  if (val == null) return '—'
-  return val.toFixed(1)
-}
-
-function trend(l3: number | null | undefined, avg: number | null | undefined): string {
-  if (l3 == null || avg == null) return ''
-  if (l3 === avg) return '='
-  return l3 > avg ? '↑' : '↓'
-}
-
-function trendCls(l3: number | null | undefined, avg: number | null | undefined): string {
-  if (l3 == null || avg == null) return ''
-  if (l3 === avg) return 'text-blue-400'
-  return l3 > avg ? 'text-green-400' : 'text-red-400'
 }
 
 const columnRange = computed(() => {
@@ -542,11 +502,11 @@ const columnRange = computed(() => {
   ] as PlayerSeasonRow[]
   const range = {} as Record<StatKey | 'star', { min: number; max: number }>
   for (const col of statCols) {
-    const vals = allRows.map(r => r.aflPlayerSeason?.statsLast3?.[col.key]).filter((v): v is number => v != null)
+    const vals = allRows.map(r => r.aflPlayerSeason?.statsLastN?.[col.key]).filter((v): v is number => v != null)
     if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
   }
   const starVals = allRows
-    .map(r => r.aflPlayerSeason?.statsLast3 ? starScore(r.aflPlayerSeason.statsLast3) : null)
+    .map(r => r.aflPlayerSeason?.statsLastN ? starScore(r.aflPlayerSeason.statsLastN) : null)
     .filter((v): v is number => v != null)
   if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
   return range

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -273,7 +273,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useQuery, useMutation } from '@vue/apollo-composable'
+import { useQuery, useMutation, useApolloClient } from '@vue/apollo-composable'
 import { useTheme } from '@/composables/useTheme'
 import { heatStyle } from '@/utils/heatmap'
 import { statCols, starScore, type StatSummary, type StatKey, LAST_N } from '../utils/playerStats'
@@ -293,6 +293,7 @@ import PlayerSearchModal from '../components/PlayerSearchModal.vue'
 const props = defineProps<{ clubSeasonId: string }>()
 
 const { selectedClubId, liveRoundId } = useFflState()
+const { client } = useApolloClient()
 const managing = ref(false)
 const showTraded = ref(false)
 
@@ -474,6 +475,13 @@ function cancelAddSearch() {
 
 async function onPlayerAdded() {
   addModalOpen.value = false
+  // The federation fields added to GET_FFL_CLUB_SEASON (~300ms) can cause a pre-mutation
+  // in-flight request to still be running when the mutation completes. Apollo deduplicates
+  // refetchSquad() against that stale in-flight and returns pre-mutation data.
+  // Fix: client.query with network-only creates an independent request that bypasses
+  // deduplication and waits past the stale in-flight. Once it resolves, there is no
+  // competing in-flight so the subsequent refetchSquad() fires cleanly.
+  await client.query({ query: GET_FFL_CLUB_SEASON, variables: { id: props.clubSeasonId }, fetchPolicy: 'network-only' })
   await refetchSquad()
   flashSaved()
 }

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -16,35 +16,34 @@
       </router-link>
     </div>
 
-    <!-- Manage toolbar — only for the selected club -->
-    <div v-if="isMyClub" class="mb-6 flex items-center gap-3">
-      <button
-        @click="managing = !managing"
-        class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
-        :class="managing
-          ? 'border-active bg-active text-active-text'
-          : 'border-border bg-surface text-text hover:bg-surface-hover'"
-      >
-        <span class="flex items-center gap-1.5">
-          <IconManage v-if="!managing" class="w-3.5 h-3.5" />
-          {{ managing ? 'Done' : 'Manage' }}
-        </span>
-      </button>
-      <button
-        v-if="managing"
-        @click="openAddSearch"
-        class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
-      >
-        + Add Player
-      </button>
-      <span v-if="saveMessage" class="text-sm text-green-500">{{ saveMessage }}</span>
-    </div>
-
     <div v-if="squadLoading" class="text-text-faint">Loading...</div>
     <div v-else-if="squadError" class="text-red-400">{{ squadError.message }}</div>
     <template v-else>
       <div v-if="players.length > 0">
-        <div class="mb-4 flex items-center gap-6">
+        <div class="mb-4 flex items-center gap-4">
+          <template v-if="isMyClub">
+            <button
+              @click="managing = !managing"
+              class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
+              :class="managing
+                ? 'border-active bg-active text-active-text'
+                : 'border-border bg-surface text-text hover:bg-surface-hover'"
+            >
+              <span class="flex items-center gap-1.5">
+                <IconManage v-if="!managing" class="w-3.5 h-3.5" />
+                {{ managing ? 'Done' : 'Manage' }}
+              </span>
+            </button>
+            <button
+              v-if="managing"
+              @click="openAddSearch"
+              class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
+            >
+              + Add Player
+            </button>
+            <span v-if="saveMessage" class="text-sm text-green-500">{{ saveMessage }}</span>
+            <span class="w-px h-5 bg-border"></span>
+          </template>
           <div class="flex">
             <button
               v-for="seg in segments"
@@ -56,7 +55,7 @@
                 : 'border-transparent text-text-muted hover:text-text hover:border-border'"
             >{{ seg.label }}</button>
           </div>
-          <p v-show="statsView === 'stats'" class="text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> L3 avg — heatmap on L3</p>
+          <p v-show="statsView === 'stats'" class="text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> Last 3 avg</p>
         </div>
 
         <div class="overflow-x-auto">
@@ -64,7 +63,7 @@
           <thead>
             <tr class="border-b border-border text-left text-text-muted">
               <th class="sticky left-0 z-20 bg-surface py-2 pr-3 font-medium w-36">Player</th>
-              <th class="sticky left-36 z-20 bg-surface py-2 pr-3 font-medium whitespace-nowrap">AFL Club</th>
+              <th class="sticky left-36 z-20 bg-surface py-2 pr-3 font-medium whitespace-nowrap">Club</th>
               <!-- Squad headers -->
               <th v-show="statsView === 'squad'" class="py-2 pl-4 w-full">
                 <div class="flex">

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -55,15 +55,33 @@
                 : 'border-transparent text-text-muted hover:text-text hover:border-border'"
             >{{ seg.label }}</button>
           </div>
-          <p v-show="statsView === 'stats'" class="text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> Last {{ LAST_N }} avg</p>
+          <StatSourceToggle v-show="statsView === 'stats'" class="ml-auto" />
         </div>
 
         <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b border-border text-left text-text-muted">
-              <th class="sticky left-0 z-20 bg-surface py-2 pr-3 font-medium w-36">Player</th>
-              <th class="sticky left-36 z-20 bg-surface py-2 pr-3 font-medium whitespace-nowrap">Club</th>
+              <th class="sticky left-0 z-20 bg-surface py-2 pr-3 font-medium w-36">
+                <button
+                  v-if="statsView === 'stats'"
+                  class="transition-colors"
+                  :class="statsSortKey === 'name' ? 'text-sky-400' : 'hover:text-text'"
+                  title="Sort by name (click again for position order)"
+                  @click="toggleStatsSort('name')"
+                >Player</button>
+                <template v-else>Player</template>
+              </th>
+              <th class="sticky left-36 z-20 bg-surface py-2 pr-3 font-medium whitespace-nowrap">
+                <button
+                  v-if="statsView === 'stats'"
+                  class="transition-colors"
+                  :class="statsSortKey === 'club' ? 'text-sky-400' : 'hover:text-text'"
+                  title="Sort by club (click again for position order)"
+                  @click="toggleStatsSort('club')"
+                >Club</button>
+                <template v-else>Club</template>
+              </th>
               <!-- Squad headers -->
               <th v-show="statsView === 'squad'" class="py-2 pl-4 w-full">
                 <div class="flex">
@@ -71,15 +89,29 @@
                 </div>
               </th>
               <th v-show="statsView === 'squad' && isMyClub && managing" class="py-2 px-2"></th>
-              <!-- Stats headers -->
+              <!-- Stats headers — click to sort, click again for position order -->
               <template v-for="col in statCols" :key="col.key">
-              <th v-show="statsView === 'stats'" class="py-2 px-2 font-medium text-right">{{ col.label }}</th>
+              <th v-show="statsView === 'stats'" class="py-2 px-2 font-medium text-right">
+                <button
+                  class="transition-colors"
+                  :class="statsSortKey === col.key ? 'text-sky-400' : 'hover:text-text'"
+                  :title="`Sort by ${POSITION_LABEL[col.key]} (click again for position order)`"
+                  @click="toggleStatsSort(col.key)"
+                >{{ POSITION_LABEL[col.key] }}</button>
+              </th>
               </template>
-              <th v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 font-medium text-right text-yellow-400">★</th>
+              <th v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 font-medium text-right">
+                <button
+                  class="transition-colors"
+                  :class="statsSortKey === 'star' ? 'text-sky-400' : 'text-text-muted hover:text-text'"
+                  title="Sort by Star score (click again for position order)"
+                  @click="toggleStatsSort('star')"
+                >Star <span class="text-yellow-400">★</span></button>
+              </th>
             </tr>
           </thead>
           <tbody>
-            <template v-for="(group, gi) in groupedPlayers" :key="group.pos ?? 'bench'">
+            <template v-for="(group, gi) in displayedGroups" :key="group.pos ?? 'bench'">
               <tr v-if="gi > 0"><td colspan="10" class="pt-3"></td></tr>
               <template v-for="row in group.players" :key="row.id">
                 <tr
@@ -91,8 +123,10 @@
                   @click="statsView === 'squad' && managing && toggleRow(row)"
                 >
                   <td class="sticky left-0 z-10 bg-surface group-hover:bg-surface-hover py-2 pr-3 font-medium w-36 truncate max-w-[144px]">
-                    <router-link v-if="row.aflPlayerSeason?.id" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }" class="hover:text-text-muted transition-colors" @click.stop>{{ row.player.aflPlayer.name }}</router-link>
-                    <span v-else>{{ row.player.aflPlayer.name }}</span>
+                    <PlayerStatsCard :name="row.player.aflPlayer.name" :club="row.aflPlayerSeason?.clubSeason?.club?.name ?? null" :afl-status="null" :afl-player-season-id="row.aflPlayerSeason?.id ?? null" :afl-round-id="null">
+                      <router-link v-if="row.aflPlayerSeason?.id" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }" class="hover:text-text-muted transition-colors" @click.stop>{{ row.player.aflPlayer.name }}</router-link>
+                      <span v-else>{{ row.player.aflPlayer.name }}</span>
+                    </PlayerStatsCard>
                   </td>
                   <td class="sticky left-36 z-10 bg-surface group-hover:bg-surface-hover py-2 pr-3 text-xs text-text-muted whitespace-nowrap">
                     <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="inline-flex items-center gap-1 hover:text-text transition-colors" @click.stop>
@@ -168,8 +202,10 @@
                   @click="statsView === 'squad' && managing && toggleRow(row)"
                 >
                   <td class="sticky left-0 z-10 bg-surface py-2 pr-3 font-medium w-36 truncate max-w-[144px]">
-                    <router-link v-if="row.aflPlayerSeason?.id" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }" class="hover:text-text-muted transition-colors" @click.stop>{{ row.player.aflPlayer.name }}</router-link>
-                    <span v-else>{{ row.player.aflPlayer.name }}</span>
+                    <PlayerStatsCard :name="row.player.aflPlayer.name" :club="row.aflPlayerSeason?.clubSeason?.club?.name ?? null" :afl-status="null" :afl-player-season-id="row.aflPlayerSeason?.id ?? null" :afl-round-id="null">
+                      <router-link v-if="row.aflPlayerSeason?.id" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }" class="hover:text-text-muted transition-colors" @click.stop>{{ row.player.aflPlayer.name }}</router-link>
+                      <span v-else>{{ row.player.aflPlayer.name }}</span>
+                    </PlayerStatsCard>
                   </td>
                   <td class="sticky left-36 z-10 bg-surface py-2 pr-3 text-xs text-text-muted whitespace-nowrap">
                     <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="inline-flex items-center gap-1 hover:text-text transition-colors" @click.stop>
@@ -276,8 +312,11 @@ import { ref, computed, watch } from 'vue'
 import { useQuery, useMutation, useApolloClient } from '@vue/apollo-composable'
 import { useTheme } from '@/composables/useTheme'
 import { heatStyle } from '@/utils/heatmap'
-import { statCols, starScore, type StatSummary, type StatKey, LAST_N } from '../utils/playerStats'
+import { statCols, starScore, type StatSummary, type StatKey } from '../utils/playerStats'
 import StatCell from '../components/StatCell.vue'
+import PlayerStatsCard from '../components/PlayerStatsCard.vue'
+import StatSourceToggle from '../components/StatSourceToggle.vue'
+import { useStatSource } from '../composables/useStatSource'
 import { GET_FFL_CLUB_SEASON, GET_FFL_SEASON_POSITIONS, GET_FFL_ROUND_CLUB_MATCHES } from '../api/queries'
 import { REMOVE_FFL_PLAYER_FROM_SEASON, UPDATE_FFL_PLAYER_SEASON } from '../api/mutations'
 import { useFflState } from '../composables/useFflState'
@@ -305,6 +344,7 @@ const segments: { id: StatsView; label: string }[] = [
 ]
 
 const { isDark } = useTheme()
+const { statSource } = useStatSource()
 
 const isMyClub = computed(() => !!selectedClubId.value && clubSeason.value?.club.id === selectedClubId.value)
 
@@ -418,6 +458,41 @@ const groupedPlayers = computed(() => {
   })
 })
 
+// --- Stats view sorting ---
+
+// Click a header to sort flat (stats descending, name/club ascending);
+// click it again to return to the default position-group order.
+type StatsSortKey = StatKey | 'star' | 'name' | 'club'
+const statsSortKey = ref<StatsSortKey | null>(null)
+
+function toggleStatsSort(key: StatsSortKey) {
+  statsSortKey.value = statsSortKey.value === key ? null : key
+}
+
+const displayedGroups = computed(() => {
+  const key = statsSortKey.value
+  if (statsView.value !== 'stats' || !key) return groupedPlayers.value
+
+  let sorted: PlayerSeasonRow[]
+  if (key === 'name') {
+    sorted = [...activePlayers.value].sort(byLastName)
+  } else if (key === 'club') {
+    const club = (r: PlayerSeasonRow) => r.aflPlayerSeason?.clubSeason?.club?.name ?? ''
+    sorted = [...activePlayers.value].sort((a, b) => club(a).localeCompare(club(b)) || byLastName(a, b))
+  } else {
+    const val = (r: PlayerSeasonRow): number => {
+      const ps = r.aflPlayerSeason
+      const s = statSource.value === 'form'
+        ? (ps?.statsLastN ?? ps?.statsAll)
+        : (ps?.statsAll ?? ps?.statsLastN)
+      if (!s) return -1
+      return key === 'star' ? starScore(s) : s[key]
+    }
+    sorted = [...activePlayers.value].sort((a, b) => val(b) - val(a))
+  }
+  return [{ pos: null, label: '', players: sorted }]
+})
+
 // --- Manage mode: add/remove ---
 
 // Saved flash
@@ -503,18 +578,21 @@ interface PlayerSeasonRow {
   costCents?: number | null
 }
 
+// Heatmap ranges scaled to the active stat source (global Last N/Season toggle).
 const columnRange = computed(() => {
   const allRows = [
     ...groupedPlayers.value.flatMap(g => g.players),
     ...tradedPlayers.value,
   ] as PlayerSeasonRow[]
+  const src = (r: PlayerSeasonRow) =>
+    statSource.value === 'form' ? r.aflPlayerSeason?.statsLastN : r.aflPlayerSeason?.statsAll
   const range = {} as Record<StatKey | 'star', { min: number; max: number }>
   for (const col of statCols) {
-    const vals = allRows.map(r => r.aflPlayerSeason?.statsLastN?.[col.key]).filter((v): v is number => v != null)
+    const vals = allRows.map(r => src(r)?.[col.key]).filter((v): v is number => v != null)
     if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
   }
   const starVals = allRows
-    .map(r => r.aflPlayerSeason?.statsLastN ? starScore(r.aflPlayerSeason.statsLastN) : null)
+    .map(r => { const s = src(r); return s ? starScore(s) : null })
     .filter((v): v is number => v != null)
   if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
   return range

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -81,7 +81,10 @@
                     >{{ row.player.aflPlayer.name }}</router-link>
                     <span v-else>{{ row.player.aflPlayer.name }}</span>
                   </td>
-                  <td class="py-2 pr-4 text-xs text-text-muted">{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</td>
+                  <td class="py-2 pr-4 text-xs text-text-muted">
+                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
+                    <span v-else>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</span>
+                  </td>
                   <td class="py-2">
                     <div class="flex gap-0.5">
                       <span
@@ -159,7 +162,10 @@
                     >{{ row.player.aflPlayer.name }}</router-link>
                     <span v-else>{{ row.player.aflPlayer.name }}</span>
                   </td>
-                  <td class="py-2 pr-4 text-xs text-text-muted">{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</td>
+                  <td class="py-2 pr-4 text-xs text-text-muted">
+                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
+                    <span v-else>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</span>
+                  </td>
                   <td class="py-2">
                     <div class="flex gap-0.5">
                       <span

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -82,7 +82,7 @@
                     <span v-else>{{ row.player.aflPlayer.name }}</span>
                   </td>
                   <td class="py-2 pr-4 text-xs text-text-muted">
-                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
+                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
                     <span v-else>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</span>
                   </td>
                   <td class="py-2">
@@ -163,7 +163,7 @@
                     <span v-else>{{ row.player.aflPlayer.name }}</span>
                   </td>
                   <td class="py-2 pr-4 text-xs text-text-muted">
-                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
+                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
                     <span v-else>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</span>
                   </td>
                   <td class="py-2">

--- a/frontend/web/src/features/ffl/views/SquadView.vue
+++ b/frontend/web/src/features/ffl/views/SquadView.vue
@@ -43,69 +43,99 @@
     <div v-if="squadLoading" class="text-text-faint">Loading...</div>
     <div v-else-if="squadError" class="text-red-400">{{ squadError.message }}</div>
     <template v-else>
-      <div v-if="players.length > 0" class="overflow-x-auto">
+      <div v-if="players.length > 0">
+        <div class="mb-4 flex items-center gap-6">
+          <div class="flex">
+            <button
+              v-for="seg in segments"
+              :key="seg.id"
+              @click="statsView = seg.id"
+              class="px-3 py-1 text-sm transition-colors border-b-2"
+              :class="statsView === seg.id
+                ? 'border-active text-text font-medium'
+                : 'border-transparent text-text-muted hover:text-text hover:border-border'"
+            >{{ seg.label }}</button>
+          </div>
+          <p v-show="statsView === 'stats'" class="text-xs text-text-faint">Season avg <span class="text-green-400">↑</span><span class="text-red-400">↓</span> L3 avg — heatmap on L3</p>
+        </div>
+
+        <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b border-border text-left text-text-muted">
-              <th class="py-2 pr-4 font-medium">Player</th>
-              <th class="py-2 pr-4 font-medium">Club</th>
-              <th class="py-2">
-                <div class="flex gap-0.5">
-                  <span
-                    v-for="round in rounds"
-                    :key="round.id"
-                    class="w-5 text-center text-[10px] text-text-faint font-normal"
-                  >{{ roundLabel(round.name) }}</span>
+              <th class="sticky left-0 z-20 bg-surface py-2 pr-3 font-medium w-36">Player</th>
+              <th class="sticky left-36 z-20 bg-surface py-2 pr-3 font-medium whitespace-nowrap">AFL Club</th>
+              <!-- Squad headers -->
+              <th v-show="statsView === 'squad'" class="py-2 pl-4 w-full">
+                <div class="flex">
+                  <span v-for="round in rounds" :key="round.id" class="flex-1 text-center text-[10px] text-text-faint font-normal">{{ roundLabel(round.name) }}</span>
                 </div>
               </th>
-              <th v-if="isMyClub && managing" class="py-2 px-2"></th>
+              <th v-show="statsView === 'squad' && isMyClub && managing" class="py-2 px-2"></th>
+              <!-- Stats headers -->
+              <template v-for="col in statCols" :key="col.key">
+              <th v-show="statsView === 'stats'" class="py-2 px-2 font-medium text-right">{{ col.label }}</th>
+              </template>
+              <th v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 font-medium text-right text-yellow-400">★</th>
             </tr>
           </thead>
           <tbody>
             <template v-for="(group, gi) in groupedPlayers" :key="group.pos ?? 'bench'">
-              <tr v-if="gi > 0"><td colspan="3" class="pt-3"></td></tr>
+              <tr v-if="gi > 0"><td colspan="10" class="pt-3"></td></tr>
               <template v-for="row in group.players" :key="row.id">
                 <tr
+                  class="group hover:bg-surface-hover"
                   :class="[
-                    managing ? 'cursor-pointer hover:bg-surface-hover' : '',
+                    statsView === 'squad' && managing ? 'cursor-pointer' : '',
                     expandedId === row.id ? '' : 'border-b border-border-subtle'
                   ]"
-                  @click="managing && toggleRow(row)"
+                  @click="statsView === 'squad' && managing && toggleRow(row)"
                 >
-                  <td class="py-2 pr-4 font-medium">
-                    <router-link
-                      v-if="row.aflPlayerSeason?.id"
-                      :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }"
-                      class="hover:underline hover:text-active transition-colors"
-                      @click.stop
-                    >{{ row.player.aflPlayer.name }}</router-link>
+                  <td class="sticky left-0 z-10 bg-surface group-hover:bg-surface-hover py-2 pr-3 font-medium w-36 truncate max-w-[144px]">
+                    <router-link v-if="row.aflPlayerSeason?.id" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }" class="hover:text-text-muted transition-colors" @click.stop>{{ row.player.aflPlayer.name }}</router-link>
                     <span v-else>{{ row.player.aflPlayer.name }}</span>
                   </td>
-                  <td class="py-2 pr-4 text-xs text-text-muted">
-                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
+                  <td class="sticky left-36 z-10 bg-surface group-hover:bg-surface-hover py-2 pr-3 text-xs text-text-muted whitespace-nowrap">
+                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="inline-flex items-center gap-1 hover:text-text transition-colors" @click.stop>
+                      <img :src="aflClubLogoUrl(row.aflPlayerSeason.clubSeason.club?.name ?? '')" class="w-4 h-4 object-contain shrink-0" />
+                      {{ row.aflPlayerSeason.clubSeason.club?.name ?? '—' }}
+                    </router-link>
                     <span v-else>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</span>
                   </td>
-                  <td class="py-2">
-                    <div class="flex gap-0.5">
-                      <span
-                        v-for="round in rounds"
-                        :key="round.id"
-                        class="w-5 text-center text-xs font-mono inline-block"
-                        :class="roundColor(row.id, round.id)"
-                      >{{ roundLetter(row.id, round.id) }}</span>
+                  <!-- Squad cells -->
+                  <td v-show="statsView === 'squad'" class="py-2 pl-4 w-full">
+                    <div class="flex">
+                      <span v-for="round in rounds" :key="round.id" class="flex-1 text-center text-xs font-mono" :class="roundColor(row.id, round.id)">{{ roundLetter(row.id, round.id) }}</span>
                     </div>
                   </td>
-                  <td v-if="isMyClub && managing" class="py-2 px-2 text-right" @click.stop>
-                    <button
-                      @click="openRemoveModal(row.id, row.player.aflPlayer.name, row.aflPlayerSeason?.clubSeason?.club?.name ?? '')"
-                      aria-label="Remove"
-                      class="text-red-400 hover:text-red-300 transition-colors"
-                    >
+                  <td v-show="statsView === 'squad' && isMyClub && managing" class="py-2 px-2 text-right" @click.stop>
+                    <button @click="openRemoveModal(row.id, row.player.aflPlayer.name, row.aflPlayerSeason?.clubSeason?.club?.name ?? '')" aria-label="Remove" class="text-red-400 hover:text-red-300 transition-colors">
                       <IconBin class="w-3.5 h-3.5" />
                     </button>
                   </td>
+                  <!-- Stats cells -->
+                  <template v-for="col in statCols" :key="col.key">
+                  <td v-show="statsView === 'stats'" class="py-2 px-2 tabular-nums">
+                    <div class="flex items-end justify-end gap-1">
+                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll?.[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
+                      <template v-if="row.aflPlayerSeason?.statsLast3?.[col.key] != null">
+                        <span v-if="trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])" class="text-[10px]" :class="trendCls(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])">{{ trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
+                        <span :style="statHeat(row.aflPlayerSeason.statsLast3[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason.statsLast3[col.key]) }}</span>
+                      </template>
+                    </div>
+                  </td>
+                  </template>
+                  <td v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 tabular-nums">
+                    <div class="flex items-end justify-end gap-1">
+                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null, 'star')">{{ row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll).toFixed(1) : '—' }}</span>
+                      <template v-if="row.aflPlayerSeason?.statsLast3">
+                        <span v-if="trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)" class="text-[10px]" :class="trendCls(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)">{{ trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null) }}</span>
+                        <span :style="statHeat(starScore(row.aflPlayerSeason.statsLast3), 'star')">{{ starScore(row.aflPlayerSeason.statsLast3).toFixed(1) }}</span>
+                      </template>
+                    </div>
+                  </td>
                 </tr>
-                <tr v-if="expandedId === row.id" class="border-b border-border-subtle">
+                <tr v-if="expandedId === row.id && statsView === 'squad'" class="border-b border-border-subtle">
                   <td colspan="4" class="pb-3 pt-1 px-0">
                     <div class="flex gap-4">
                       <div class="flex flex-col gap-2 text-xs shrink-0">
@@ -114,19 +144,9 @@
                         <div><div class="text-text-muted">Cost</div><div class="text-text">{{ formatCost(row.costCents) }}</div></div>
                       </div>
                       <div class="flex-1 flex flex-col" @click.stop>
-                        <textarea
-                          v-model="expandedNotes"
-                          rows="3"
-                          placeholder="Add notes..."
-                          class="flex-1 w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-text-faint focus:border-active focus:outline-none resize-none"
-                        />
+                        <textarea v-model="expandedNotes" rows="3" placeholder="Add notes..." class="flex-1 w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-text-faint focus:border-active focus:outline-none resize-none" />
                         <div class="flex justify-end mt-2">
-                          <button
-                            v-if="expandedDirty"
-                            @click="saveExpanded"
-                            :disabled="expandedSubmitting"
-                            class="rounded-lg px-3 py-1.5 text-xs font-medium bg-active text-active-text hover:opacity-90 transition-colors disabled:opacity-40"
-                          >{{ expandedSubmitting ? '…' : 'Save' }}</button>
+                          <button v-if="expandedDirty" @click="saveExpanded" :disabled="expandedSubmitting" class="rounded-lg px-3 py-1.5 text-xs font-medium bg-active text-active-text hover:opacity-90 transition-colors disabled:opacity-40">{{ expandedSubmitting ? '…' : 'Save' }}</button>
                         </div>
                       </div>
                     </div>
@@ -135,50 +155,60 @@
               </template>
             </template>
             <template v-if="tradedPlayers.length > 0">
-              <tr><td colspan="4" class="pt-4 pb-1">
-                <button
-                  @click="showTraded = !showTraded"
-                  class="flex items-center gap-1.5 text-xs font-medium text-text-faint uppercase tracking-wide hover:text-text-muted transition-colors"
-                >
+              <tr><td colspan="10" class="pt-4 pb-1">
+                <button @click="showTraded = !showTraded" class="flex items-center gap-1.5 text-xs font-medium text-text-faint uppercase tracking-wide hover:text-text-muted transition-colors">
                   <span>{{ showTraded ? '▾' : '▸' }}</span>
                   Traded ({{ tradedPlayers.length }})
                 </button>
               </td></tr>
               <template v-if="showTraded" v-for="row in tradedPlayers" :key="row.id">
                 <tr
-                  class="opacity-40"
+                  class="opacity-40 group hover:opacity-60"
                   :class="[
-                    managing ? 'cursor-pointer hover:opacity-60' : '',
+                    statsView === 'squad' && managing ? 'cursor-pointer' : '',
                     expandedId === row.id ? '' : 'border-b border-border-subtle'
                   ]"
-                  @click="managing && toggleRow(row)"
+                  @click="statsView === 'squad' && managing && toggleRow(row)"
                 >
-                  <td class="py-2 pr-4 font-medium">
-                    <router-link
-                      v-if="row.aflPlayerSeason?.id"
-                      :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }"
-                      class="hover:underline hover:text-active transition-colors"
-                      @click.stop
-                    >{{ row.player.aflPlayer.name }}</router-link>
+                  <td class="sticky left-0 z-10 bg-surface py-2 pr-3 font-medium w-36 truncate max-w-[144px]">
+                    <router-link v-if="row.aflPlayerSeason?.id" :to="{ name: 'ffl-afl-player-season', params: { aflPlayerSeasonId: row.aflPlayerSeason.id } }" class="hover:text-text-muted transition-colors" @click.stop>{{ row.player.aflPlayer.name }}</router-link>
                     <span v-else>{{ row.player.aflPlayer.name }}</span>
                   </td>
-                  <td class="py-2 pr-4 text-xs text-text-muted">
-                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="hover:text-text transition-colors" @click.stop>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</router-link>
+                  <td class="sticky left-36 z-10 bg-surface py-2 pr-3 text-xs text-text-muted whitespace-nowrap">
+                    <router-link v-if="row.aflPlayerSeason?.clubSeason?.id" :to="{ name: 'ffl-afl-club-season', params: { clubSeasonId: row.aflPlayerSeason.clubSeason.id } }" class="inline-flex items-center gap-1 hover:text-text transition-colors" @click.stop>
+                      <img :src="aflClubLogoUrl(row.aflPlayerSeason.clubSeason.club?.name ?? '')" class="w-4 h-4 object-contain shrink-0" />
+                      {{ row.aflPlayerSeason.clubSeason.club?.name ?? '—' }}
+                    </router-link>
                     <span v-else>{{ row.aflPlayerSeason?.clubSeason?.club?.name ?? '—' }}</span>
                   </td>
-                  <td class="py-2">
-                    <div class="flex gap-0.5">
-                      <span
-                        v-for="round in rounds"
-                        :key="round.id"
-                        class="w-5 text-center text-xs font-mono inline-block"
-                        :class="roundColor(row.id, round.id)"
-                      >{{ roundLetter(row.id, round.id) }}</span>
+                  <td v-show="statsView === 'squad'" class="py-2 pl-4 w-full">
+                    <div class="flex">
+                      <span v-for="round in rounds" :key="round.id" class="flex-1 text-center text-xs font-mono" :class="roundColor(row.id, round.id)">{{ roundLetter(row.id, round.id) }}</span>
                     </div>
                   </td>
-                  <td v-if="isMyClub && managing" class="py-2 px-2"></td>
+                  <td v-show="statsView === 'squad' && isMyClub && managing" class="py-2 px-2"></td>
+                  <template v-for="col in statCols" :key="col.key">
+                  <td v-show="statsView === 'stats'" class="py-2 px-2 tabular-nums">
+                    <div class="flex items-end justify-end gap-1">
+                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll?.[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
+                      <template v-if="row.aflPlayerSeason?.statsLast3?.[col.key] != null">
+                        <span v-if="trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])" class="text-[10px]" :class="trendCls(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key])">{{ trend(row.aflPlayerSeason.statsLast3[col.key], row.aflPlayerSeason?.statsAll?.[col.key]) }}</span>
+                        <span :style="statHeat(row.aflPlayerSeason.statsLast3[col.key], col.key)">{{ fmtStat(row.aflPlayerSeason.statsLast3[col.key]) }}</span>
+                      </template>
+                    </div>
+                  </td>
+                  </template>
+                  <td v-show="statsView === 'stats'" class="py-2 pl-2 pr-3 tabular-nums">
+                    <div class="flex items-end justify-end gap-1">
+                      <span class="text-xs" :style="statHeat(row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null, 'star')">{{ row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll).toFixed(1) : '—' }}</span>
+                      <template v-if="row.aflPlayerSeason?.statsLast3">
+                        <span v-if="trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)" class="text-[10px]" :class="trendCls(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null)">{{ trend(starScore(row.aflPlayerSeason.statsLast3), row.aflPlayerSeason?.statsAll ? starScore(row.aflPlayerSeason.statsAll) : null) }}</span>
+                        <span :style="statHeat(starScore(row.aflPlayerSeason.statsLast3), 'star')">{{ starScore(row.aflPlayerSeason.statsLast3).toFixed(1) }}</span>
+                      </template>
+                    </div>
+                  </td>
                 </tr>
-                <tr v-if="expandedId === row.id" class="border-b border-border-subtle opacity-40">
+                <tr v-if="expandedId === row.id && statsView === 'squad'" class="border-b border-border-subtle opacity-40">
                   <td colspan="4" class="pb-3 pt-1 px-0">
                     <div class="flex gap-4">
                       <div class="flex flex-col gap-2 text-xs shrink-0">
@@ -187,19 +217,9 @@
                         <div><div class="text-text-muted">Cost</div><div class="text-text">{{ formatCost(row.costCents) }}</div></div>
                       </div>
                       <div class="flex-1 flex flex-col" @click.stop>
-                        <textarea
-                          v-model="expandedNotes"
-                          rows="3"
-                          placeholder="Add notes..."
-                          class="flex-1 w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-text-faint focus:border-active focus:outline-none resize-none"
-                        />
+                        <textarea v-model="expandedNotes" rows="3" placeholder="Add notes..." class="flex-1 w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-text-faint focus:border-active focus:outline-none resize-none" />
                         <div class="flex justify-end mt-2">
-                          <button
-                            v-if="expandedDirty"
-                            @click="saveExpanded"
-                            :disabled="expandedSubmitting"
-                            class="rounded-lg px-3 py-1.5 text-xs font-medium bg-active text-active-text hover:opacity-90 transition-colors disabled:opacity-40"
-                          >{{ expandedSubmitting ? '…' : 'Save' }}</button>
+                          <button v-if="expandedDirty" @click="saveExpanded" :disabled="expandedSubmitting" class="rounded-lg px-3 py-1.5 text-xs font-medium bg-active text-active-text hover:opacity-90 transition-colors disabled:opacity-40">{{ expandedSubmitting ? '…' : 'Save' }}</button>
                         </div>
                       </div>
                     </div>
@@ -209,6 +229,7 @@
             </template>
           </tbody>
         </table>
+        </div>
       </div>
       <p v-else class="text-text-faint">No players on squad.</p>
     </template>
@@ -258,6 +279,8 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useQuery, useMutation } from '@vue/apollo-composable'
+import { useTheme } from '@/composables/useTheme'
+import { heatStyle } from '@/utils/heatmap'
 import { GET_FFL_CLUB_SEASON, GET_FFL_SEASON_POSITIONS, GET_FFL_ROUND_CLUB_MATCHES } from '../api/queries'
 import { REMOVE_FFL_PLAYER_FROM_SEASON, UPDATE_FFL_PLAYER_SEASON } from '../api/mutations'
 import { useFflState } from '../composables/useFflState'
@@ -266,6 +289,7 @@ import IconTeamBuilder from '../components/icons/IconTeamBuilder.vue'
 import IconManage from '../components/icons/IconManage.vue'
 import IconBin from '../components/icons/IconBin.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
+import { clubLogoUrl as aflClubLogoUrl } from '@/features/afl/utils/clubLogos'
 import { POSITION_LETTERS, POSITION_COLORS, POSITION_ORDER, POSITION_LABEL, primaryPosition, type RoundEntry } from '../utils/position'
 import PlayerSearchModal from '../components/PlayerSearchModal.vue'
 
@@ -274,6 +298,15 @@ const props = defineProps<{ clubSeasonId: string }>()
 const { selectedClubId, liveRoundId } = useFflState()
 const managing = ref(false)
 const showTraded = ref(false)
+
+type StatsView = 'squad' | 'stats'
+const statsView = ref<StatsView>('squad')
+const segments: { id: StatsView; label: string }[] = [
+  { id: 'squad', label: 'Positions' },
+  { id: 'stats', label: 'Stats' },
+]
+
+const { isDark } = useTheme()
 
 const isMyClub = computed(() => !!selectedClubId.value && clubSeason.value?.club.id === selectedClubId.value)
 
@@ -449,14 +482,82 @@ async function onPlayerAdded() {
 }
 
 // Inline row expansion
+interface StatSummary {
+  goals: number; kicks: number; handballs: number
+  marks: number; tackles: number; hitouts: number
+}
+
 interface PlayerSeasonRow {
   id: string
   player: { id: string; aflPlayerId: string; aflPlayer: { id: string; name: string } }
-  aflPlayerSeason?: { id: string; clubSeason?: { club?: { name: string } } } | null
+  aflPlayerSeason?: {
+    id: string
+    clubSeason?: { id: string; club?: { name: string } } | null
+    statsAll?: StatSummary | null
+    statsLast3?: StatSummary | null
+  } | null
   fromRoundId?: string | null
   toRoundId?: string | null
   notes?: string | null
   costCents?: number | null
+}
+
+// --- Stats view ---
+
+const statCols = [
+  { key: 'kicks'     as const, label: 'K' },
+  { key: 'handballs' as const, label: 'H' },
+  { key: 'marks'     as const, label: 'M' },
+  { key: 'tackles'   as const, label: 'T' },
+  { key: 'hitouts'   as const, label: 'R' },
+  { key: 'goals'     as const, label: 'G' },
+]
+
+type StatKey = typeof statCols[number]['key']
+
+function starScore(s: StatSummary): number {
+  return s.goals * 5 + s.kicks + s.handballs + s.marks * 2 + s.tackles * 4
+}
+
+function fmtStat(val: number | null | undefined): string {
+  if (val == null) return '—'
+  return val.toFixed(1)
+}
+
+function trend(l3: number | null | undefined, avg: number | null | undefined): string {
+  if (l3 == null || avg == null) return ''
+  if (l3 === avg) return '='
+  return l3 > avg ? '↑' : '↓'
+}
+
+function trendCls(l3: number | null | undefined, avg: number | null | undefined): string {
+  if (l3 == null || avg == null) return ''
+  if (l3 === avg) return 'text-blue-400'
+  return l3 > avg ? 'text-green-400' : 'text-red-400'
+}
+
+const columnRange = computed(() => {
+  const allRows = [
+    ...groupedPlayers.value.flatMap(g => g.players),
+    ...tradedPlayers.value,
+  ] as PlayerSeasonRow[]
+  const range = {} as Record<StatKey | 'star', { min: number; max: number }>
+  for (const col of statCols) {
+    const vals = allRows.map(r => r.aflPlayerSeason?.statsLast3?.[col.key]).filter((v): v is number => v != null)
+    if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  const starVals = allRows
+    .map(r => r.aflPlayerSeason?.statsLast3 ? starScore(r.aflPlayerSeason.statsLast3) : null)
+    .filter((v): v is number => v != null)
+  if (starVals.length) range['star'] = { min: Math.min(...starVals), max: Math.max(...starVals) }
+  return range
+})
+
+function statHeat(value: number | null | undefined, key: StatKey | 'star'): Record<string, string> {
+  if (value == null) return {}
+  const r = columnRange.value[key]
+  if (!r) return {}
+  return heatStyle(value, r.min, r.max, isDark.value)
 }
 
 const expandedId = ref<string | null>(null)
@@ -514,5 +615,9 @@ watch(managing, (val) => {
 
 watch(isMyClub, (val) => {
   if (!val) managing.value = false
+})
+
+watch(statsView, (val) => {
+  if (val === 'stats') managing.value = false
 })
 </script>

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -8,13 +8,13 @@
         <div class="flex items-center">
           <h1 class="text-2xl font-bold flex items-center gap-3">
             <img v-if="selectedClubSeason" :src="clubLogoUrl(selectedClubSeason.club.name)" :alt="selectedClubSeason.club.name" class="w-10 h-10 object-contain" />
-            {{ selectedClubSeason?.club.name ?? '' }}<span class="font-normal text-text-muted"> · Team Builder</span>
+            {{ selectedClubSeason?.club.name ?? '' }}<span v-if="!readonly" class="font-normal text-text-muted"> · Team Builder</span>
           </h1>
           <div class="flex items-center gap-3 ml-auto">
             <div class="flex items-center gap-1 rounded-lg border border-border px-1">
               <router-link
                 v-if="prevClubMatchId"
-                :to="{ name: 'ffl-club-match-edit', params: { clubMatchId: prevClubMatchId } }"
+                :to="{ name: readonly ? 'ffl-club-match' : 'ffl-club-match-edit', params: { clubMatchId: prevClubMatchId } }"
                 class="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:bg-control-hover hover:text-text transition-colors text-sm"
                 title="Previous round"
               >‹</router-link>
@@ -22,7 +22,7 @@
               <span class="text-sm text-text-muted tabular-nums">{{ currentRound?.name }}</span>
               <router-link
                 v-if="nextClubMatchId"
-                :to="{ name: 'ffl-club-match-edit', params: { clubMatchId: nextClubMatchId } }"
+                :to="{ name: readonly ? 'ffl-club-match' : 'ffl-club-match-edit', params: { clubMatchId: nextClubMatchId } }"
                 class="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:bg-control-hover hover:text-text transition-colors text-sm"
                 title="Next round"
               >›</router-link>
@@ -36,6 +36,14 @@
               <IconSquad class="w-4 h-4" />
               Squad
             </router-link>
+            <router-link
+              v-if="readonly && isMyClub && bootstrapClubMatchId"
+              :to="{ name: 'ffl-club-match-edit', params: { clubMatchId: bootstrapClubMatchId } }"
+              class="flex items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
+            >
+              <IconTeamBuilder class="w-4 h-4" />
+              Team Builder
+            </router-link>
           </div>
         </div>
       </div>
@@ -43,7 +51,7 @@
       <template v-if="selectedClubSeason && clubMatch">
         <div class="mb-6 flex items-center gap-4 flex-wrap">
           <!-- Subs mode -->
-          <template v-if="subsMode">
+          <template v-if="!readonly && subsMode">
             <button
               @click="exitSubsMode"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
@@ -58,7 +66,7 @@
           </template>
 
           <!-- Manage mode -->
-          <template v-else-if="managing">
+          <template v-else-if="!readonly && managing">
             <button
               @click="cancelManage"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
@@ -94,14 +102,14 @@
           </template>
 
           <!-- Default mode buttons -->
-          <template v-else>
+          <template v-else-if="!readonly">
             <button
               @click="managing = true"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors"
             >
               <span class="flex items-center gap-1.5">
                 <IconManage class="w-3.5 h-3.5" />
-                Manage
+                Build Team
               </span>
             </button>
             <button
@@ -112,6 +120,28 @@
               <span class="flex items-center gap-1.5">
                 <IconSubs class="w-3.5 h-3.5" />
                 Substitutions
+              </span>
+            </button>
+            <button
+              v-if="clubMatchDataStatus === 'no_data' || clubMatchDataStatus === 'submitted'"
+              @click="markFinal"
+              :disabled="markingFinal"
+              class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors disabled:opacity-40"
+            >
+              <span class="flex items-center gap-1.5">
+                <IconLock class="w-3.5 h-3.5" />
+                {{ markingFinal ? 'Marking…' : 'Mark Final' }}
+              </span>
+            </button>
+            <button
+              v-if="clubMatchDataStatus === 'final'"
+              @click="markSubmitted"
+              :disabled="markingSubmitted"
+              class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors disabled:opacity-40"
+            >
+              <span class="flex items-center gap-1.5">
+                <IconLock :open="true" class="w-3.5 h-3.5" />
+                {{ markingSubmitted ? 'Marking…' : 'Mark Submitted' }}
               </span>
             </button>
             <span class="w-2 shrink-0" />
@@ -129,18 +159,19 @@
           </template>
 
           <!-- Data status pill -->
-          <span
-            v-if="clubMatchDataStatus"
-            class="ml-auto shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-            :class="dataStatusClass[clubMatchDataStatus] ?? 'bg-surface-raised text-text-faint'"
-          >
-            {{ dataStatusLabel[clubMatchDataStatus] ?? clubMatchDataStatus }}
-          </span>
+          <div class="ml-auto flex items-center gap-2 shrink-0">
+            <span v-if="markStatusError" class="text-xs text-red-400">{{ markStatusError }}</span>
+            <span
+              v-if="clubMatchDataStatus"
+              class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+              :class="dataStatusClass[clubMatchDataStatus] ?? 'bg-surface-raised text-text-faint'"
+            >{{ dataStatusLabel[clubMatchDataStatus] ?? clubMatchDataStatus }}</span>
+          </div>
         </div>
 
         <!-- Substitution suggestions -->
         <div
-          v-if="!managing && suggestedSubstitutionHints.length > 0"
+          v-if="!readonly && !managing && suggestedSubstitutionHints.length > 0"
           class="mb-4 rounded-lg border border-sky-500/30 bg-sky-500/10 px-4 py-3"
         >
           <p class="text-xs font-semibold text-sky-400 mb-1">Improve your score:</p>
@@ -484,7 +515,7 @@
           </div>
         </div>
       </template>
-      <p v-else class="text-text-faint">No club selected. Choose a club in the nav bar.</p>
+      <p v-else class="text-text-faint">{{ readonly ? 'No data.' : 'No club selected. Choose a club in the nav bar.' }}</p>
 
     </template>
   </div>
@@ -495,6 +526,7 @@ import { ref, computed, watch, nextTick } from 'vue'
 import { useQuery, useMutation, useLazyQuery } from '@vue/apollo-composable'
 import { GET_FFL_ROUND, GET_FFL_SEASON_CLUBS, GET_FFL_CLUB_SEASON, GET_FFL_CLUB_MATCH, GET_FFL_CLUB_MATCH_TEAM } from '../api/queries'
 import { SET_FFL_TEAM, DECLARE_FFL_SUBSTITUTIONS } from '../api/mutations'
+import { MARK_FFL_TEAM_FINAL, MARK_FFL_TEAM_SUBMITTED } from '../../data-ops/api/mutations'
 import Breadcrumb from '../components/Breadcrumb.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import { clubLogoUrl } from '../utils/clubLogos'
@@ -502,6 +534,8 @@ import { clubAbbrev } from '../../afl/utils/clubAbbrev'
 import { positionFormula } from '../utils/position'
 import { isScoring } from '../utils/scoring'
 import IconSquad from '../components/icons/IconSquad.vue'
+import IconTeamBuilder from '../components/icons/IconTeamBuilder.vue'
+import IconLock from '../components/icons/IconLock.vue'
 import IconManage from '../components/icons/IconManage.vue'
 import IconSubs from '../components/icons/IconSubs.vue'
 import IconBin from '../components/icons/IconBin.vue'
@@ -510,7 +544,7 @@ import PlayerStatsCard from '../components/PlayerStatsCard.vue'
 import { useFflState } from '../composables/useFflState'
 import { POSITION_MULTIPLIERS } from '../utils/position'
 
-const props = defineProps<{ clubMatchId: string }>()
+const props = defineProps<{ clubMatchId: string; readonly?: boolean }>()
 
 const positions = [
   { key: 'goals',     label: 'Goals',     short: 'G',  count: 3 },
@@ -570,10 +604,12 @@ const bootstrapRoundId = computed(() => clubMatchBootstrap.value?.fflClubMatch?.
 const bootstrapAflRoundId = computed(() => clubMatchBootstrap.value?.fflClubMatch?.aflRoundId ?? null)
 const bootstrapSeasonId = computed(() => clubMatchBootstrap.value?.fflClubMatch?.seasonId ?? '')
 const bootstrapClubSeasonId = computed(() => clubMatchBootstrap.value?.fflClubMatch?.clubSeasonId ?? '')
+const bootstrapClubMatchId = computed(() => clubMatchBootstrap.value?.fflClubMatch?.id ?? '')
 const bootstrapClubId = computed(() => clubMatchBootstrap.value?.fflClubMatch?.club?.id ?? '')
+const isMyClub = computed(() => !!bootstrapClubId.value && bootstrapClubId.value === selectedClubId.value)
 
 watch(bootstrapClubId, (id) => {
-  if (id) setClub(id)
+  if (id && !props.readonly) setClub(id)
 }, { immediate: true })
 
 const { result: roundResult, loading: roundLoading, error: roundError } = useQuery(
@@ -981,6 +1017,41 @@ const clubMatchDataStatus = computed(() => clubMatch.value?.dataStatus as string
 const clubMatchLocked = computed(() => clubMatchDataStatus.value === 'final')
 
 const dataStatusLabel: Record<string, string> = { no_data: 'Not submitted', submitted: 'Submitted', final: 'Final' }
+
+const markingFinal = ref(false)
+const markingSubmitted = ref(false)
+const markStatusError = ref('')
+
+const roundRefetchVars = () => ({ query: GET_FFL_ROUND, variables: { id: bootstrapRoundId.value, aflRoundId: bootstrapAflRoundId.value } })
+
+const { mutate: markFinalMutation } = useMutation(MARK_FFL_TEAM_FINAL, () => ({ refetchQueries: [roundRefetchVars()], awaitRefetchQueries: true }))
+const { mutate: markSubmittedMutation } = useMutation(MARK_FFL_TEAM_SUBMITTED, () => ({ refetchQueries: [roundRefetchVars()], awaitRefetchQueries: true }))
+
+async function markFinal() {
+  if (!currentMatch.value) return
+  markStatusError.value = ''
+  markingFinal.value = true
+  try {
+    await markFinalMutation({ input: { clubMatchId: props.clubMatchId, matchId: currentMatch.value.id, roundId: bootstrapRoundId.value } })
+  } catch (e: any) {
+    markStatusError.value = e.message ?? 'Failed'
+  } finally {
+    markingFinal.value = false
+  }
+}
+
+async function markSubmitted() {
+  if (!currentMatch.value) return
+  markStatusError.value = ''
+  markingSubmitted.value = true
+  try {
+    await markSubmittedMutation({ input: { clubMatchId: props.clubMatchId, matchId: currentMatch.value.id, roundId: bootstrapRoundId.value } })
+  } catch (e: any) {
+    markStatusError.value = e.message ?? 'Failed'
+  } finally {
+    markingSubmitted.value = false
+  }
+}
 const dataStatusClass: Record<string, string> = {
   no_data:   'bg-surface-raised text-text-faint',
   submitted: 'bg-yellow-500/15 text-yellow-500',

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -90,14 +90,15 @@
               v-if="prevClubMatchId && !clubMatchLocked"
               @click="copyPreviousTeam"
               :disabled="prevTeamLoading"
+              :title="`Set team from ${prevRound?.name}`"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text hover:bg-surface-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              {{ prevTeamLoading ? 'Replicating…' : `Replicate ${prevRound?.name}` }}
+              {{ prevTeamLoading ? 'Replicating…' : `${prevRound?.name} Team` }}
             </button>
             <button
               v-if="!clubMatchLocked"
               @click="applyBestTeam"
-              title="Fill starters with the highest projected total (uses the active Last 5/Season stat source)"
+              title="Set team for the highest projected total (uses active Last 5/Season stat source)"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
             >
               Best Team

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -123,7 +123,7 @@
               </span>
             </button>
             <button
-              v-if="clubMatchDataStatus === 'no_data' || clubMatchDataStatus === 'submitted'"
+              v-if="starterCount > 0 && (clubMatchDataStatus === 'no_data' || clubMatchDataStatus === 'submitted')"
               @click="markFinal"
               :disabled="markingFinal"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface-hover transition-colors disabled:opacity-40"

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -301,7 +301,7 @@
                         class="w-9 text-right text-xs tabular-nums whitespace-nowrap"
                         :class="col.key === 'star' ? 'text-yellow-400/70' : 'text-text-muted'"
                         :style="statHeat(slot.player, col.key)"
-                      ><span v-if="statTrend(slot.player, col.key) === 'up'" class="text-[10px] text-green-400" :title="trendUpTitle">↑</span><span v-else-if="statTrend(slot.player, col.key) === 'down'" class="text-[10px] text-red-400" :title="trendDownTitle">↓</span><span
+                      ><span v-if="statTrend(slot.player, col.key) === 'up'" class="text-[10px] text-green-400 mr-0.5" :title="trendUpTitle">↑</span><span v-else-if="statTrend(slot.player, col.key) === 'down'" class="text-[10px] text-red-400 mr-0.5" :title="trendDownTitle">↓</span><span
                         :class="col.key === pos.key ? 'rounded bg-sky-500/15 ring-1 ring-sky-400/40 px-1 py-0.5' : ''"
                       >{{ squadStat(slot.player, col.key) }}</span></span>
                     </span>
@@ -595,7 +595,7 @@
                     class="w-9 text-right text-xs tabular-nums whitespace-nowrap"
                     :class="col.key === 'star' ? 'text-yellow-400/70' : 'text-text-muted'"
                     :style="statHeat(player, col.key)"
-                  ><span v-if="statTrend(player, col.key) === 'up'" class="text-[10px] text-green-400" :title="trendUpTitle">↑</span><span v-else-if="statTrend(player, col.key) === 'down'" class="text-[10px] text-red-400" :title="trendDownTitle">↓</span>{{ squadStat(player, col.key) }}</span>
+                  ><span v-if="statTrend(player, col.key) === 'up'" class="text-[10px] text-green-400 mr-0.5" :title="trendUpTitle">↑</span><span v-else-if="statTrend(player, col.key) === 'down'" class="text-[10px] text-red-400 mr-0.5" :title="trendDownTitle">↓</span>{{ squadStat(player, col.key) }}</span>
                   <!-- Popup fallback for drag and drop -->
                   <button
                     aria-label="Add to team"
@@ -677,7 +677,7 @@
                       class="w-9 text-right text-xs tabular-nums whitespace-nowrap opacity-40"
                       :class="col.key === 'star' ? 'text-yellow-400/70' : 'text-text-muted'"
                       :style="statHeat(player, col.key)"
-                    ><span v-if="statTrend(player, col.key) === 'up'" class="text-[10px] text-green-400" :title="trendUpTitle">↑</span><span v-else-if="statTrend(player, col.key) === 'down'" class="text-[10px] text-red-400" :title="trendDownTitle">↓</span>{{ squadStat(player, col.key) }}</span>
+                    ><span v-if="statTrend(player, col.key) === 'up'" class="text-[10px] text-green-400 mr-0.5" :title="trendUpTitle">↑</span><span v-else-if="statTrend(player, col.key) === 'down'" class="text-[10px] text-red-400 mr-0.5" :title="trendDownTitle">↓</span>{{ squadStat(player, col.key) }}</span>
                     <button
                       aria-label="Add to team"
                       class="w-6 h-6 flex items-center justify-center rounded text-text-faint hover:bg-control-hover hover:text-text transition-colors"

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -539,27 +539,7 @@
           <div v-if="managing">
             <div class="flex items-center justify-between mb-3">
               <h2 class="text-lg font-semibold text-text-heading">Squad ({{ availablePlayers.length }})</h2>
-              <span
-                class="text-xs text-text-faint whitespace-nowrap"
-                :title="`↑/↓ = last ${LAST_N} form at least 15% above/below season average`"
-              >
-                <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = last {{ LAST_N }} form
-              </span>
-              <!-- Form/Season toggle -->
-              <div class="flex items-center rounded border border-border overflow-hidden text-[10px] text-text-faint">
-                <button
-                  class="px-1.5 py-0.5 transition-colors"
-                  :class="statSource === 'form' ? 'bg-control text-text' : 'hover:text-text'"
-                  :title="`Show averages over each player's last ${LAST_N} games`"
-                  @click="statSource = 'form'"
-                >Last {{ LAST_N }}</button>
-                <button
-                  class="px-1.5 py-0.5 transition-colors"
-                  :class="statSource === 'season' ? 'bg-control text-text' : 'hover:text-text'"
-                  title="Show averages over the whole season"
-                  @click="statSource = 'season'"
-                >Season</button>
-              </div>
+              <StatSourceToggle />
             </div>
             <!-- Sort headers: name on the left, trend explainer in the gap, stat columns on the right -->
             <div class="flex items-center justify-between px-4 mb-1 text-[10px] text-text-faint">
@@ -779,8 +759,10 @@ import { useTheme } from '@/composables/useTheme'
 import { solveBestAssignment } from '../utils/bestTeam'
 import PlayerStatsCard from '../components/PlayerStatsCard.vue'
 import { useFflState } from '../composables/useFflState'
+import { useStatSource } from '../composables/useStatSource'
+import StatSourceToggle from '../components/StatSourceToggle.vue'
 import { POSITION_MULTIPLIERS } from '../utils/position'
-import { starScore, fmtStat, statCols, trendDir, LAST_N, type StatSummary } from '../utils/playerStats'
+import { starScore, fmtStat, statCols, trendDir, LAST_N, TREND_PCT, type StatSummary } from '../utils/playerStats'
 
 const props = defineProps<{ clubMatchId: string; readonly?: boolean }>()
 
@@ -1526,8 +1508,9 @@ const squadStatsById = computed(() => {
   return map
 })
 
-// Which stat set drives the summary columns, heatmap, sort, and projections.
-const statSource = ref<'form' | 'season'>('form')
+// Which stat set drives the summary columns, heatmap, sort, and projections —
+// global toggle shared with the other stats pages.
+const { statSource } = useStatSource()
 
 const statSourceTitle = computed(() =>
   statSource.value === 'form' ? `Last ${LAST_N} form averages` : 'Season averages'
@@ -1551,8 +1534,8 @@ function formStats(player: SquadPlayer): StatSummary | null {
 }
 
 // Trend of form vs season for one stat (see trendDir in utils/playerStats).
-const trendUpTitle = `Trending up: last ${LAST_N} average is at least 15% above season average`
-const trendDownTitle = `Trending down: last ${LAST_N} average is at least 15% below season average`
+const trendUpTitle = `Trending up: last ${LAST_N} average is at least ${TREND_PCT * 100}% above season average`
+const trendDownTitle = `Trending down: last ${LAST_N} average is at least ${TREND_PCT * 100}% below season average`
 
 function statTrend(player: SquadPlayer, key: typeof statSummaryCols[number]['key']): 'up' | 'down' | null {
   const { form, season } = playerStatSets(player)

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -777,7 +777,7 @@ import { solveBestAssignment } from '../utils/bestTeam'
 import PlayerStatsCard from '../components/PlayerStatsCard.vue'
 import { useFflState } from '../composables/useFflState'
 import { POSITION_MULTIPLIERS } from '../utils/position'
-import { starScore, fmtStat, statCols, LAST_N, type StatSummary } from '../utils/playerStats'
+import { starScore, fmtStat, statCols, trendDir, LAST_N, type StatSummary } from '../utils/playerStats'
 
 const props = defineProps<{ clubMatchId: string; readonly?: boolean }>()
 
@@ -1547,8 +1547,7 @@ function formStats(player: SquadPlayer): StatSummary | null {
   return statSource.value === 'season' ? season : (form ?? season)
 }
 
-// Trend of form vs season for one stat: ▲/▼ when form deviates meaningfully
-// (at least 15% of the season value, and at least 0.5 absolute).
+// Trend of form vs season for one stat (see trendDir in utils/playerStats).
 const trendUpTitle = `Trending up: last ${LAST_N} average is at least 15% above season average`
 const trendDownTitle = `Trending down: last ${LAST_N} average is at least 15% below season average`
 
@@ -1557,10 +1556,7 @@ function statTrend(player: SquadPlayer, key: typeof statSummaryCols[number]['key
   if (!form || !season) return null
   const f = key === 'star' ? starScore(form) : form[key]
   const s = key === 'star' ? starScore(season) : season[key]
-  const threshold = Math.max(0.5, 0.15 * Math.abs(s))
-  if (f - s >= threshold) return 'up'
-  if (s - f >= threshold) return 'down'
-  return null
+  return trendDir(f, s)
 }
 
 function squadStat(player: SquadPlayer, key: typeof statSummaryCols[number]['key']): string {

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -119,7 +119,7 @@
             >
               <span class="flex items-center gap-1.5">
                 <IconSubs class="w-3.5 h-3.5" />
-                Substitutions
+                Make Substitutions
               </span>
             </button>
             <button

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -96,6 +96,14 @@
             </button>
             <button
               v-if="!clubMatchLocked"
+              @click="applyBestTeam"
+              title="Fill starters with the highest projected total (uses the active Last 5/Season stat source)"
+              class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            >
+              Best Team
+            </button>
+            <button
+              v-if="!clubMatchLocked"
               @click="() => { resetTeamState(); markDirty() }"
               class="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
             >
@@ -764,6 +772,7 @@ import IconCopy from '../components/icons/IconCopy.vue'
 import IconMenu from '../components/icons/IconMenu.vue'
 import { heatStyle } from '@/utils/heatmap'
 import { useTheme } from '@/composables/useTheme'
+import { solveBestAssignment } from '../utils/bestTeam'
 import PlayerStatsCard from '../components/PlayerStatsCard.vue'
 import { useFflState } from '../composables/useFflState'
 import { POSITION_MULTIPLIERS } from '../utils/position'
@@ -1630,6 +1639,46 @@ const projectedTotal = computed(() => {
   }
   return Math.round(total)
 })
+
+// ── Best team ────────────────────────────────────────────────────────────────
+
+// Fills the starter slots with the highest-scoring assignment of squad players
+// to positions (Hungarian algorithm over projected scores from the active stat
+// source). Bench slots whose player becomes a starter are cleared; the rest of
+// the bench is left alone. Local state only — Save still applies it.
+function applyBestTeam() {
+  const pool = squad.value.filter(p => !p.toRoundId && formStats(p))
+  if (!pool.length) return
+
+  const slotPositions: PositionKey[] = []
+  for (const pos of positions) {
+    for (let i = 0; i < pos.count; i++) slotPositions.push(pos.key)
+  }
+
+  const values = slotPositions.map(pos => pool.map(p => projectedScore(p, pos) ?? 0))
+  const assignment = solveBestAssignment(values)
+
+  const byPos = new Map<PositionKey, SquadPlayer[]>(positions.map(p => [p.key, []]))
+  assignment.forEach((playerIdx, slotIdx) => {
+    if (playerIdx >= 0) byPos.get(slotPositions[slotIdx])!.push(pool[playerIdx])
+  })
+
+  const starterIds = new Set<string>()
+  for (const pos of positions) {
+    const chosen = byPos.get(pos.key)!
+      .sort((a, b) => (projectedScore(b, pos.key) ?? 0) - (projectedScore(a, pos.key) ?? 0))
+    teamSlots.value[pos.key] = Array.from({ length: pos.count }, (_, i) => ({ player: chosen[i] ?? null }))
+    for (const p of chosen) starterIds.add(p.id)
+  }
+
+  for (const bSlot of benchDualSlots.value) {
+    if (bSlot.player && starterIds.has(bSlot.player.id)) {
+      bSlot.player = null
+      bSlot.positions = [null, null]
+    }
+  }
+  markDirty()
+}
 
 // ── Popup menus (fallback for drag and drop) ─────────────────────────────────
 

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -1267,10 +1267,7 @@ function initSubsState() {
       .map((pm: { id: string }) => pm.id)
   )
   const savedApplied = pms.some((pm: { status: string | null }) => pm.status === 'interchanged_out')
-  const suggestedIc = clubMatch.value?.suggestedSubstitutions?.some(
-    (s: { kind: string }) => s.kind === 'interchange'
-  ) ?? false
-  interchangeApplied.value = savedApplied || suggestedIc
+  interchangeApplied.value = savedApplied
 }
 
 function isInterchangeSlot(slot: BenchDualSlot): boolean {

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -1,5 +1,7 @@
 <template>
   <div>
+    <!-- Click-away backdrop for popup menus -->
+    <div v-if="openMenuKey" class="fixed inset-0 z-40" @click="closeMenu" />
     <div v-if="loading" class="text-text-faint">Loading...</div>
     <div v-else-if="error" class="text-red-400">{{ error.message }}</div>
     <template v-else-if="round">
@@ -192,11 +194,31 @@
           Skipped (no longer in squad): {{ skippedOnCopy.join(', ') }}
         </p>
 
-        <!-- Summary bar -->
+        <!-- Summary bar. In manage mode the projected pill sits at the right edge of
+             the team column (mirroring the grid below); counts stay on the far right. -->
         <div class="mb-8 rounded-lg border border-border bg-surface-raised px-4 py-3">
-          <div class="flex items-center justify-between">
+          <div v-if="managing" class="grid grid-cols-1 sm:grid-cols-2 gap-8 items-center">
+            <div class="flex items-center justify-between">
+              <h2 class="text-sm font-semibold text-text-heading">Team</h2>
+              <span
+                v-if="projectedTotal > 0"
+                class="rounded-md bg-sky-500/15 ring-1 ring-sky-400/40 px-2.5 py-0.5 text-sm tabular-nums text-sky-400"
+                :title="`Estimated total from ${statSourceTitle.toLowerCase()}`"
+              >Projected ~{{ projectedTotal }}</span>
+            </div>
+            <div class="flex items-center justify-end gap-3">
+              <span class="text-sm tabular-nums text-text-muted">{{ starterCount }}/18 starters · {{ benchCount }}/4 bench</span>
+              <span class="text-sm font-semibold tabular-nums">{{ grandTotal }}</span>
+            </div>
+          </div>
+          <div v-else class="flex items-center justify-between">
             <h2 class="text-sm font-semibold text-text-heading">Team</h2>
             <div class="flex items-center gap-3">
+              <span
+                v-if="!readonly && projectedTotal > 0"
+                class="rounded-md bg-sky-500/15 ring-1 ring-sky-400/40 px-2.5 py-0.5 text-sm tabular-nums text-sky-400"
+                :title="`Estimated total from ${statSourceTitle.toLowerCase()}`"
+              >Projected ~{{ projectedTotal }}</span>
               <span class="text-sm tabular-nums text-text-muted">{{ starterCount }}/18 starters · {{ benchCount }}/4 bench</span>
               <span class="text-sm font-semibold tabular-nums">{{ grandTotal }}</span>
             </div>
@@ -219,11 +241,19 @@
                   v-for="(slot, index) in teamSlots[pos.key]"
                   :key="index"
                   class="flex items-center justify-between rounded-lg border px-4 py-2 transition-colors"
-                  :class="slot.player
+                  :class="[slot.player
                     ? (subsMode && slot.player.aflStatus === 'dnp'
                       ? (subbedOutIds.has(slot.player.pmId ?? '') ? 'border-sky-500/40 bg-sky-500/5 cursor-pointer' : 'border-amber-600/30 bg-amber-500/5 cursor-pointer')
                       : 'border-border bg-surface-raised')
-                    : 'border-dashed border-border-subtle bg-surface'"
+                    : 'border-dashed border-border-subtle bg-surface',
+                    managing && slot.player ? 'cursor-grab active:cursor-grabbing' : '',
+                    dragOverKey === `s:${pos.key}:${index}` ? '!border-sky-400 bg-sky-500/10' : '']"
+                  :draggable="managing && !!slot.player"
+                  @dragstart="onDragStart($event, { kind: 'starter', pos: pos.key, index })"
+                  @dragend="onDragEnd"
+                  @dragover="onDragOverTarget($event, `s:${pos.key}:${index}`, starterDropAction(pos.key, index))"
+                  @dragleave="onDragLeave(`s:${pos.key}:${index}`)"
+                  @drop.prevent="onDropTarget(starterDropAction(pos.key, index))"
                   @click="onStarterClick(slot.player)"
                 >
                   <div v-if="slot.player" class="flex items-center gap-3">
@@ -254,41 +284,82 @@
                     </div>
                   </div>
                   <span v-else class="text-text-faint text-sm">Empty slot</span>
-                  <div v-if="slot.player && managing" class="flex items-center gap-2">
+                  <div v-if="slot.player && managing" class="relative flex items-center gap-2 shrink-0">
+                    <span class="flex items-center gap-0.5" :title="statSourceTitle">
+                      <span
+                        v-for="col in statSummaryCols"
+                        :key="col.key"
+                        class="w-9 text-right text-xs tabular-nums whitespace-nowrap"
+                        :class="col.key === 'star' ? 'text-yellow-400/70' : 'text-text-muted'"
+                        :style="statHeat(slot.player, col.key)"
+                      ><span v-if="statTrend(slot.player, col.key) === 'up'" class="text-[10px] text-green-400" :title="trendUpTitle">↑</span><span v-else-if="statTrend(slot.player, col.key) === 'down'" class="text-[10px] text-red-400" :title="trendDownTitle">↓</span><span
+                        :class="col.key === pos.key ? 'rounded bg-sky-500/15 ring-1 ring-sky-400/40 px-1 py-0.5' : ''"
+                      >{{ squadStat(slot.player, col.key) }}</span></span>
+                    </span>
                     <button
-                      v-for="target in positions.filter(p => p.key !== pos.key)"
-                      :key="target.key"
-                      class="rounded px-1.5 py-0.5 text-xs transition-colors"
-                      :disabled="isPositionFull(target.key)"
-                      :class="[
-                        isPositionFull(target.key) ? 'opacity-30 cursor-not-allowed' : '',
-                        target.key === 'star' ? 'text-yellow-400 hover:bg-control-hover hover:text-yellow-300' : 'text-text-faint hover:bg-control-hover hover:text-text'
-                      ]"
-                      :title="`Move to ${target.label}`"
-                      @click="moveToPosition(pos.key, index, target.key)"
+                      aria-label="Player actions"
+                      class="w-6 h-6 flex items-center justify-center rounded text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                      @click.stop="toggleMenu(`starter:${pos.key}:${index}`)"
                     >
-                      {{ target.short }}
+                      <IconMenu class="w-3.5 h-3.5" />
                     </button>
-                    <span class="w-px h-3 bg-border-subtle shrink-0" />
-                    <button
-                      v-if="index > 0 && teamSlots[pos.key][index - 1].player"
-                      aria-label="Move up"
-                      class="text-xs text-text-faint hover:text-text transition-colors"
-                      @click.stop="swapStarters(pos.key, index, index - 1)"
-                    >↑</button>
-                    <button
-                      v-if="index < teamSlots[pos.key].length - 1 && teamSlots[pos.key][index + 1].player"
-                      aria-label="Move down"
-                      class="text-xs text-text-faint hover:text-text transition-colors"
-                      @click.stop="swapStarters(pos.key, index, index + 1)"
-                    >↓</button>
-                    <button
-                      aria-label="Remove"
-                      class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                      @click="removeFromTeam(pos.key, index)"
+                    <div
+                      v-if="openMenuKey === `starter:${pos.key}:${index}`"
+                      class="absolute right-0 top-full mt-1 z-50 w-44 rounded-lg border border-border bg-surface shadow-lg p-1"
+                      @click.stop
                     >
-                      <IconBin class="w-3.5 h-3.5" />
-                    </button>
+                      <p class="px-2 py-1 text-[10px] uppercase tracking-wide text-text-faint">Move to</p>
+                      <button
+                        v-for="target in positions.filter(p => p.key !== pos.key)"
+                        :key="target.key"
+                        class="flex w-full items-center justify-between rounded px-2 py-1 text-xs transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                        :class="target.key === 'star' ? 'text-yellow-400' : 'text-text'"
+                        :disabled="isPositionFull(target.key)"
+                        @click.stop="moveToPosition(pos.key, index, target.key); closeMenu()"
+                      >
+                        <span>{{ target.label }}</span>
+                        <span class="flex items-center gap-1.5">
+                          <span class="flex items-center gap-0.5">
+                            <span v-for="n in emptySlotCount(target.key)" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                          </span>
+                          <span class="text-text-faint">{{ target.short }}</span>
+                        </span>
+                      </button>
+                      <button
+                        class="flex w-full items-center justify-between rounded px-2 py-1 text-xs text-text transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                        :disabled="benchDualFull"
+                        @click.stop="moveStarterToBench(pos.key, index); closeMenu()"
+                      >
+                        <span>Bench</span>
+                        <span class="flex items-center gap-1.5">
+                          <span class="flex items-center gap-0.5">
+                            <span v-for="n in benchEmptyCount" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                          </span>
+                          <span class="text-text-faint">B</span>
+                        </span>
+                      </button>
+                      <template v-if="canMoveUp(pos.key, index) || canMoveDown(pos.key, index)">
+                        <div class="my-1 h-px bg-border-subtle" />
+                        <button
+                          v-if="canMoveUp(pos.key, index)"
+                          class="flex w-full items-center rounded px-2 py-1 text-xs text-text transition-colors hover:bg-control-hover"
+                          @click.stop="swapStarters(pos.key, index, index - 1); closeMenu()"
+                        >Move up</button>
+                        <button
+                          v-if="canMoveDown(pos.key, index)"
+                          class="flex w-full items-center rounded px-2 py-1 text-xs text-text transition-colors hover:bg-control-hover"
+                          @click.stop="swapStarters(pos.key, index, index + 1); closeMenu()"
+                        >Move down</button>
+                      </template>
+                      <div class="my-1 h-px bg-border-subtle" />
+                      <button
+                        class="flex w-full items-center gap-1.5 rounded px-2 py-1 text-xs text-red-400 transition-colors hover:bg-control-hover"
+                        @click.stop="removeFromTeam(pos.key, index); closeMenu()"
+                      >
+                        <IconBin class="w-3.5 h-3.5" />
+                        Remove
+                      </button>
+                    </div>
                   </div>
                   <div v-else-if="slot.player" class="flex items-center gap-2 shrink-0">
                     <span class="w-28 shrink-0"></span>
@@ -315,8 +386,16 @@
                         ? (interchangeApplied ? 'border-sky-500/40 bg-sky-500/5 cursor-pointer' : 'border-amber-600/30 bg-amber-500/5 cursor-pointer')
                         : 'border-border bg-surface-raised')
                       : 'border-dashed border-border-subtle bg-surface',
-                    recentlyClearedSlot === index ? '!border-orange-400' : ''
+                    recentlyClearedSlot === index ? '!border-orange-400' : '',
+                    managing && slot.player ? 'cursor-grab active:cursor-grabbing' : '',
+                    dragOverKey === `b:${index}` ? '!border-sky-400 bg-sky-500/10' : ''
                   ]"
+                  :draggable="managing && !!slot.player"
+                  @dragstart="onDragStart($event, { kind: 'bench', index })"
+                  @dragend="onDragEnd"
+                  @dragover="onDragOverTarget($event, `b:${index}`, benchDropAction(index))"
+                  @dragleave="onDragLeave(`b:${index}`)"
+                  @drop.prevent="onDropTarget(benchDropAction(index))"
                   @click="onBenchRowClick(slot)"
                 >
                   <!-- Left: name -->
@@ -344,8 +423,8 @@
                     </div>
                     <span v-else class="text-text-faint text-sm">Empty slot</span>
                   </div>
-                  <!-- Right: selectors + remove (manage) or read-only tags -->
-                  <div class="flex items-center gap-2 ml-4 shrink-0">
+                  <!-- Right: selectors + actions menu (manage) or read-only tags -->
+                  <div class="relative flex items-center gap-2 ml-4 shrink-0">
                     <template v-if="slot.player && managing">
                       <select
                         class="text-xs rounded bg-control text-text px-1 py-0.5 border border-border"
@@ -371,14 +450,43 @@
                         </option>
                       </select>
                       <button
-                        aria-label="Remove"
-                        class="text-xs text-red-400 hover:text-red-300 transition-colors"
-                        @click="removeBenchDual(index)"
+                        aria-label="Bench player actions"
+                        class="w-6 h-6 flex items-center justify-center rounded text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                        @click.stop="toggleMenu(`bench:${index}`)"
                       >
-                        <svg class="w-3.5 h-3.5" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
-                          <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M6 6.5v4M8 6.5v4M3 3.5l.7 7.5a.5.5 0 00.5.5h5.6a.5.5 0 00.5-.5L11 3.5"/>
-                        </svg>
+                        <IconMenu class="w-3.5 h-3.5" />
                       </button>
+                      <div
+                        v-if="openMenuKey === `bench:${index}`"
+                        class="absolute right-0 top-full mt-1 z-50 w-44 rounded-lg border border-border bg-surface shadow-lg p-1"
+                        @click.stop
+                      >
+                        <p class="px-2 py-1 text-[10px] uppercase tracking-wide text-text-faint">Move to</p>
+                        <button
+                          v-for="target in positions"
+                          :key="target.key"
+                          class="flex w-full items-center justify-between rounded px-2 py-1 text-xs transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                          :class="target.key === 'star' ? 'text-yellow-400' : 'text-text'"
+                          :disabled="isPositionFull(target.key)"
+                          @click.stop="moveBenchToStarter(index, target.key); closeMenu()"
+                        >
+                          <span>{{ target.label }}</span>
+                          <span class="flex items-center gap-1.5">
+                            <span class="flex items-center gap-0.5">
+                              <span v-for="n in emptySlotCount(target.key)" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                            </span>
+                            <span class="text-text-faint">{{ target.short }}</span>
+                          </span>
+                        </button>
+                        <div class="my-1 h-px bg-border-subtle" />
+                        <button
+                          class="flex w-full items-center gap-1.5 rounded px-2 py-1 text-xs text-red-400 transition-colors hover:bg-control-hover"
+                          @click.stop="removeBenchDual(index); closeMenu()"
+                        >
+                          <IconBin class="w-3.5 h-3.5" />
+                          Remove
+                        </button>
+                      </div>
                     </template>
                     <template v-else-if="slot.player">
                       <div class="flex items-center gap-2 shrink-0">
@@ -420,12 +528,63 @@
 
           <!-- Squad panel (right col, manage mode only) -->
           <div v-if="managing">
-            <h2 class="text-lg font-semibold text-text-heading mb-3">Squad ({{ availablePlayers.length }})</h2>
-            <div class="space-y-1">
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="text-lg font-semibold text-text-heading">Squad ({{ availablePlayers.length }})</h2>
+              <span class="text-[10px] text-text-faint/70 whitespace-nowrap">
+                <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = last {{ LAST_N }} form ≥15% above/below season avg
+              </span>
+              <!-- Form/Season toggle -->
+              <div class="flex items-center rounded border border-border overflow-hidden text-[10px] text-text-faint">
+                <button
+                  class="px-1.5 py-0.5 transition-colors"
+                  :class="statSource === 'form' ? 'bg-control text-text' : 'hover:text-text'"
+                  :title="`Show averages over each player's last ${LAST_N} games`"
+                  @click="statSource = 'form'"
+                >Last {{ LAST_N }}</button>
+                <button
+                  class="px-1.5 py-0.5 transition-colors"
+                  :class="statSource === 'season' ? 'bg-control text-text' : 'hover:text-text'"
+                  title="Show averages over the whole season"
+                  @click="statSource = 'season'"
+                >Season</button>
+              </div>
+            </div>
+            <!-- Sort headers: name on the left, trend explainer in the gap, stat columns on the right -->
+            <div class="flex items-center justify-between px-4 mb-1 text-[10px] text-text-faint">
+              <button
+                class="transition-colors"
+                :class="squadSortKey === 'name' ? 'text-sky-400 font-semibold' : 'hover:text-text'"
+                title="Sort by name"
+                @click="squadSortKey = 'name'"
+              >Name</button>
+              <div class="flex items-center gap-0.5" :title="statSourceTitle">
+                <button
+                  v-for="col in statSummaryCols"
+                  :key="col.key"
+                  class="w-9 text-right transition-colors"
+                  :class="squadSortKey === col.key
+                    ? 'text-sky-400 font-semibold'
+                    : (col.key === 'star' ? 'text-yellow-400/70 hover:text-yellow-300' : 'hover:text-text')"
+                  :title="`Sort by ${col.label}`"
+                  @click="toggleSquadSort(col.key)"
+                >{{ col.label }}</button>
+                <span class="w-6" />
+              </div>
+            </div>
+            <div
+              class="space-y-1"
+              :class="dragOverKey === 'squad' ? 'rounded-lg ring-1 ring-red-400/50' : ''"
+              @dragover="onDragOverTarget($event, 'squad', squadDropAction())"
+              @dragleave="onDragLeave('squad')"
+              @drop.prevent="onDropTarget(squadDropAction())"
+            >
               <div
-                v-for="player in availablePlayers"
+                v-for="player in sortedAvailablePlayers"
                 :key="player.id"
-                class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2"
+                class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2 cursor-grab active:cursor-grabbing"
+                draggable="true"
+                @dragstart="onDragStart($event, { kind: 'squad', player })"
+                @dragend="onDragEnd"
               >
                 <div class="flex items-center gap-3 min-w-0">
                   <PlayerStatsCard :name="player.name" :club="player.club" :afl-status="player.aflStatus" :afl-player-season-id="player.aflPlayerSeasonId" :afl-round-id="bootstrapAflRoundId">
@@ -436,32 +595,59 @@
                   </PlayerStatsCard>
                   <span v-if="playerShowScore(player)" class="text-sm tabular-nums text-text shrink-0">{{ player.score }}</span>
                 </div>
-                <div class="flex items-center gap-1">
-                  <!-- Position buttons (starters) -->
+                <div class="relative flex items-center gap-0.5 shrink-0">
+                  <!-- Stats summary -->
+                  <span
+                    v-for="col in statSummaryCols"
+                    :key="col.key"
+                    class="w-9 text-right text-xs tabular-nums whitespace-nowrap"
+                    :class="col.key === 'star' ? 'text-yellow-400/70' : 'text-text-muted'"
+                    :style="statHeat(player, col.key)"
+                  ><span v-if="statTrend(player, col.key) === 'up'" class="text-[10px] text-green-400" :title="trendUpTitle">↑</span><span v-else-if="statTrend(player, col.key) === 'down'" class="text-[10px] text-red-400" :title="trendDownTitle">↓</span>{{ squadStat(player, col.key) }}</span>
+                  <!-- Popup fallback for drag and drop -->
                   <button
-                    v-for="pos in positions"
-                    :key="pos.key"
-                    class="rounded px-2 py-0.5 text-xs transition-colors"
-                    :class="[
-                      isPositionFull(pos.key) ? 'opacity-30 cursor-not-allowed' : '',
-                      pos.key === 'star' ? 'text-yellow-400 hover:bg-control-hover hover:text-yellow-300' : 'text-text-muted hover:bg-control-hover hover:text-text'
-                    ]"
-                    :disabled="isPositionFull(pos.key)"
-                    @click="addToTeam(pos.key, player)"
+                    aria-label="Add to team"
+                    class="w-6 h-6 flex items-center justify-center rounded text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                    @click.stop="toggleMenu(`squad:${player.id}`)"
                   >
-                    {{ pos.short }}
+                    <IconMenu class="w-3.5 h-3.5" />
                   </button>
-                  <span class="w-px h-4 bg-border mx-0.5 shrink-0"></span>
-                  <!-- Bench -->
-                  <button
-                    class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
-                    :disabled="benchDualFull"
-                    :class="{ 'opacity-30 cursor-not-allowed': benchDualFull }"
-                    title="Add to bench"
-                    @click="addBenchDual(player)"
+                  <div
+                    v-if="openMenuKey === `squad:${player.id}`"
+                    class="absolute right-0 top-full mt-1 z-50 w-44 rounded-lg border border-border bg-surface shadow-lg p-1"
+                    @click.stop
                   >
-                    B
-                  </button>
+                    <p class="px-2 py-1 text-[10px] uppercase tracking-wide text-text-faint">Add to</p>
+                    <button
+                      v-for="pos in positions"
+                      :key="pos.key"
+                      class="flex w-full items-center justify-between rounded px-2 py-1 text-xs transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                      :class="pos.key === 'star' ? 'text-yellow-400' : 'text-text'"
+                      :disabled="isPositionFull(pos.key)"
+                      @click.stop="addToTeam(pos.key, player); closeMenu()"
+                    >
+                      <span>{{ pos.label }}</span>
+                      <span class="flex items-center gap-1.5">
+                        <span class="flex items-center gap-0.5">
+                          <span v-for="n in emptySlotCount(pos.key)" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                        </span>
+                        <span class="text-text-faint">{{ pos.short }}</span>
+                      </span>
+                    </button>
+                    <button
+                      class="flex w-full items-center justify-between rounded px-2 py-1 text-xs text-text transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                      :disabled="benchDualFull"
+                      @click.stop="addBenchDual(player); closeMenu()"
+                    >
+                      <span>Bench</span>
+                      <span class="flex items-center gap-1.5">
+                        <span class="flex items-center gap-0.5">
+                          <span v-for="n in benchEmptyCount" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                        </span>
+                        <span class="text-text-faint">B</span>
+                      </span>
+                    </button>
+                  </div>
                 </div>
               </div>
               <p v-if="availablePlayers.length === 0" class="text-sm text-text-faint">All players assigned</p>
@@ -476,11 +662,14 @@
               </button>
               <div v-if="showTraded" class="space-y-1">
                 <div
-                  v-for="player in tradedPlayers"
+                  v-for="player in sortedTradedPlayers"
                   :key="player.id"
-                  class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2 opacity-40"
+                  class="flex items-center justify-between rounded-lg border border-border bg-surface-raised px-4 py-2 cursor-grab active:cursor-grabbing"
+                  draggable="true"
+                  @dragstart="onDragStart($event, { kind: 'squad', player })"
+                  @dragend="onDragEnd"
                 >
-                  <div class="flex items-center gap-3 min-w-0">
+                  <div class="flex items-center gap-3 min-w-0 opacity-40">
                     <PlayerStatsCard :name="player.name" :club="player.club" :afl-status="player.aflStatus" :afl-player-season-id="player.aflPlayerSeasonId" :afl-round-id="bootstrapAflRoundId">
                       <div>
                         <div class="font-medium text-sm">{{ player.name }}</div>
@@ -489,25 +678,57 @@
                     </PlayerStatsCard>
                     <span v-if="playerShowScore(player)" class="text-sm tabular-nums text-text shrink-0">{{ player.score }}</span>
                   </div>
-                  <div class="flex items-center gap-1">
+                  <div class="relative flex items-center gap-0.5 shrink-0">
+                    <span
+                      v-for="col in statSummaryCols"
+                      :key="col.key"
+                      class="w-9 text-right text-xs tabular-nums whitespace-nowrap opacity-40"
+                      :class="col.key === 'star' ? 'text-yellow-400/70' : 'text-text-muted'"
+                      :style="statHeat(player, col.key)"
+                    ><span v-if="statTrend(player, col.key) === 'up'" class="text-[10px] text-green-400" :title="trendUpTitle">↑</span><span v-else-if="statTrend(player, col.key) === 'down'" class="text-[10px] text-red-400" :title="trendDownTitle">↓</span>{{ squadStat(player, col.key) }}</span>
                     <button
-                      v-for="pos in positions"
-                      :key="pos.key"
-                      class="rounded px-2 py-0.5 text-xs transition-colors"
-                      :class="[
-                        isPositionFull(pos.key) ? 'opacity-30 cursor-not-allowed' : '',
-                        pos.key === 'star' ? 'text-yellow-400 hover:bg-control-hover hover:text-yellow-300' : 'text-text-muted hover:bg-control-hover hover:text-text'
-                      ]"
-                      :disabled="isPositionFull(pos.key)"
-                      @click="addToTeam(pos.key, player)"
-                    >{{ pos.short }}</button>
-                    <span class="w-px h-4 bg-border mx-0.5 shrink-0"></span>
-                    <button
-                      class="rounded px-2 py-0.5 text-xs text-text-faint hover:bg-control-hover hover:text-text transition-colors"
-                      :disabled="benchDualFull"
-                      :class="{ 'opacity-30 cursor-not-allowed': benchDualFull }"
-                      @click="addBenchDual(player)"
-                    >B</button>
+                      aria-label="Add to team"
+                      class="w-6 h-6 flex items-center justify-center rounded text-text-faint hover:bg-control-hover hover:text-text transition-colors"
+                      @click.stop="toggleMenu(`squad:${player.id}`)"
+                    >
+                      <IconMenu class="w-3.5 h-3.5" />
+                    </button>
+                    <div
+                      v-if="openMenuKey === `squad:${player.id}`"
+                      class="absolute right-0 top-full mt-1 z-50 w-44 rounded-lg border border-border bg-surface shadow-lg p-1"
+                      @click.stop
+                    >
+                      <p class="px-2 py-1 text-[10px] uppercase tracking-wide text-text-faint">Add to</p>
+                      <button
+                        v-for="pos in positions"
+                        :key="pos.key"
+                        class="flex w-full items-center justify-between rounded px-2 py-1 text-xs transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                        :class="pos.key === 'star' ? 'text-yellow-400' : 'text-text'"
+                        :disabled="isPositionFull(pos.key)"
+                        @click.stop="addToTeam(pos.key, player); closeMenu()"
+                      >
+                        <span>{{ pos.label }}</span>
+                        <span class="flex items-center gap-1.5">
+                          <span class="flex items-center gap-0.5">
+                            <span v-for="n in emptySlotCount(pos.key)" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                          </span>
+                          <span class="text-text-faint">{{ pos.short }}</span>
+                        </span>
+                      </button>
+                      <button
+                        class="flex w-full items-center justify-between rounded px-2 py-1 text-xs text-text transition-colors hover:bg-control-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                        :disabled="benchDualFull"
+                        @click.stop="addBenchDual(player); closeMenu()"
+                      >
+                        <span>Bench</span>
+                        <span class="flex items-center gap-1.5">
+                          <span class="flex items-center gap-0.5">
+                            <span v-for="n in benchEmptyCount" :key="n" class="w-1 h-1 rounded-full bg-text-faint" />
+                          </span>
+                          <span class="text-text-faint">B</span>
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -540,9 +761,13 @@ import IconManage from '../components/icons/IconManage.vue'
 import IconSubs from '../components/icons/IconSubs.vue'
 import IconBin from '../components/icons/IconBin.vue'
 import IconCopy from '../components/icons/IconCopy.vue'
+import IconMenu from '../components/icons/IconMenu.vue'
+import { heatStyle } from '@/utils/heatmap'
+import { useTheme } from '@/composables/useTheme'
 import PlayerStatsCard from '../components/PlayerStatsCard.vue'
 import { useFflState } from '../composables/useFflState'
 import { POSITION_MULTIPLIERS } from '../utils/position'
+import { starScore, fmtStat, statCols, LAST_N, type StatSummary } from '../utils/playerStats'
 
 const props = defineProps<{ clubMatchId: string; readonly?: boolean }>()
 
@@ -579,6 +804,8 @@ interface SquadPlayer {
   hitouts: number | null
   byeStats: { goals: number; kicks: number; handballs: number; marks: number; tackles: number; hitouts: number; games: number } | null
   aflPlayerSeasonId: string | null
+  statsAll: StatSummary | null
+  statsLastN: StatSummary | null
 }
 
 interface Slot {
@@ -730,7 +957,7 @@ const squad = computed<SquadPlayer[]>(() => {
   return clubSeasonData.value.players.nodes.map((r: {
     id: string
     player: { aflPlayer: { name: string } }
-    aflPlayerSeason?: { id?: string; clubSeason?: { club?: { name: string } | null } | null } | null
+    aflPlayerSeason?: { id?: string; clubSeason?: { club?: { name: string } | null } | null; statsAll?: StatSummary | null; statsLastN?: StatSummary | null } | null
     toRoundId?: string | null
   }) => {
     const pm = playerMatchBySeasonId.value.get(r.id)
@@ -752,6 +979,8 @@ const squad = computed<SquadPlayer[]>(() => {
       hitouts: pm?.hitouts ?? null,
       byeStats: pm?.byeStats ?? null,
       aflPlayerSeasonId: pm?.aflPlayerSeasonId ?? r.aflPlayerSeason?.id ?? null,
+      statsAll: r.aflPlayerSeason?.statsAll ?? null,
+      statsLastN: r.aflPlayerSeason?.statsLastN ?? null,
     }
   })
 })
@@ -883,6 +1112,8 @@ function loadTeamFromMatch(cm: NonNullable<typeof clubMatch.value>) {
       hitouts: pm.aflPlayerMatch?.hitouts ?? null,
       byeStats: pm.playerSeason?.aflPlayerSeason?.stats ?? null,
       aflPlayerSeasonId: pm.playerSeason?.aflPlayerSeason?.id ?? squadEntry?.aflPlayerSeasonId ?? null,
+      statsAll: squadEntry?.statsAll ?? null,
+      statsLastN: squadEntry?.statsLastN ?? null,
     }
     const isBench = pm.backupPositions != null || pm.interchangePosition != null
 
@@ -1239,6 +1470,311 @@ function flashClearedSlot(index: number) {
 function setInterchange(value: string) {
   interchangePosition.value = value || null
   markDirty()
+}
+
+function moveBenchToStarter(index: number, pos: PositionKey) {
+  const bSlot = benchDualSlots.value[index]
+  if (!bSlot.player) return
+  const slot = teamSlots.value[pos].find(s => !s.player)
+  if (!slot) return
+  slot.player = bSlot.player
+  bSlot.player = null
+  bSlot.positions = [null, null]
+  markDirty()
+}
+
+function moveStarterToBench(pos: PositionKey, index: number) {
+  const player = teamSlots.value[pos][index].player
+  if (!player) return
+  const slot = benchDualSlots.value.find(s => !s.player)
+  if (!slot) return
+  slot.player = player
+  teamSlots.value[pos][index].player = null
+  markDirty()
+}
+
+function canMoveUp(pos: PositionKey, index: number): boolean {
+  return index > 0 && !!teamSlots.value[pos][index - 1].player
+}
+
+function canMoveDown(pos: PositionKey, index: number): boolean {
+  const slots = teamSlots.value[pos]
+  return index < slots.length - 1 && !!slots[index + 1].player
+}
+
+// ── Stats summary (manage mode) ──────────────────────────────────────────────
+
+// Same column order as the squad page (statCols), with the star score appended.
+const statSummaryCols = [...statCols, { key: 'star', label: '★' }] as const
+
+const squadStatsById = computed(() => {
+  const map = new Map<string, { statsAll: StatSummary | null; statsLastN: StatSummary | null }>()
+  for (const p of squad.value) map.set(p.id, { statsAll: p.statsAll, statsLastN: p.statsLastN })
+  return map
+})
+
+// Which stat set drives the summary columns, heatmap, sort, and projections.
+const statSource = ref<'form' | 'season'>('form')
+
+const statSourceTitle = computed(() =>
+  statSource.value === 'form' ? `Last ${LAST_N} form averages` : 'Season averages'
+)
+
+// Both stat sets for a player. Team-slot players are looked up by id because
+// they may have been loaded before the club season stats arrived.
+function playerStatSets(player: SquadPlayer): { form: StatSummary | null; season: StatSummary | null } {
+  const s = squadStatsById.value.get(player.id)
+  return {
+    form: s?.statsLastN ?? player.statsLastN ?? null,
+    season: s?.statsAll ?? player.statsAll ?? null,
+  }
+}
+
+// The active stat set per the toggle; form falls back to season when a player
+// has no recent games.
+function formStats(player: SquadPlayer): StatSummary | null {
+  const { form, season } = playerStatSets(player)
+  return statSource.value === 'season' ? season : (form ?? season)
+}
+
+// Trend of form vs season for one stat: ▲/▼ when form deviates meaningfully
+// (at least 15% of the season value, and at least 0.5 absolute).
+const trendUpTitle = `Trending up: last ${LAST_N} average is at least 15% above season average`
+const trendDownTitle = `Trending down: last ${LAST_N} average is at least 15% below season average`
+
+function statTrend(player: SquadPlayer, key: typeof statSummaryCols[number]['key']): 'up' | 'down' | null {
+  const { form, season } = playerStatSets(player)
+  if (!form || !season) return null
+  const f = key === 'star' ? starScore(form) : form[key]
+  const s = key === 'star' ? starScore(season) : season[key]
+  const threshold = Math.max(0.5, 0.15 * Math.abs(s))
+  if (f - s >= threshold) return 'up'
+  if (s - f >= threshold) return 'down'
+  return null
+}
+
+function squadStat(player: SquadPlayer, key: typeof statSummaryCols[number]['key']): string {
+  const s = formStats(player)
+  if (!s) return '—'
+  return fmtStat(key === 'star' ? starScore(s) : s[key])
+}
+
+// Per-column heatmap over the whole squad (same palette as the Squad page).
+const { isDark } = useTheme()
+
+const statColumnRange = computed(() => {
+  const range = {} as Record<typeof statSummaryCols[number]['key'], { min: number; max: number }>
+  for (const col of statSummaryCols) {
+    const vals = squad.value
+      .map(p => {
+        const s = formStats(p)
+        return s ? (col.key === 'star' ? starScore(s) : s[col.key]) : null
+      })
+      .filter((v): v is number => v != null)
+    if (vals.length) range[col.key] = { min: Math.min(...vals), max: Math.max(...vals) }
+  }
+  return range
+})
+
+function statHeat(player: SquadPlayer, key: typeof statSummaryCols[number]['key']): Record<string, string> {
+  const s = formStats(player)
+  if (!s) return {}
+  const r = statColumnRange.value[key]
+  if (!r) return {}
+  return heatStyle(key === 'star' ? starScore(s) : s[key], r.min, r.max, isDark.value)
+}
+
+// Squad panel sorting — click a stat header to sort descending, click again to
+// return to last-name order. Defaults to star score.
+const squadSortKey = ref<typeof statSummaryCols[number]['key'] | 'name'>('star')
+
+function toggleSquadSort(key: typeof statSummaryCols[number]['key']) {
+  squadSortKey.value = squadSortKey.value === key ? 'name' : key
+}
+
+function sortBySquadKey(players: SquadPlayer[]): SquadPlayer[] {
+  const key = squadSortKey.value
+  if (key === 'name') {
+    return [...players].sort((a, b) => {
+      const lastA = a.name.split(' ').pop()?.toLowerCase() ?? ''
+      const lastB = b.name.split(' ').pop()?.toLowerCase() ?? ''
+      return lastA.localeCompare(lastB)
+    })
+  }
+  const val = (p: SquadPlayer): number => {
+    const s = formStats(p)
+    if (!s) return -1
+    return key === 'star' ? starScore(s) : s[key]
+  }
+  return [...players].sort((a, b) => val(b) - val(a))
+}
+
+const sortedAvailablePlayers = computed(() => sortBySquadKey(availablePlayers.value))
+const sortedTradedPlayers = computed(() => sortBySquadKey(tradedPlayers.value))
+
+// Projected points for a starter slot: form average for the position stat × multiplier.
+function projectedScore(player: SquadPlayer, pos: PositionKey): number | null {
+  const s = formStats(player)
+  if (!s) return null
+  return pos === 'star' ? starScore(s) : s[pos] * (POSITION_MULTIPLIERS[pos] ?? 1)
+}
+
+// Estimated team total: form-based projections summed across all filled starter slots.
+const projectedTotal = computed(() => {
+  let total = 0
+  for (const pos of positions) {
+    for (const slot of teamSlots.value[pos.key]) {
+      if (!slot.player) continue
+      total += projectedScore(slot.player, pos.key) ?? 0
+    }
+  }
+  return Math.round(total)
+})
+
+// ── Popup menus (fallback for drag and drop) ─────────────────────────────────
+
+// Remaining open slots per target — rendered as dots in the popup menus.
+function emptySlotCount(key: PositionKey): number {
+  return teamSlots.value[key].filter(s => !s.player).length
+}
+
+const benchEmptyCount = computed(() => benchDualSlots.value.filter(s => !s.player).length)
+
+const openMenuKey = ref<string | null>(null)
+
+function toggleMenu(key: string) {
+  openMenuKey.value = openMenuKey.value === key ? null : key
+}
+
+function closeMenu() {
+  openMenuKey.value = null
+}
+
+// ── Drag and drop ────────────────────────────────────────────────────────────
+
+type DragSource =
+  | { kind: 'squad'; player: SquadPlayer }
+  | { kind: 'starter'; pos: PositionKey; index: number }
+  | { kind: 'bench'; index: number }
+
+const dragSource = ref<DragSource | null>(null)
+const dragOverKey = ref<string | null>(null)
+
+function onDragStart(ev: DragEvent, src: DragSource) {
+  if (!managing.value) {
+    ev.preventDefault()
+    return
+  }
+  dragSource.value = src
+  closeMenu()
+  if (ev.dataTransfer) {
+    ev.dataTransfer.setData('text/plain', '')
+    ev.dataTransfer.effectAllowed = 'move'
+  }
+}
+
+function onDragEnd() {
+  dragSource.value = null
+  dragOverKey.value = null
+}
+
+function onDragLeave(key: string) {
+  if (dragOverKey.value === key) dragOverKey.value = null
+}
+
+// Returns the action a drop on the given starter slot would perform, or null if invalid.
+function starterDropAction(pos: PositionKey, index: number): (() => void) | null {
+  const src = dragSource.value
+  if (!src) return null
+  const slot = teamSlots.value[pos][index]
+  if (src.kind === 'squad') {
+    const player = src.player
+    if (!slot.player) return () => { slot.player = player; markDirty() }
+    if (!isPositionFull(pos)) return () => addToTeam(pos, player)
+    return null
+  }
+  if (src.kind === 'starter') {
+    const { pos: fromPos, index: fromIndex } = src
+    if (fromPos === pos) {
+      if (fromIndex === index || !slot.player) return null
+      return () => swapStarters(pos, fromIndex, index)
+    }
+    // Cross-position: fill an empty slot, or swap occupants.
+    const fromSlot = teamSlots.value[fromPos][fromIndex]
+    if (!slot.player) return () => { slot.player = fromSlot.player; fromSlot.player = null; markDirty() }
+    return () => {
+      const tmp = fromSlot.player
+      fromSlot.player = slot.player
+      slot.player = tmp
+      markDirty()
+    }
+  }
+  // Bench → starter slot.
+  const bSlot = benchDualSlots.value[src.index]
+  if (!bSlot.player) return null
+  const place = (target: Slot) => {
+    target.player = bSlot.player
+    bSlot.player = null
+    bSlot.positions = [null, null]
+    markDirty()
+  }
+  if (!slot.player) return () => place(slot)
+  const empty = teamSlots.value[pos].find(s => !s.player)
+  if (empty) return () => place(empty)
+  return null
+}
+
+// Returns the action a drop on the given bench slot would perform, or null if invalid.
+function benchDropAction(index: number): (() => void) | null {
+  const src = dragSource.value
+  if (!src) return null
+  const slot = benchDualSlots.value[index]
+  if (src.kind === 'squad') {
+    const player = src.player
+    if (!slot.player) return () => { slot.player = player; markDirty() }
+    if (!benchDualFull.value) return () => addBenchDual(player)
+    return null
+  }
+  if (src.kind === 'starter') {
+    const fromSlot = teamSlots.value[src.pos][src.index]
+    if (!fromSlot.player) return null
+    if (!slot.player) return () => { slot.player = fromSlot.player; fromSlot.player = null; markDirty() }
+    if (!benchDualFull.value) return () => { addBenchDual(fromSlot.player!); fromSlot.player = null }
+    return null
+  }
+  // Bench → bench: reorder (player and backup positions travel together).
+  if (src.index === index) return null
+  const other = benchDualSlots.value[src.index]
+  return () => {
+    const tmpPlayer = other.player
+    const tmpPositions = other.positions
+    other.player = slot.player
+    other.positions = slot.positions
+    slot.player = tmpPlayer
+    slot.positions = tmpPositions
+    markDirty()
+  }
+}
+
+// Dropping a team/bench player back on the squad list removes them from the team.
+function squadDropAction(): (() => void) | null {
+  const src = dragSource.value
+  if (!src) return null
+  if (src.kind === 'starter') return () => removeFromTeam(src.pos, src.index)
+  if (src.kind === 'bench') return () => removeBenchDual(src.index)
+  return null
+}
+
+function onDragOverTarget(ev: DragEvent, key: string, action: (() => void) | null) {
+  if (!action) return
+  ev.preventDefault()
+  if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'move'
+  dragOverKey.value = key
+}
+
+function onDropTarget(action: (() => void) | null) {
+  if (action) action()
+  onDragEnd()
 }
 
 // ── Subs mode ────────────────────────────────────────────────────────────────

--- a/frontend/web/src/features/ffl/views/TeamBuilderView.vue
+++ b/frontend/web/src/features/ffl/views/TeamBuilderView.vue
@@ -539,8 +539,11 @@
           <div v-if="managing">
             <div class="flex items-center justify-between mb-3">
               <h2 class="text-lg font-semibold text-text-heading">Squad ({{ availablePlayers.length }})</h2>
-              <span class="text-[10px] text-text-faint/70 whitespace-nowrap">
-                <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = last {{ LAST_N }} form ≥15% above/below season avg
+              <span
+                class="text-xs text-text-faint whitespace-nowrap"
+                :title="`↑/↓ = last ${LAST_N} form at least 15% above/below season average`"
+              >
+                <span class="text-green-400">↑</span>/<span class="text-red-400">↓</span> = last {{ LAST_N }} form
               </span>
               <!-- Form/Season toggle -->
               <div class="flex items-center rounded border border-border overflow-hidden text-[10px] text-text-faint">

--- a/frontend/web/src/utils/cookie.ts
+++ b/frontend/web/src/utils/cookie.ts
@@ -1,0 +1,10 @@
+export function getCookie(name: string): string {
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'))
+  return match ? decodeURIComponent(match[2]) : ''
+}
+
+export function setCookie(name: string, value: string, expiryDays = 1) {
+  const expires = new Date()
+  expires.setDate(expires.getDate() + expiryDays)
+  document.cookie = `${name}=${encodeURIComponent(value)};expires=${expires.toUTCString()};path=/`
+}

--- a/frontend/web/src/utils/heatmap.ts
+++ b/frontend/web/src/utils/heatmap.ts
@@ -1,9 +1,9 @@
 // dark:  slate-500 → yellow-400
-// light: slate-300 → purple-700
+// light: slate-300 → blue-700
 export function heatStyle(value: number, min: number, max: number, isDark: boolean): Record<string, string> {
   if (max === 0 || max === min) return {}
   const t = (value - min) / (max - min)
   const [lr, lg, lb] = isDark ? [100, 116, 139] : [203, 213, 225]
-  const [hr, hg, hb] = isDark ? [250, 204, 21]  : [126, 34,  206]
+  const [hr, hg, hb] = isDark ? [250, 204, 21]  : [29,  78,  216]
   return { color: `rgb(${Math.round(lr + t * (hr - lr))},${Math.round(lg + t * (hg - lg))},${Math.round(lb + t * (hb - lb))})` }
 }

--- a/frontend/web/src/utils/heatmap.ts
+++ b/frontend/web/src/utils/heatmap.ts
@@ -1,0 +1,9 @@
+// dark:  slate-500 → yellow-400
+// light: slate-300 → purple-700
+export function heatStyle(value: number, min: number, max: number, isDark: boolean): Record<string, string> {
+  if (max === 0 || max === min) return {}
+  const t = (value - min) / (max - min)
+  const [lr, lg, lb] = isDark ? [100, 116, 139] : [203, 213, 225]
+  const [hr, hg, hb] = isDark ? [250, 204, 21]  : [126, 34,  206]
+  return { color: `rgb(${Math.round(lr + t * (hr - lr))},${Math.round(lg + t * (hg - lg))},${Math.round(lb + t * (hb - lb))})` }
+}

--- a/frontend/web/vite.config.ts
+++ b/frontend/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
@@ -11,5 +12,9 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+  },
+  test: {
+    // Unit tests only (ADR-019); Playwright owns e2e/*.spec.ts
+    include: ['src/**/*.test.ts'],
   },
 })

--- a/justfile
+++ b/justfile
@@ -108,6 +108,10 @@ test-afl:
 test-ffl:
     cd services/ffl && go test -tags integration ./...
 
+# Run frontend unit tests (vitest — pure logic only)
+test-frontend:
+    cd frontend/web && npm run test:unit
+
 # Run e2e tests in a fully isolated environment (dev stack may remain running)
 test-e2e:
     #!/usr/bin/env bash
@@ -139,6 +143,7 @@ test-e2e:
 test-all:
     just test-afl
     just test-ffl
+    just test-frontend
     just test-e2e
 
 # Back up Postgres to backups/ (set BACKUP_REMOTE=rclone-remote:bucket/path to also upload)

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ dev-reset:
     #!/usr/bin/env bash
     read -p "IMPORTANT!!! Do you need to back up the database first? [y/N] " answer
     if [[ "$answer" =~ ^[Yy]$ ]]; then
-        echo "Aborting — run 'just backup-db' first, then re-run 'just dev-reset'."
+        echo "Aborting — run 'just db-backup' first, then re-run 'just dev-reset'."
         exit 1
     fi
     docker compose -f dev/docker-compose.yml down -v
@@ -142,11 +142,11 @@ test-all:
     just test-e2e
 
 # Back up Postgres to backups/ (set BACKUP_REMOTE=rclone-remote:bucket/path to also upload)
-backup-db:
+db-backup:
     @bash dev/backup/backup.sh
 
 # Restore Postgres from a backup file (defaults to latest in backups/)
-restore-db file="":
+db-restore file="":
     #!/usr/bin/env bash
     bash dev/backup/restore.sh {{file}}
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,16 @@
+# Plans
+
+Future work can flow through this funnel:
+
+```
+anything (reviews, analyses, discussions)
+      │  candidates land as an entry in…
+      ▼
+plans/ideas.md            ← THE one place to look before roadmapping
+      ▼  graduates when scheduled
+plans/roadmap.md          ← committed phases only
+      ▼  becomes the active phase
+plans/current-sprint.md   ← tasks in flight; checked off as completed
+      ▼
+plans/history.md          ← archive when built
+```

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -12,3 +12,4 @@ See `plans/ideas.md` for full item descriptions where relevant.
 - [x] PAGE-3: AFL club season view (`/ffl/afl/club-seasons/:id`) — all players at an AFL club with FFL ownership, stats, and * avg; entry from AFL ladder club names
 - [x] Club Match page (`/ffl/club-matches/:id`) — read-only view of a club's team and scores; linked from FFL match view; Team Builder link shown when club is selected
 - [x] Frontend architecture: formalised three-namespace page hierarchy (FFL / AFL / AFL Lens) in `frontend.md`; consistent page naming and route conventions across `router.ts`, `frontend.md`, and `ideas.md`
+- [x] Cross-page linking UX pass — AFL round Top Players (logo + match link), AFL match DataOps footer removed + stat headers (K H D M R T G B Pts), AFL Lens club season inline player/club links, FFL round top scorer match links, FFL match header club season links, "Improve your score" pill moved above grid for alignment

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -8,4 +8,4 @@ See `plans/ideas.md` for full item descriptions where relevant.
 
 ## Tasks
 
-Phase 23 has no task list yet — refer to `plans/ideas.md` and confirm scope before starting work.
+- [x] PAGE-1: AFL player season view (`/ffl/afl/player-seasons/:id`) — MEDIAN backend, status pills, season stats table, row-level match links, header breadcrumb links, stat label fixes

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -1,6 +1,6 @@
-# Current Sprint — Phase 22: Real Data Load & Seed Cleanup
+# Current Sprint — Phase 23: UX — Player Intelligence
 
-**Sprint goal:** Replace synthetic seed data with real 2026 AFL and FFL data, and slim the dev seed to a lean scaffold.
+**Sprint goal:** Richer player and club context for FFL decision-making.
 
 See `plans/ideas.md` for full item descriptions where relevant.
 
@@ -8,12 +8,4 @@ See `plans/ideas.md` for full item descriptions where relevant.
 
 ## Tasks
 
-- [x] Import all 2026 AFL rounds played to date (teams, players, match stats) via existing import tooling
-- [x] Verify AFL ladder calculation produces correct standings
-- [x] Calculate score(s) for bye players on bench; currently shows as "?".  Fix FFL Team import in Rounds 3/4.
-- [x] Import all 2026 FFL round teams to date
-- [x] Verify FFL ladder calculation produces correct standings
-- [x] Smoke-test team submission and substitution flows against real data; capture edge cases
-- [x] Reduce `dev/seed` to a single representative round (enough for demo and future dev)
-- [x] Confirm e2e tests pass against slim seed
-- [x] Add FFLSuggestedInterchange type to graph; show interchange hint on MatchView and TeamBuilderView
+Phase 23 has no task list yet — refer to `plans/ideas.md` and confirm scope before starting work.

--- a/plans/current-sprint.md
+++ b/plans/current-sprint.md
@@ -9,3 +9,6 @@ See `plans/ideas.md` for full item descriptions where relevant.
 ## Tasks
 
 - [x] PAGE-1: AFL player season view (`/ffl/afl/player-seasons/:id`) — MEDIAN backend, status pills, season stats table, row-level match links, header breadcrumb links, stat label fixes
+- [x] PAGE-3: AFL club season view (`/ffl/afl/club-seasons/:id`) — all players at an AFL club with FFL ownership, stats, and * avg; entry from AFL ladder club names
+- [x] Club Match page (`/ffl/club-matches/:id`) — read-only view of a club's team and scores; linked from FFL match view; Team Builder link shown when club is selected
+- [x] Frontend architecture: formalised three-namespace page hierarchy (FFL / AFL / AFL Lens) in `frontend.md`; consistent page naming and route conventions across `router.ts`, `frontend.md`, and `ideas.md`

--- a/plans/history.md
+++ b/plans/history.md
@@ -229,3 +229,14 @@ Completed phases from the xffl rebuild. See `plans/roadmap.md` for active and up
 - [x] NAV-5: Replace DataOps round dropdown with RoundNav component
 - [x] PAGE-7: Enhance current-round pill with pulsing indicator when `start_dt` = today
 - [x] Playwright tests for new navigation elements
+
+## Phase 22: Real Data Load & Seed Cleanup ✅
+
+**Goal:** Replace synthetic seed data with real 2026 AFL and FFL data, and slim the dev seed to a lean scaffold.
+
+- [x] Import all 2026 AFL rounds played to date (teams, players, match stats) via existing import tooling
+- [x] Import all 2026 FFL round teams to date
+- [x] Verify ladder calculation produces correct standings
+- [x] Smoke-test team submission and substitution flows against real data; capture edge cases
+- [x] Reduce `dev/seed` to a single representative round (enough for demo and future dev)
+- [x] Confirm e2e tests pass against slim seed

--- a/plans/ideas.md
+++ b/plans/ideas.md
@@ -8,25 +8,18 @@ Aspirational ideas, designs, and things to revisit. Not commitments. Some items 
 
 ### Navigation
 
-| ID | Title | Summary | Effort |
-|---|---|---|---|
-| NAV-1 | Header links → live round | AFL and FFL header links navigate to `/afl/rounds/:liveRoundId` and `/ffl/rounds/:liveRoundId` instead of the ladder home. `liveRoundId` is already in state from boot. | XS |
-| NAV-2 | Cross-domain round link | Contextual pill near the round title: "↔ AFL Round 16" / "↔ FFL Round 16". Replaces the buried bottom-of-page AFL Round link on FFL round view. Uses `round.aflRoundId` for FFL→AFL; needs `fflRoundByAflRound` for AFL→FFL (already wired in bootstrap). | S |
-| NAV-3 | Ladder pill in RoundNav | First item in RoundNav before round number pills — ladder icon + hover tooltip "Ladder". Links to the season home/ladder view. | XS |
-| NAV-4 | DataOps in header | DataOps icon link always visible in header right-side nav. Links to `/ffl/data-ops` with the live round pre-selected via query param. | XS |
-| NAV-5 | DataOps RoundNav | Replace round dropdown inside DataOps with a RoundNav component (same as AFL/FFL round pages). Eventually: pill colours reflect data health — green = all data final, orange = in progress, red = past round with missing data. Colour-coding deferred until query cost is assessed. | M |
+(No outstanding navigation items.)
 
 ### Pages
 
 | ID | Route | Status | What it shows | Effort |
 |---|---|---|---|---|
-| PAGE-1 | `/ffl/afl/player-seasons/:aflPlayerSeasonId` | Partially built | FFL league view of one AFL player's season: all FFL ownership stints + unowned gaps, per-round k/h/m/t/r/g + * score + FFL position + FFL club. Most valuable page in the system. | M |
+| PAGE-1 | `/ffl/afl/player-seasons/:aflPlayerSeasonId` | Built | FFL league view of one AFL player's season: all FFL ownership stints + unowned gaps, per-round k/h/m/t/r/g + * score + FFL position + FFL club. Most valuable page in the system. | M |
 | PAGE-2 | `/ffl/player-seasons/:fflPlayerSeasonId` | Expand-row in SquadView; not a full page | One club's ownership of a player: club-specific notes, averages scoped to "while they were mine", per-round breakdown. | S |
-| PAGE-3 | `/ffl/afl/club-seasons/:aflClubSeasonId` | Not built | All players at an AFL club this season: name / FFL club / position / k/h/m/t/r/g / * avg. Sections: FFL ownership summary ("6 Ruiboys, 4 Cheetahs, 3 unowned") + best unowned sublist. Entry from AFL ladder club names. | M |
+| PAGE-3 | `/ffl/afl/club-seasons/:clubSeasonId` | Built | All players at an AFL club this season: name / FFL club / k/h/m/t/r/g / * avg. Entry from AFL ladder club names. | M |
 | PAGE-4 | `/ffl/free-agents` | Not built | All unowned AFL players, sorted by * avg desc. Filterable by position. Columns: name / AFL club / position / * avg / last round score. Primary trade-target intelligence tool. | M |
 | PAGE-5 | `/ffl/club-seasons/:id` (expand) | SquadView exists; dashboard additions not built | Add to top of SquadView: total * scored this season, points by round (sparkline or table), top scorer, W/L/D record. Squad list below unchanged. | S |
 | PAGE-6 | `/ffl` and `/afl` (expand) | Ladder exists; results matrix not built | Add round-by-round W/L/D grid alongside the standard ladder — traditional FFL results page format. Entry point: NAV-3 Ladder pill. | S |
-| PAGE-7 | RoundNav live indicator | Basic version exists (ring on current round) | Enhance current-round pill with pulsing dot or "LIVE" badge when `start_dt` = today. Frontend only — `start_dt` already in round data. | XS |
 | PAGE-8 | `/ffl/compare` | Not built | Pick 2–3 AFL players via search, compare stats/FFL scores side-by-side. Shareable URL (player IDs in query params). | L |
 | PAGE-9 | `/ffl/afl/clubs/:aflClubId` | Future — needs 2+ seasons | All-time FFL history of an AFL club across seasons: players drafted, aggregate scoring, per-season breakdown. | — |
 | PAGE-10 | `/ffl/afl/players/:aflPlayerId` | Future — needs 2+ seasons | All-time FFL career of an AFL player across seasons: FFL clubs, total * points, FFL games played. | — |
@@ -59,7 +52,7 @@ Fields in the schema, populated by backend processes, not yet rendered in the UI
 |---|---|
 | PAGE-1 | FFL query by AFL player season ID; return all FFL stints + unowned rounds; cross-subgraph via federation |
 | PAGE-2 | Likely exists; may need a dedicated `fflPlayerSeason(id)` resolver with more detail than SquadView currently fetches |
-| PAGE-3 | New resolver: `aflClubSeason(id)` returning all players with FFL ownership joined via federation |
+| PAGE-3 | Built — `aflClubSeason(id)` resolver with FFL ownership via federation |
 | PAGE-4 | New resolver or filter on existing player queries: unowned players cross-joined with season averages |
 | PAGE-8 | No new backend; reuses existing player season queries |
 | PAGE-11 | No new backend; reuses existing player season stat queries already available for SquadView |
@@ -105,12 +98,11 @@ package "FFL — AFL lens" {
 }
 
 package "Admin" {
-  rectangle "/ffl/data-ops\nData Ops (NAV-5)" as DataOps
+  rectangle "/ffl/data-ops\nData Ops" as DataOps
 }
 
-AFL_Home  --> AFL_Round    : RoundNav (NAV-3 Ladder pill back to AFL_Home)
-FFL_Home  --> FFL_Round    : RoundNav (NAV-3 Ladder pill back to FFL_Home)
-AFL_Round <--> FFL_Round   : NAV-2 cross-domain pill
+AFL_Home  --> AFL_Round    : RoundNav
+FFL_Home  --> FFL_Round    : RoundNav
 AFL_Round --> AFL_Match    : match row
 AFL_Round --> AFL_Admin    : edit icon
 AFL_Match --> P1           : player name

--- a/plans/ideas.md
+++ b/plans/ideas.md
@@ -1,174 +1,86 @@
 # Ideas
 
-Aspirational ideas, designs, and things to revisit. Not commitments. Some items have stable IDs for referencing from the roadmap.
+Aspirational candidates, designs, and things to revisit — not commitments. Items carry stable IDs
+(`PAGE-*`, `STATS-*`, `REV-*`) where the roadmap or other docs reference them; larger designs live
+in sibling files and are indexed here.
 
 ---
 
-## UX Vision
+## UX
 
-### Navigation
-
-(No outstanding navigation items.)
-
-### Pages
+### Possible pages
 
 | ID | Route | Status | What it shows | Effort |
 |---|---|---|---|---|
-| PAGE-1 | `/ffl/afl/player-seasons/:aflPlayerSeasonId` | Built | FFL league view of one AFL player's season: all FFL ownership stints + unowned gaps, per-round k/h/m/t/r/g + * score + FFL position + FFL club. Most valuable page in the system. | M |
 | PAGE-2 | `/ffl/player-seasons/:fflPlayerSeasonId` | Expand-row in SquadView; not a full page | One club's ownership of a player: club-specific notes, averages scoped to "while they were mine", per-round breakdown. | S |
-| PAGE-3 | `/ffl/afl/club-seasons/:clubSeasonId` | Built | All players at an AFL club this season: name / FFL club / k/h/m/t/r/g / * avg. Entry from AFL ladder club names. | M |
-| PAGE-4 | `/ffl/free-agents` | Not built | All unowned AFL players, sorted by * avg desc. Filterable by position. Columns: name / AFL club / position / * avg / last round score. Primary trade-target intelligence tool. | M |
-| PAGE-5 | `/ffl/club-seasons/:id` (expand) | SquadView exists; dashboard additions not built | Add to top of SquadView: total * scored this season, points by round (sparkline or table), top scorer, W/L/D record. Squad list below unchanged. | S |
-| PAGE-6 | `/ffl` and `/afl` (expand) | Ladder exists; results matrix not built | Add round-by-round W/L/D grid alongside the standard ladder — traditional FFL results page format. Entry point: NAV-3 Ladder pill. | S |
-| PAGE-8 | `/ffl/compare` | Not built | Pick 2–3 AFL players via search, compare stats/FFL scores side-by-side. Shareable URL (player IDs in query params). | L |
 | PAGE-9 | `/ffl/afl/clubs/:aflClubId` | Future — needs 2+ seasons | All-time FFL history of an AFL club across seasons: players drafted, aggregate scoring, per-season breakdown. | — |
 | PAGE-10 | `/ffl/afl/players/:aflPlayerId` | Future — needs 2+ seasons | All-time FFL career of an AFL player across seasons: FFL clubs, total * points, FFL games played. | — |
-| PAGE-11 | Team Builder analytics (enrich `/ffl/club-matches/:id/edit`) | Not built | Surface season averages, rolling averages, and last-N-games stats per player at team-building time. Season average is the first use case and feeds into bye scoring. | M |
 
-### Pending surface
+### Player Notes
 
-Fields in the schema, populated by backend processes, not yet rendered in the UI. Planned for Phase 23.
+Fields in the schema, populated by backend processes, not yet rendered in the UI.
 
 | Field | Written by | Proposed UX home |
 |---|---|---|
 | `FFLClubMatch.notes` | FFL import (score reconciliation rationale) | FFL match view — alongside club match score |
 | `FFLPlayerMatch.notes` | FFL import (posted player scores) | FFL match view — alongside individual player scores |
 
-### Design notes
+---
 
-- **No pure AFL player/club pages.** AFL section stays as-is (ladder / rounds / matches). AFL match player links and AFL ladder club links point to their FFL-lens equivalents (PAGE-1, PAGE-3).
-- **`/ffl/afl/` sub-namespace** for FFL's view of AFL entities. Future all-time pages (PAGE-9, PAGE-10) follow naturally.
-- **Traded player example** on PAGE-1 (`/ffl/afl/player-seasons/42`):
-  ```
-  Rnd   FFL Club    Pos   K   H   M   T   R   G    *
-  1–4   (unowned)   —     8   6   3   2   0   0    —
-  5–10  Ruiboys     DEF   9   5   4   3   0   0   38
-  11–13 Cheetahs    MID  11   7   2   4   1   0   52
-  ```
+## Stats & Analytics
 
-### Backend work per new page
-
-| Page | Backend needed |
-|---|---|
-| PAGE-1 | FFL query by AFL player season ID; return all FFL stints + unowned rounds; cross-subgraph via federation |
-| PAGE-2 | Likely exists; may need a dedicated `fflPlayerSeason(id)` resolver with more detail than SquadView currently fetches |
-| PAGE-3 | Built — `aflClubSeason(id)` resolver with FFL ownership via federation |
-| PAGE-4 | New resolver or filter on existing player queries: unowned players cross-joined with season averages |
-| PAGE-8 | No new backend; reuses existing player season queries |
-| PAGE-11 | No new backend; reuses existing player season stat queries already available for SquadView |
-
-### Navigation map
-
-```plantuml
-@startuml
-!theme plain
-skinparam defaultTextAlignment center
-skinparam rectangle {
-  BackgroundColor #f8f8f8
-  BorderColor #aaaaaa
-}
-skinparam package {
-  BackgroundColor #eef4ff
-  BorderColor #7799cc
-}
-
-package "AFL" {
-  rectangle "/afl\nLadder + Results\n(PAGE-6)" as AFL_Home
-  rectangle "/afl/rounds/:id\nRound" as AFL_Round
-  rectangle "/afl/matches/:id\nMatch" as AFL_Match
-  rectangle "/afl/matches/:id/edit\nAdmin Match" as AFL_Admin
-}
-
-package "FFL" {
-  rectangle "/ffl\nLadder + Results\n(PAGE-6)" as FFL_Home
-  rectangle "/ffl/rounds/:id\nRound" as FFL_Round
-  rectangle "/ffl/matches/:id\nMatch" as FFL_Match
-  rectangle "/ffl/club-seasons/:id\nSquad (PAGE-5)" as FFL_Squad
-  rectangle "/ffl/club-matches/:id/edit\nTeam Builder (PAGE-11)" as FFL_TB
-  rectangle "/ffl/free-agents\nFree Agents (PAGE-4)" as FFL_Free
-  rectangle "/ffl/compare\nCompare (PAGE-8)" as FFL_Compare
-}
-
-package "FFL — AFL lens" {
-  rectangle "/ffl/afl/player-seasons/:id\nAFL Player Season (PAGE-1)" as P1
-  rectangle "/ffl/player-seasons/:id\nPlayer Stint (PAGE-2)" as P2
-  rectangle "/ffl/afl/club-seasons/:id\nAFL Club Season (PAGE-3)" as P3
-  rectangle "/ffl/afl/clubs/:id\nAFL Club all-time (PAGE-9)" as P9
-  rectangle "/ffl/afl/players/:id\nAFL Player all-time (PAGE-10)" as P10
-}
-
-package "Admin" {
-  rectangle "/ffl/data-ops\nData Ops" as DataOps
-}
-
-AFL_Home  --> AFL_Round    : RoundNav
-FFL_Home  --> FFL_Round    : RoundNav
-AFL_Round --> AFL_Match    : match row
-AFL_Round --> AFL_Admin    : edit icon
-AFL_Match --> P1           : player name
-AFL_Home  --> P3           : ladder club name
-FFL_Round --> FFL_Match    : match row
-FFL_Round --> FFL_Squad    : club name
-FFL_Match --> P2           : player name
-FFL_Squad --> FFL_TB       : build team
-FFL_Squad --> P3           : AFL club name
-FFL_Squad --> P2           : player name
-P3 --> P1                  : player name
-P3 --> P9                  : club all-time
-P1 --> P2                  : own-club stint row
-P1 --> P10                 : player all-time
-P2 --> P1                  : season overview
-FFL_Free  --> P1           : player name
-FFL_Free  --> FFL_Compare  : compare action
-
-@enduml
-```
+| ID | Design | Summary |
+|---|---|---|
+| STATS-1 | [stats-analytics.md](stats-analytics.md) | Records, history, quirks, and graphs over 20 years of AFL+FFL data. Postgres `stats` read model (denormalised facts + precomputed records, idempotent rebuild) → Stats GraphQL subgraph federated onto existing entities → ECharts in the frontend; Metabase (local, free) over the same schema for owner exploration — Milestone 1 is a cheap do-now candidate. Typesense stays text-search-only; ClickHouse rejected at this scale. Supersedes the old Phase 26 decision gate and the former "CQRS player stats read model" idea. |
 
 ---
 
-## Pre-match AFL player naming
+## Quality & Hardening
 
-**What:** AFL clubs announce their teams a day or two before a match (typically Thursday for a Saturday game). The named squad may change before the match starts — late omissions, bench trimming, injury replacements. Currently xffl has no record of a player being "named" before the match starts. A player either has stats (played) or has no record at all.
+The cross-lens actions from the 2026-07 codebase review. Full detail, severity tags, and
+`file:line` references: [`doc/review-findings.md`](../doc/review-findings.md) (dated snapshot at
+commit `1ce978c`).
 
-Note: separate from *player availability* (injury/suspension status, Phase 24) — availability is a season-long state; naming is a per-match pre-game event.
+REV-1 (event reliability) graduated to roadmap Phase 25.
 
-**Why parked:** Purely informational for the current workflow — does not affect scoring or ladder calculations. The data ops workflow only imports stats once matches are complete or in progress. Adding pre-match tracking before the data pipeline is established adds complexity with no near-term payoff. The event model was deliberately designed to accommodate it later without breaking changes.
-
-**What would need to change:**
-
-*AFL domain and data ops:*
-- A new status value `named` for AFL PlayerMatch: player is registered for this match but no stats yet.
-- A data source for pre-match squads (AFL website, Champion Data feed, or manual entry via Data Ops UI).
-- `AFL.MatchUpdated (partial)` payload would include named-but-not-yet-played players at status `"named"` alongside players with stats at `"playing"`.
-
-*FFL domain:*
-- `drv_afl_status = named` reinstated on `ffl.player_match`: player is linked to an AFL PlayerMatch but the match has not started.
-- FFL UI Team Builder could show pre-match squad status before games begin (useful for TMs planning subs in advance).
-
-*Event flow:*
-- `AFL.MatchUpdated` `PlayerSeasonIDStatusMap` would carry `"named"` as a valid third value alongside `"playing"`, `"played"`, `"dnp"`.
-- On `partial` transition: players previously `named` who now have stats transition to `"playing"`; those still without stats remain `"named"`.
-- On `final`: players still `"named"` become `"dnp"`.
-- No new events needed — `AFL.MatchUpdated` already fires on state transitions; the map just gains richer values.
+| ID | Action | Detail in |
+|---|---|---|
+| REV-2 | Give every derived field a rebuild path and a staleness check — re-derive `drv_result`, build score reconciliation as a drv-vs-recomputed diff; amend ADR-010 with both invariants. | review §6 |
+| REV-3 | Emit `AFL.MatchUpdated(partial)` on final→partial reversal so FFL doesn't keep believing the match is final. | review §6 |
+| REV-4 | Finish ADR-017: add the missing DataLoaders, convert direct resolver lookups, batch the federation entity resolvers. Collapses the worst N+1s. | review §5 |
+| REV-5 | Reconcile the contradicting ADRs: retire ADR-008 properly; fix ADR-004's no-callback rule + stale facts; align ACL table naming across ADR-016/decisions.md/cookbook. | review §1 |
+| REV-6 | Wire `MapPgError` (or delete it and amend ADR-009) — kills the raw-pgx-error leak. | review §3 |
+| REV-7 | Fix test-tier violations: tag the Typesense container test; rewrite the pg dispatcher test hermetically; add search + shared to `just test-all`. | review §7 |
+| REV-8 | Documentation truth pass: domain.md match-style fiction + `named` status; cookbook, testing.md, repo-map.md, frontend.md staleness. | review §2 |
+| REV-9 | Frontend structural pass: settle the cross-feature import rule; split `TeamBuilderView.vue`; introduce fragments; scope Team Builder/Squad queries. | review §4 |
+| REV-10 | Backup/restore parity guard: dump schema alongside data backups or diff live schema against init SQL. | review §3 |
 
 ---
 
-## CQRS player stats read model
+## Platform & Other
 
-Move AFL player stats reads from GraphQL/PostgreSQL to the search index as query volume grows (ADR-013). SquadView and other stat-heavy pages would query the index instead of the DB. Defer until query performance is actually a problem.
+### Player availability
 
----
+Track AFL injury and suspension data per player season, and enforce availability at FFL team submission.
 
-## Other Ideas
+- Add availability columns to `afl.player_season`: `availability TEXT`, `available_from_round_id INTEGER`, `availability_note TEXT`
+- Update init SQL and test-e2e init SQL; apply via `ALTER TABLE` to live DB per migration strategy in cookbook
+- Import pipeline: pull AFL injury/suspension list; populate availability fields
+- FFL team submission validation: reject naming an unavailable player
+- UX: show availability status on free agents page (PAGE-4) and player season view (PAGE-1)
+
+### Deployment
+
+- CI-ready (GitHub Actions or similar)
+- ADR — consider deployment options (AWS, GCP, etc.)
+
+### Search UI
+
+Full-text search view with filters (source, type), backed by Typesense as-is. (Index enrichment
+for stats/aggregates and the ADR-015 Typesense-vs-ClickHouse question are covered by STATS-1.)
+
+### Other
 
 - **Live AFL data source** — afltables may serve for weekly reconciliation once historical load is complete, but a real-time feed would unlock live in-progress scoring
 - **Mobile app**
 - **Backup remote destination** — rclone supports S3, GCS, B2 with a single consistent interface; decide when deployment target is clearer
-
----
-
-## Revisit
-
-### GraphQL traversal shortcuts
-
-Fields like `FFLPlayerMatch.player` let callers skip `playerSeason → player`; `FFLPlayerMatch.playerSeasonId` is a bare FK when the object is already reachable. Audit all types in `query.graphqls` for relations that duplicate an existing traversal, then decide whether to remove the shortcut or keep it as a convenience alias.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -4,17 +4,6 @@
 
 Full stack rebuild (backend + frontend). Gateway introduced early so frontends always connect through it. All frontend phases require Playwright tests. See `plans/history.md` for completed phases 1–21.
 
-## Phase 22: Real Data Load & Seed Cleanup
-
-**Goal:** Replace synthetic seed data with real 2026 AFL and FFL data, and slim the dev seed to a lean scaffold.
-
-- [ ] Import all 2026 AFL rounds played to date (teams, players, match stats) via existing import tooling
-- [ ] Import all 2026 FFL round teams to date
-- [ ] Verify ladder calculation produces correct standings
-- [ ] Smoke-test team submission and substitution flows against real data; capture edge cases
-- [ ] Reduce `dev/seed` to a single representative round (enough for demo and future dev)
-- [ ] Confirm e2e tests pass against slim seed
-
 ## Phase 23: UX — Player Intelligence
 
 **Goal:** Richer player and club context for FFL decision-making. Candidate areas from `plans/ideas.md`: player season pages, free agents, club pages, Team Builder analytics, notes in the match view, score reconciliation. Scope confirmed at sprint start.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -1,24 +1,14 @@
 # Roadmap
 
-## Context
+Committed phases — active and next. Completed phases 1–21 are in `plans/history.md`.
 
-Full stack rebuild (backend + frontend). Gateway introduced early so frontends always connect through it. All frontend phases require Playwright tests. See `plans/history.md` for completed phases 1–21.
+---
 
 ## Phase 23: UX — Player Intelligence
 
 **Goal:** Richer player and club context for FFL decision-making. Candidate areas from `plans/ideas.md`: player season pages, free agents, club pages, Team Builder analytics, notes in the match view, score reconciliation. Scope confirmed at sprint start.
 
-## Phase 24: AFL Player Availability
-
-**Goal:** Track AFL injury and suspension data per player season, and enforce availability at FFL team submission.
-
-- [ ] Add availability columns to `afl.player_season`: `availability TEXT`, `available_from_round_id INTEGER`, `availability_note TEXT`
-- [ ] Update init SQL and test-e2e init SQL; apply via `ALTER TABLE` to live DB per migration strategy in cookbook
-- [ ] Import pipeline: pull AFL injury/suspension list; populate availability fields
-- [ ] FFL team submission validation: reject naming an unavailable player
-- [ ] UX: show availability status on free agents page (PAGE-4) and player season view (PAGE-1)
-
-## Phase 25: Data Management — Data Setup & Historical Import
+## Phase 24: Data Management — Data Setup & Historical Import
 
 **Goal:** Season setup tooling and one-time historical backfill — the operations needed once per season (or once ever) rather than every round.
 
@@ -28,22 +18,12 @@ Full stack rebuild (backend + frontend). Gateway introduced early so frontends a
 - [ ] Pluggable FFL scoring formula — strategy pattern keyed by season; `ScoringStrategy` interface + concrete implementations covering known formula variants; `ffl.season.scoring_strategy` column; wire into score calculation use case (deferred from Phase 20)
 - [ ] FFL historical team backfill — one-time CLI using `ForumPostParser` + `ImportRoundTeams` over historical forum data (requires pluggable scoring formula above)
 
-## Phase 26: Search Frontend + Index Enrichment
+## Phase 25: Event Reliability (REV-1)
 
-**Goal:** Search UI backed by an enriched index. Starts with a required ADR review — the technology decision must be made before building anything.
+**Goal:** Event processing fails loudly and recoverably — remove the silent-permanent-death mode found by the 2026-07 review (`doc/review-findings.md` §6, the one `critical` finding).
 
-- [ ] **Decision gate:** revisit ADR-015 — Typesense (text search strength) vs ClickHouse (aggregation-heavy analytics); probe trade-offs and amend or supersede ADR-015 before committing to either implementation
-- [ ] Search view — full-text search with filters (source, type)
-- [ ] Expand search index to support UX data requirements (player stats, aggregates, etc.)
-- [ ] Playwright tests
-
-## Phase 27: Deployment
-
-- [ ] CI-ready (GitHub Actions or similar)
-- [ ] ADR — Consider deployment options (AWS, GCP, etc.)
-
----
-
-## Future Ideas & Parked Designs
-
-See `plans/ideas.md`.
+- [ ] `shared/events/pg`: `Listen` reconnects with backoff on error (or the service exits fatally) — never log-and-die silently
+- [ ] Re-`LISTEN` on the new connection after reconnect; log recovery at warn level
+- [ ] Publish failures escalate beyond a debug/warn line (error log at minimum, visible in service output)
+- [ ] Verify FFL and Search listener goroutines (`ffl/cmd/main.go`, `search/cmd/main.go`) surface listener death — no warn-and-continue
+- [ ] Integration test: kill the listener connection mid-run; assert events resume after reconnect

--- a/plans/stats-analytics.md
+++ b/plans/stats-analytics.md
@@ -1,0 +1,248 @@
+# Stats & Analytics — Design (STATS-1)
+
+**Status:** idea / design — not yet scheduled.
+**Supersedes:** the old roadmap Phase 26 decision gate (revisit ADR-015: Typesense vs ClickHouse) and the former "CQRS player stats read model" idea (move stat reads to the search index) — both resolved by this design.
+**Depends on:** Phase 25 (historical import) for the 20-year dataset; useful before it with the ~3 seasons already loaded.
+
+**Question:** with 20 years of AFL + FFL history loaded, what is the best solution for records ("best ever FFL score", "most hitouts in a match"), longitudinal history ("total games, draws, average winning margin"), interesting quirks, and graphs?
+
+**Short answer:** not a search index. Build a small **Stats read model in Postgres** (a `stats` schema of denormalised fact tables + precomputed record tables, rebuilt idempotently), exposed as a **Stats GraphQL subgraph** that federates onto the existing entities, charted in the frontend with **ECharts**, with **Metabase pointed at the same schema** for owner-side quirk-hunting. Keep Typesense strictly for text search. Defer ClickHouse indefinitely — the data will never be big enough to need it.
+
+---
+
+## 1. What "statistical digging" actually decomposes into
+
+Four distinct query shapes, and they want different machinery:
+
+| Shape | Examples | What it needs |
+|---|---|---|
+| **Records / leaderboards** | Best ever FFL score, most hitouts in a match, highest losing score | Top-N over a fact table, filterable by scope (all-time / season / club / player / era) |
+| **Longitudinal aggregates** | Total games, draws, avg winning margin, win % by club by decade, head-to-head | GROUP BY + joins across match/club/season dimensions |
+| **Quirks / exploration** | Longest streaks, biggest comebacks, "won every stat but lost", closest ladder finishes | Window functions (`LAG`, `RANK`, running sums), ad-hoc SQL, a human at a query console |
+| **Graphs / time series** | Player form curves, club score history, ladder position over rounds, score distributions | Ordered series endpoints; percentile/histogram aggregates |
+
+The third row is the tell: **streaks, deltas, and rankings are window-function territory**. No search engine does window functions. Whatever serves rows 1, 2 and 4 to the product UI, row 3 needs a SQL surface for the human doing the digging.
+
+## 2. Scale reality check (this decides everything)
+
+Dev DB at 2026-07 holds ~3 seasons: 26,496 `afl.player_match` rows, 639 matches. Extrapolating:
+
+| Dataset | 20 years, est. rows |
+|---|---|
+| `afl.player_match` (the big one) | ~180–250k |
+| `afl.match` / `club_match` | ~4.5k / ~9k |
+| `ffl.player_match` | ~90–120k |
+| **Total fact rows** | **< 500k** |
+
+Half a million rows is not analytics scale — it is **smaller than the test datasets used to benchmark OLAP engines**. Postgres aggregates this in milliseconds with ordinary indexes; a full sequential scan of the entire fact set is single-digit milliseconds on any laptop. Every architectural decision below follows from this number: the problem is **modelling and API design**, not query horsepower.
+
+## 3. Why the search index is the wrong primary tool
+
+Typesense (and search engines generally) are document-retrieval engines: tokenise → match → rank. What they offer beyond that is facet counts and basic per-facet min/max/avg. They do not do:
+
+- joins (player → match → opponent → era),
+- window functions (streaks, running totals, rank-within-group),
+- arbitrary GROUP BY with HAVING,
+- percentiles/histograms for distributions,
+- point-in-time correctness ("only final matches count").
+
+You *can* index one document per player-match and get "top 10 by hitouts" via sort — but that's the only row of the table in §1 it covers, and you'd be maintaining a second copy of the data to get a worse version of `ORDER BY hitouts DESC LIMIT 10`. ADR-013's framing ("Typesense remains the read model for aggregated reads — season averages, rankings, top scorers") drew this boundary too generously, and notably the codebase has already quietly corrected it in practice: season averages and medians shipped as SQL (`AFLPlayerSeason.stats` backed by `PlayerSeasonStatsRepository`), not as Typesense queries. This design just makes that correction official.
+
+**Typesense keeps its real job:** typeahead and full-text search ("find the player named Horne-something"), returning IDs into the graph. That part of ADR-015 stands.
+
+## 4. Industry practice, mapped to this repo
+
+The standard pattern at every scale is **separate the operational plane from the analytical plane**:
+
+1. **Operational stores** stay normalised and serve transactions (the `afl.*`, `ffl.*` schemas).
+2. An **analytical read model** is derived from them — denormalised, rebuildable, optimised for reads. At warehouse scale this is ELT into Snowflake/BigQuery/ClickHouse with dbt; at this scale it is Fowler's *Reporting Database* pattern: a schema of derived tables in the same Postgres.
+3. A **semantic layer** names the metrics (what exactly is "winning margin"?) so every consumer — UI, BI tool, future LLM query planner — computes them the same way. At enterprise scale that's dbt metrics/Cube; here it's a well-documented view layer.
+4. **BI tooling for exploration** (Metabase/Superset) sits on the read model for the humans; the product UI gets a purpose-built API.
+
+This is also exactly CQRS applied at the data layer, which ADR-013 already endorses ("preserve the CQRS split for aggregated reads") — the only change is *what implements the read side*.
+
+### Options assessed
+
+| Option | Verdict | Why |
+|---|---|---|
+| **Postgres read model** (`stats` schema, derived tables/matviews) | ✅ **Recommended** | Full SQL power (windows, percentiles, joins); zero new infrastructure; fits the repo's existing "recalculate from scratch, idempotent" philosophy; trivially handles 100× the projected data |
+| **Typesense as analytics store** | ❌ Reject for aggregates | §3. Keep for text search only |
+| **ClickHouse** | ❌ Defer indefinitely | Columnar OLAP earns its ops cost from ~50–100M rows and high-cardinality scans. At 500k rows it is strictly slower to operate and no faster to query |
+| **DuckDB** | 🟡 Optional side-tool | Superb for ad-hoc exploration (`ATTACH` the Postgres DB or query a parquet export directly, no server). Worth having in the toolbox for quirk-hunting sessions; not needed in the serving path |
+| **Metabase (or Superset)** | ✅ Recommended for exploration | Point it read-only at the `stats` schema: instant ad-hoc charts, saved "quirk" questions, zero code. Most quirks are *found* interactively, then the good ones get promoted into the product. See Milestone 1 |
+| **Cube.dev / dbt semantic layer** | ❌ Overkill | The metric registry can be a documented SQL view layer + GraphQL enum at this scale |
+
+## 5. Recommended architecture
+
+### 5.1 A Stats bounded context
+
+Create a **Stats context** (a fourth service, or initially a module — see §8) that owns a `stats` schema. It is a *derived, disposable* read model: every table can be dropped and rebuilt from the operational schemas at any time. That property is what keeps it architecturally cheap — no migrations discipline, no backup obligation, no consistency ceremony beyond "rebuild".
+
+**Cross-schema access needs an ADR.** ADR-003 forbids cross-schema access *between operational services*. The industry-standard carve-out is that the analytics plane reads the operational plane read-only (warehouses read replicas/CDC feeds, not service APIs). Recommend a new ADR permitting the Stats context **read-only SELECT on `afl.*` and `ffl.*`** (enforced with a dedicated PG role), on the grounds that: it writes only to `stats.*`; it can never influence operational behaviour; and the alternative — refetching 300k rows through GraphQL like the search reindex does — is ceremony without benefit. (If purity is preferred, the API-fetch route works at this scale; it's just slower and more code. The ADR should record the choice either way.)
+
+### 5.2 The read model itself
+
+Wide, denormalised fact tables — one row per grain, names resolved, no joins needed at query time ("one big table" is legitimate best practice at this scale):
+
+```sql
+CREATE SCHEMA stats;
+
+-- Grain: one AFL player-match. ~250k rows.
+CREATE TABLE stats.afl_player_match (
+    afl_player_match_id INT PRIMARY KEY,
+    player_id INT, player_name TEXT,
+    club_id INT, club_name TEXT,
+    opponent_club_id INT, opponent_name TEXT,
+    season_id INT, season_name TEXT, round_id INT, round_name TEXT, round_seq INT,
+    match_id INT, venue TEXT, start_dt TIMESTAMPTZ,
+    kicks INT, handballs INT, disposals INT, marks INT, hitouts INT,
+    tackles INT, goals INT, behinds INT, score INT,
+    club_score INT, opponent_score INT, margin INT, result TEXT,  -- from the player's perspective
+    match_final BOOL                                              -- correctness gate, see §6
+);
+
+-- Grain: one FFL player-match (fantasy score + position + activation status + era).
+CREATE TABLE stats.ffl_player_match ( ... , scoring_era TEXT, ... );
+
+-- Grain: one match (both codes). Margins, totals, results, streak inputs.
+CREATE TABLE stats.match ( ... );
+
+-- Precomputed records: the "Records" page reads this table directly.
+CREATE TABLE stats.record (
+    record_key TEXT,          -- e.g. 'ffl_highest_club_score', 'afl_most_hitouts_match'
+    scope TEXT,               -- 'all_time' | 'season:<id>' | 'club:<id>'
+    rank INT,                 -- keep top 10, not just #1 — ties and "previous record" for free
+    value NUMERIC,
+    holder_label TEXT, holder_entity TEXT, holder_id INT,
+    match_id INT, season_name TEXT, achieved_on DATE,
+    PRIMARY KEY (record_key, scope, rank)
+);
+```
+
+On top: a **metric view layer** (`stats.v_club_season_summary`, `stats.v_head_to_head`, `stats.v_player_career`) that is the single place each metric is defined. `doc/useful.sql` is the embryo of this — promote its queries into versioned views instead of a scratch file.
+
+### 5.3 Refresh strategy
+
+Consistent with the repo's existing philosophy (ladders: "entire season recalculated from scratch — simpler and drift-free"):
+
+- **Full rebuild** is the primitive: one idempotent job repopulates all of `stats.*` from the operational schemas. At 500k rows this is seconds. Expose as `just stats-rebuild` + a mutation.
+- **Event-driven incremental**: subscribe (like the search service does) to `AFL.MatchUpdated(final)` and `FFL.MatchScoreFinalized` and rebuild the affected season slice. Because a lost event only means *stale stats until the next full rebuild*, the at-most-once delivery findings from the codebase review (`doc/review-findings.md` §6) are acceptable here — schedule a nightly full rebuild as the backstop and the staleness window is bounded. This is the correct consistency budget for analytics.
+- Historical data (Phase 25 imports) needs no special path: it lands in `afl.*`/`ffl.*`, next rebuild picks it up.
+
+### 5.4 API: a Stats GraphQL subgraph
+
+Stats joins the federated graph — this is the architecturally elegant payoff of ADR-013:
+
+```graphql
+type Query {
+  statsLeaderboard(metric: StatMetric!, grain: StatGrain!,   # e.g. FFL_SCORE × PLAYER_MATCH
+                   scope: StatScopeInput, first: Int, after: String): LeaderboardConnection!
+  statsRecords(category: RecordCategory, scope: StatScopeInput): [StatRecord!]!
+  statsTimeseries(subject: TimeseriesSubjectInput!, metric: StatMetric!): [TimeseriesPoint!]!
+  statsHeadToHead(clubA: ID!, clubB: ID!): HeadToHead!
+}
+
+# Federation: stats attach where users already are
+type AFLPlayer @key(fields: "id") {
+  id: ID! @external
+  careerTotals: AFLCareerTotals!
+  records: [StatRecord!]!
+}
+type FFLClub @key(fields: "id") { historySummary: ClubHistory! }  # total games, draws, avg margin…
+```
+
+Rules that carry over: metrics as **enums** (this *is* the semantic layer at the API boundary — one name per metric, defined once in the view layer); cursor Connections per ADR-014 for leaderboards; entity resolvers batched from day one (don't repeat the ADR-017 drift). This design also lands the ADR-015 "LLM query planner" vision cleanly: the planner populates `{metric, grain, scope}` against a closed vocabulary — far more tractable than generating SQL or search-engine queries.
+
+### 5.5 Graphs
+
+- **Product UI:** [Apache ECharts](https://echarts.apache.org/) via `vue-echarts` — the battle-tested Vue pairing; handles time series, distributions, heatmaps (the frontend already has a heatmap idiom to preserve), brush/zoom for 20-year series. Lighter alternative if only sparklines/bars materialise: Observable Plot or hand-rolled SVG. One ADR-011-style addition, added when the first chart ships.
+- **Server sends series, client renders.** The `statsTimeseries` field returns ordered points; no client-side aggregation of raw facts. 20 years of per-round points for one player is ~500 points — no downsampling needed.
+- **Exploration:** Metabase (Milestone 1 below). Promote discoveries into `stats.record` keys or curated views; the product's "Quirks" page can literally be a table of curated query results refreshed by the rebuild job.
+
+## 6. Correctness concerns specific to this domain
+
+These bite harder than any engine choice:
+
+1. **Finality filtering.** Records must only be set by `data_status = final` matches (both axes for FFL). Bake it in structurally: the rebuild only ingests final matches, or every fact row carries `match_final` and every view filters on it. Never let a provisional 180-point score into "best ever".
+2. **Era-dependent FFL scoring.** Phase 25 already plans a pluggable `ScoringStrategy` per season (e.g. star excluded hitouts from 2026). Two consequences: (a) historical FFL scores must be **stored as facts computed under their era's formula**, never recomputed with the current one; (b) every FFL fact row carries `scoring_era`, and cross-era leaderboards must either display the era or be segmented by it. "Most FFL hitout points ever" is a different question before and after a rule change — the model has to make that visible, not paper over it.
+3. **AFL era context.** 20 years spans real-world rule/era changes (game length, interchange rules). Cheap insurance: a `stats.era` dimension keyed by season range, so views *can* segment even if v1 doesn't.
+4. **Lineage.** Historical imports come from a different source (afltables CSV) than live rounds (FootyWire). Carry `source` on fact rows — when a record looks suspicious, the first question is always "which import produced this row".
+5. **Identity over 20 years.** Player identity resolution across two decades (name changes, duplicates from fuzzy import matching) is the biggest data-quality risk in the whole plan. A `stats.v_data_quality` view (players with implausible gaps, duplicate name+DOB candidates, matches whose player scores don't sum to club score) should be part of the rebuild from day one — it will pay for itself during the Phase 25 backfill.
+
+## 7. Data flow (end to end)
+
+```
+ afltables CSV (historical, once)   FootyWire (weekly)      Forum posts (weekly)
+        │                                │                        │
+        └── Phase 25 import CLIs ──► afl.* ◄─ Data Ops UI    ffl.* ◄─ Data Ops UI
+                                        │                        │
+                                        │   (read-only role, per new ADR)
+                                        ▼                        ▼
+                              ┌──────────────────────────────────────┐
+                              │  Stats rebuild job                   │
+                              │  full rebuild (nightly/manual)       │
+                              │  + event-triggered season slices     │
+                              └──────────────┬───────────────────────┘
+                                             ▼
+                                       stats.* schema
+                                 (facts · views · records)
+                                   │                  │
+                     Stats GraphQL subgraph      Metabase (read-only)
+                       (federated, :8083)          owner exploration
+                                   │
+                            Apollo Router
+                                   │
+                        Vue frontend + ECharts
+                 (Records page · History pages · charts)
+```
+
+Typesense stays exactly where it is: text search in, entity IDs out — a sibling of this flow, not part of it.
+
+## 8. Milestones
+
+### Milestone 1 — Metabase exploration (cheap, do-now candidate)
+
+Run Metabase OSS locally — free, self-hosted, fully offline — over a first cut of the `stats` schema (views over the ~3 seasons already loaded). Validates the metric definitions and answers quirk questions *before* any service is built. Product UI is out of scope.
+
+**Decisions made:**
+- **Edition:** Metabase Open Source (AGPL). No account, no license, no cloud. Anonymous telemetry disabled via `MB_ANON_TRACKING_ENABLED=false`.
+- **Runtime:** Docker container alongside the dev stack in `dev/docker-compose.yml`. Port **3030** on the host (3000 clashes with Vite).
+- **App data:** Metabase's own H2 file on a named volume (`metabasedata`). Single user — deleting the volume removes all trace.
+- **DB access:** a dedicated **read-only role** (`stats_reader`), `SELECT` only, scoped to the `stats` schema. Metabase never sees `afl.*`/`ffl.*` directly.
+- **Connectivity:** same compose network as `xffl-postgres`, connect via service name (or `host.docker.internal:5432`, the Apollo Router pattern).
+
+⚠️ New infra dependency → needs an ADR line before it lands (rule 5 in CLAUDE.md) — fold into the stats-phase ADR, or a small standalone ADR if this milestone runs earlier.
+
+**Tasks:**
+- [ ] ADR coverage for Metabase as dev-stack infra
+- [ ] Create `stats` schema and promote the first queries from `doc/useful.sql` into versioned views (e.g. `stats.v_club_season_summary`, `stats.v_head_to_head`) — SQL lives in `dev/postgres/init/`
+- [ ] Create `stats_reader` role: `LOGIN`, `SELECT` on schema `stats` only; add to init SQL
+- [ ] Add `metabase` service to `dev/docker-compose.yml` (image `metabase/metabase`, port 3030, `metabasedata` volume, telemetry off)
+- [ ] First-run setup: local admin user; add Postgres connection using `stats_reader`
+- [ ] Update docs: `just dev-up` output line + CLAUDE.md common-commands note (":3030 Metabase")
+- [ ] Seed a few saved questions to prove the loop: highest FFL club score, biggest AFL winning margin, head-to-head grid
+- [ ] Capture any metric-definition corrections back into the `stats` views (they become the semantic layer the subgraph reuses)
+
+**Non-goals:** no embedding of Metabase charts in the Vue app (product charts come later via ECharts); no write access; no Metabase-side scheduled jobs.
+
+### Milestone 2 — with Phase 25 (historical import)
+
+Add the data-quality views (§6.5) and `source`/era columns as import lands. Import order: AFL history → FFL history (needs era scoring strategies first, as Phase 25 already sequences).
+
+### Milestone 3 — the Stats subgraph (a future roadmap phase)
+
+Resolve the old ADR-015 question as *"Typesense retained for text search only; analytics = Postgres stats read model; ClickHouse rejected at this scale"* — a revision to ADR-013's aggregated-reads boundary and ADR-015's scope, plus the new cross-schema-analytics ADR (§5.1). Build the Stats subgraph + rebuild job. Start it as a module inside an existing service only if a fourth service feels heavy — but the schema boundary (`stats.*`) and the read-only role are non-negotiable from day one, so extraction later is mechanical.
+
+### Milestone 4 — product surfaces
+
+Records page, club history pages, player career charts in the frontend; ECharts enters via a one-line ADR-011 amendment.
+
+## 9. Triggers to revisit
+
+Move to a columnar engine (DuckDB first, ClickHouse only with real ops appetite) only if one of these becomes true:
+
+- fact grain drops below player-match (e.g. per-possession/event data → tens of millions of rows),
+- interactive queries need sub-second scans over >20M rows,
+- the rebuild job exceeds minutes and incremental complexity stops being worth it.
+
+None are plausible for 20 years of AFL/FFL at player-match grain. The `stats.*` schema + GraphQL boundary means the engine swap, if ever needed, is a contained infrastructure change — the same argument ADR-015 already makes for search.

--- a/services/afl/api/graphql/query.graphqls
+++ b/services/afl/api/graphql/query.graphqls
@@ -92,11 +92,10 @@ type AFLPlayer @key(fields: "id") {
 
 """
 Aggregation method to apply over a set of matches.
-Only MEAN is implemented; additional methods (MEDIAN, STDDEV, …) can be added
-without a schema change.
 """
 enum AFLStatSummaryMethod {
   MEAN
+  MEDIAN
 }
 
 """

--- a/services/afl/api/graphql/query.graphqls
+++ b/services/afl/api/graphql/query.graphqls
@@ -8,6 +8,7 @@ type Query {
   aflClub(id: ID!): AFLClub!
 
   aflPlayerSeason(id: ID!): AFLPlayerSeason
+  aflClubSeason(id: ID!): AFLClubSeason
 
   aflLiveRound: AFLLiveRound
   aflPlayerSearch(query: String!): [AFLPlayer!]!
@@ -71,6 +72,7 @@ type AFLClubSeason {
   against: Int!
   percentage: Float!
   premiershipPoints: Int!
+  playerSeasons: [AFLPlayerSeason!]!
 }
 
 type AFLClubMatch {

--- a/services/afl/gqlgen.yml
+++ b/services/afl/gqlgen.yml
@@ -52,6 +52,8 @@ models:
     fields:
       season:
         resolver: true
+      playerSeasons:
+        resolver: true
   AFLClubMatch:
     fields:
       playerMatches:

--- a/services/afl/internal/application/queries.go
+++ b/services/afl/internal/application/queries.go
@@ -169,6 +169,10 @@ func (q *Queries) GetPlayerSeasonsByIDs(ctx context.Context, ids []int) (map[int
 	return q.playerSeasons.FindByIDs(ctx, ids)
 }
 
+func (q *Queries) GetPlayerSeasonsByClubSeasonID(ctx context.Context, clubSeasonID int) ([]domain.PlayerSeasonWithPlayer, error) {
+	return q.playerSeasons.FindByClubSeasonIDWithPlayer(ctx, clubSeasonID)
+}
+
 func (q *Queries) GetPlayerSeasonIDsBySeasonID(ctx context.Context, seasonID int, nameQuery *string) ([]int, error) {
 	return q.playerSeasons.FindIDsBySeasonID(ctx, seasonID, nameQuery)
 }

--- a/services/afl/internal/domain/player_season_stats.go
+++ b/services/afl/internal/domain/player_season_stats.go
@@ -14,12 +14,22 @@ type PlayerSeasonStats struct {
 	Games          int
 }
 
+// StatMethod controls how per-stat values are aggregated across matches.
+// The zero value (StatMethodMean) is the default and requires no explicit initialisation.
+type StatMethod uint8
+
+const (
+	StatMethodMean   StatMethod = iota // arithmetic mean — default zero value
+	StatMethodMedian                   // 50th-percentile (PERCENTILE_CONT)
+)
+
 // PlayerSeasonStatsParams controls which matches are included in the aggregation.
 // UpToRoundID and LastN are both optional and may be combined.
 type PlayerSeasonStatsParams struct {
 	PlayerSeasonIDs []int
-	UpToRoundID     *int // only final matches before the earliest start_dt in this round
-	LastN           *int // restrict to the most recent N qualifying matches
+	UpToRoundID     *int       // only final matches before the earliest start_dt in this round
+	LastN           *int       // restrict to the most recent N qualifying matches
+	Method          StatMethod // aggregation method; defaults to StatMethodMean
 }
 
 // PlayerSeasonStatsRepository is a read-only repository for aggregated player stats queries.

--- a/services/afl/internal/infrastructure/postgres/stats_repository.go
+++ b/services/afl/internal/infrastructure/postgres/stats_repository.go
@@ -17,13 +17,19 @@ func NewPlayerSeasonStatsRepository(pool *pgxpool.Pool) *PlayerSeasonStatsReposi
 	return &PlayerSeasonStatsRepository{pool: pool}
 }
 
-// getSeasonStatsMean aggregates stats for each player_season across final matches.
-// Both upToRoundId ($2) and lastN ($3) are optional (pass nil to omit).
-// upToRoundId filters to matches whose start_dt is before the earliest match in that round,
-// using start_dt ordering rather than round ID ordering so IDs remain opaque.
-// lastN is applied after the round filter, keeping only the most recent N matches per player.
-const getSeasonStatsMean = `
-WITH qualified AS (
+// playerSeasonStatsSQL builds the full query for aggregating player-season stats.
+//
+// Parameters passed to the query:
+//
+//	$1 int[]  — player_season_id list
+//	$2 int    — upToRoundID (NULL = no filter); restricts to final matches whose
+//	            start_dt is before the earliest start_dt in the given round, so
+//	            IDs remain opaque to callers
+//	$3 int    — lastN (NULL = no filter); keeps only the most recent N matches
+//	            per player after the round filter is applied
+func playerSeasonStatsSQL(method domain.StatMethod) string {
+	const cte = `
+WITH ranked AS (
   SELECT pm.player_season_id,
          pm.goals, pm.kicks, pm.handballs, pm.marks, pm.tackles, pm.hitouts,
          ROW_NUMBER() OVER (PARTITION BY pm.player_season_id ORDER BY m.start_dt DESC) AS rn
@@ -39,26 +45,47 @@ WITH qualified AS (
       WHERE m2.round_id = $2::int AND m2.deleted_at IS NULL
     ))
 )
+`
+	const meanSelect = `
 SELECT
   player_season_id,
   COUNT(*)::int          AS games,
-  AVG(goals)::float8     AS avg_goals,
-  AVG(kicks)::float8     AS avg_kicks,
-  AVG(handballs)::float8 AS avg_handballs,
-  AVG(marks)::float8     AS avg_marks,
-  AVG(tackles)::float8   AS avg_tackles,
-  AVG(hitouts)::float8   AS avg_hitouts
-FROM qualified
+  AVG(goals)::float8     AS goals,
+  AVG(kicks)::float8     AS kicks,
+  AVG(handballs)::float8 AS handballs,
+  AVG(marks)::float8     AS marks,
+  AVG(tackles)::float8   AS tackles,
+  AVG(hitouts)::float8   AS hitouts
+FROM ranked
 WHERE $3::int IS NULL OR rn <= $3::int
 GROUP BY player_season_id
 `
+	const medianSelect = `
+SELECT
+  player_season_id,
+  COUNT(*)::int AS games,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY goals)::float8     AS goals,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY kicks)::float8     AS kicks,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY handballs)::float8 AS handballs,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY marks)::float8     AS marks,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tackles)::float8   AS tackles,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY hitouts)::float8   AS hitouts
+FROM ranked
+WHERE $3::int IS NULL OR rn <= $3::int
+GROUP BY player_season_id
+`
+	if method == domain.StatMethodMedian {
+		return cte + medianSelect
+	}
+	return cte + meanSelect
+}
 
 func (r *PlayerSeasonStatsRepository) GetSeasonStats(ctx context.Context, params domain.PlayerSeasonStatsParams) ([]domain.PlayerSeasonStats, error) {
 	int32IDs := make([]int32, len(params.PlayerSeasonIDs))
 	for i, id := range params.PlayerSeasonIDs {
 		int32IDs[i] = int32(id)
 	}
-	rows, err := r.pool.Query(ctx, getSeasonStatsMean, int32IDs, params.UpToRoundID, params.LastN)
+	rows, err := r.pool.Query(ctx, playerSeasonStatsSQL(params.Method), int32IDs, params.UpToRoundID, params.LastN)
 	if err != nil {
 		return nil, fmt.Errorf("get season stats: %w", err)
 	}

--- a/services/afl/internal/interface/graphql/generated.go
+++ b/services/afl/internal/interface/graphql/generated.go
@@ -1400,11 +1400,10 @@ type AFLPlayer @key(fields: "id") {
 
 """
 Aggregation method to apply over a set of matches.
-Only MEAN is implemented; additional methods (MEDIAN, STDDEV, …) can be added
-without a schema change.
 """
 enum AFLStatSummaryMethod {
   MEAN
+  MEDIAN
 }
 
 """

--- a/services/afl/internal/interface/graphql/generated.go
+++ b/services/afl/internal/interface/graphql/generated.go
@@ -73,6 +73,7 @@ type ComplexityRoot struct {
 		Lost              func(childComplexity int) int
 		Percentage        func(childComplexity int) int
 		Played            func(childComplexity int) int
+		PlayerSeasons     func(childComplexity int) int
 		PremiershipPoints func(childComplexity int) int
 		Season            func(childComplexity int) int
 		Won               func(childComplexity int) int
@@ -193,6 +194,7 @@ type ComplexityRoot struct {
 
 	Query struct {
 		AflClub            func(childComplexity int, id string) int
+		AflClubSeason      func(childComplexity int, id string) int
 		AflClubs           func(childComplexity int) int
 		AflLiveRound       func(childComplexity int) int
 		AflMatch           func(childComplexity int, id string) int
@@ -229,6 +231,8 @@ type AFLClubMatchResolver interface {
 }
 type AFLClubSeasonResolver interface {
 	Season(ctx context.Context, obj *AFLClubSeason) (*AFLSeason, error)
+
+	PlayerSeasons(ctx context.Context, obj *AFLClubSeason) ([]*AFLPlayerSeason, error)
 }
 type AFLMatchResolver interface {
 	Round(ctx context.Context, obj *AFLMatch) (*AFLRound, error)
@@ -278,6 +282,7 @@ type QueryResolver interface {
 	AflClubs(ctx context.Context) ([]*AFLClub, error)
 	AflClub(ctx context.Context, id string) (*AFLClub, error)
 	AflPlayerSeason(ctx context.Context, id string) (*AFLPlayerSeason, error)
+	AflClubSeason(ctx context.Context, id string) (*AFLClubSeason, error)
 	AflLiveRound(ctx context.Context) (*AFLLiveRound, error)
 	AflPlayerSearch(ctx context.Context, query string) ([]*AFLPlayer, error)
 }
@@ -419,6 +424,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.AFLClubSeason.Played(childComplexity), true
+	case "AFLClubSeason.playerSeasons":
+		if e.ComplexityRoot.AFLClubSeason.PlayerSeasons == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLClubSeason.PlayerSeasons(childComplexity), true
 	case "AFLClubSeason.premiershipPoints":
 		if e.ComplexityRoot.AFLClubSeason.PremiershipPoints == nil {
 			break
@@ -976,6 +987,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.AflClub(childComplexity, args["id"].(string)), true
+	case "Query.aflClubSeason":
+		if e.ComplexityRoot.Query.AflClubSeason == nil {
+			break
+		}
+
+		args, err := ec.field_Query_aflClubSeason_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.AflClubSeason(childComplexity, args["id"].(string)), true
 	case "Query.aflClubs":
 		if e.ComplexityRoot.Query.AflClubs == nil {
 			break
@@ -1316,6 +1338,7 @@ input ResolveAFLPlayerMatchInput {
   aflClub(id: ID!): AFLClub!
 
   aflPlayerSeason(id: ID!): AFLPlayerSeason
+  aflClubSeason(id: ID!): AFLClubSeason
 
   aflLiveRound: AFLLiveRound
   aflPlayerSearch(query: String!): [AFLPlayer!]!
@@ -1379,6 +1402,7 @@ type AFLClubSeason {
   against: Int!
   percentage: Float!
   premiershipPoints: Int!
+  playerSeasons: [AFLPlayerSeason!]!
 }
 
 type AFLClubMatch {
@@ -1741,6 +1765,17 @@ func (ec *executionContext) field_Query__entities_args(ctx context.Context, rawA
 		return nil, err
 	}
 	args["representations"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_aflClubSeason_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -2604,6 +2639,47 @@ func (ec *executionContext) fieldContext_AFLClubSeason_premiershipPoints(_ conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AFLClubSeason_playerSeasons(ctx context.Context, field graphql.CollectedField, obj *AFLClubSeason) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLClubSeason_playerSeasons,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.AFLClubSeason().PlayerSeasons(ctx, obj)
+		},
+		nil,
+		ec.marshalNAFLPlayerSeason2ᚕᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLPlayerSeasonᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLClubSeason_playerSeasons(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLClubSeason",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AFLPlayerSeason_id(ctx, field)
+			case "player":
+				return ec.fieldContext_AFLPlayerSeason_player(ctx, field)
+			case "clubSeason":
+				return ec.fieldContext_AFLPlayerSeason_clubSeason(ctx, field)
+			case "matches":
+				return ec.fieldContext_AFLPlayerSeason_matches(ctx, field)
+			case "stats":
+				return ec.fieldContext_AFLPlayerSeason_stats(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AFLPlayerSeason", field.Name)
 		},
 	}
 	return fc, nil
@@ -3631,6 +3707,8 @@ func (ec *executionContext) fieldContext_AFLPlayerSeason_clubSeason(_ context.Co
 				return ec.fieldContext_AFLClubSeason_percentage(ctx, field)
 			case "premiershipPoints":
 				return ec.fieldContext_AFLClubSeason_premiershipPoints(ctx, field)
+			case "playerSeasons":
+				return ec.fieldContext_AFLClubSeason_playerSeasons(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AFLClubSeason", field.Name)
 		},
@@ -4119,6 +4197,8 @@ func (ec *executionContext) fieldContext_AFLSeason_ladder(_ context.Context, fie
 				return ec.fieldContext_AFLClubSeason_percentage(ctx, field)
 			case "premiershipPoints":
 				return ec.fieldContext_AFLClubSeason_premiershipPoints(ctx, field)
+			case "playerSeasons":
+				return ec.fieldContext_AFLClubSeason_playerSeasons(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AFLClubSeason", field.Name)
 		},
@@ -5770,6 +5850,73 @@ func (ec *executionContext) fieldContext_Query_aflPlayerSeason(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_aflPlayerSeason_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_aflClubSeason(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_aflClubSeason,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().AflClubSeason(ctx, fc.Args["id"].(string))
+		},
+		nil,
+		ec.marshalOAFLClubSeason2ᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLClubSeason,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_aflClubSeason(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AFLClubSeason_id(ctx, field)
+			case "club":
+				return ec.fieldContext_AFLClubSeason_club(ctx, field)
+			case "season":
+				return ec.fieldContext_AFLClubSeason_season(ctx, field)
+			case "played":
+				return ec.fieldContext_AFLClubSeason_played(ctx, field)
+			case "won":
+				return ec.fieldContext_AFLClubSeason_won(ctx, field)
+			case "lost":
+				return ec.fieldContext_AFLClubSeason_lost(ctx, field)
+			case "drawn":
+				return ec.fieldContext_AFLClubSeason_drawn(ctx, field)
+			case "for":
+				return ec.fieldContext_AFLClubSeason_for(ctx, field)
+			case "against":
+				return ec.fieldContext_AFLClubSeason_against(ctx, field)
+			case "percentage":
+				return ec.fieldContext_AFLClubSeason_percentage(ctx, field)
+			case "premiershipPoints":
+				return ec.fieldContext_AFLClubSeason_premiershipPoints(ctx, field)
+			case "playerSeasons":
+				return ec.fieldContext_AFLClubSeason_playerSeasons(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AFLClubSeason", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_aflClubSeason_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -8435,6 +8582,42 @@ func (ec *executionContext) _AFLClubSeason(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "playerSeasons":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AFLClubSeason_playerSeasons(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -9953,6 +10136,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "aflClubSeason":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_aflClubSeason(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "aflLiveRound":
 			field := field
 
@@ -11329,6 +11531,13 @@ func (ec *executionContext) marshalOAFLClubMatch2ᚖxfflᚋservicesᚋaflᚋinte
 		return graphql.Null
 	}
 	return ec._AFLClubMatch(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOAFLClubSeason2ᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLClubSeason(ctx context.Context, sel ast.SelectionSet, v *AFLClubSeason) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AFLClubSeason(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOAFLLiveRound2ᚖxfflᚋservicesᚋaflᚋinternalᚋinterfaceᚋgraphqlᚐAFLLiveRound(ctx context.Context, sel ast.SelectionSet, v *AFLLiveRound) graphql.Marshaler {

--- a/services/afl/internal/interface/graphql/loaders.go
+++ b/services/afl/internal/interface/graphql/loaders.go
@@ -16,8 +16,9 @@ type loadersKey struct{}
 // the query params that determine which matches are included.
 type statsKey struct {
 	PlayerSeasonID int
-	UpToRoundID    int // 0 = no filter
-	LastN          int // 0 = no filter
+	UpToRoundID    int              // 0 = no filter
+	LastN          int              // 0 = no filter
+	Method         domain.StatMethod // zero value = StatMethodMean
 }
 
 type Loaders struct {
@@ -53,20 +54,23 @@ func NewLoaders(q *application.Queries) *Loaders {
 }
 
 // batchPlayerSeasonStats groups keys by their params, makes one SQL call per
-// unique (UpToRoundID, LastN) combination, and returns results positionally.
+// unique (UpToRoundID, LastN, Median) combination, and returns results positionally.
 // Returns nil (not an error) for players with no qualifying matches.
 func batchPlayerSeasonStats(ctx context.Context, keys []statsKey, q *application.Queries) ([]*domain.PlayerSeasonStats, []error) {
-	type paramGroup struct{ upTo, lastN int }
+	type paramGroup struct {
+		upTo, lastN int
+		method      domain.StatMethod
+	}
 
 	groups := make(map[paramGroup][]int)
 	for _, k := range keys {
-		pg := paramGroup{k.UpToRoundID, k.LastN}
+		pg := paramGroup{k.UpToRoundID, k.LastN, k.Method}
 		groups[pg] = append(groups[pg], k.PlayerSeasonID)
 	}
 
 	resultMap := make(map[statsKey]*domain.PlayerSeasonStats, len(keys))
 	for pg, psIDs := range groups {
-		params := domain.PlayerSeasonStatsParams{PlayerSeasonIDs: psIDs}
+		params := domain.PlayerSeasonStatsParams{PlayerSeasonIDs: psIDs, Method: pg.method}
 		if pg.upTo != 0 {
 			v := pg.upTo
 			params.UpToRoundID = &v
@@ -80,7 +84,7 @@ func batchPlayerSeasonStats(ctx context.Context, keys []statsKey, q *application
 			// mark all keys in this group as errors
 			errs := make([]error, len(keys))
 			for i, k := range keys {
-				if (paramGroup{k.UpToRoundID, k.LastN}) == pg {
+				if (paramGroup{k.UpToRoundID, k.LastN, k.Method}) == pg {
 					errs[i] = err
 				}
 			}
@@ -88,7 +92,7 @@ func batchPlayerSeasonStats(ctx context.Context, keys []statsKey, q *application
 		}
 		for _, s := range rows {
 			cp := s
-			resultMap[statsKey{s.PlayerSeasonID, pg.upTo, pg.lastN}] = &cp
+			resultMap[statsKey{s.PlayerSeasonID, pg.upTo, pg.lastN, pg.method}] = &cp
 		}
 	}
 

--- a/services/afl/internal/interface/graphql/models_gen.go
+++ b/services/afl/internal/interface/graphql/models_gen.go
@@ -31,17 +31,18 @@ type AFLClubMatch struct {
 }
 
 type AFLClubSeason struct {
-	ID                string     `json:"id"`
-	Club              *AFLClub   `json:"club"`
-	Season            *AFLSeason `json:"season"`
-	Played            int        `json:"played"`
-	Won               int        `json:"won"`
-	Lost              int        `json:"lost"`
-	Drawn             int        `json:"drawn"`
-	For               int        `json:"for"`
-	Against           int        `json:"against"`
-	Percentage        float64    `json:"percentage"`
-	PremiershipPoints int        `json:"premiershipPoints"`
+	ID                string             `json:"id"`
+	Club              *AFLClub           `json:"club"`
+	Season            *AFLSeason         `json:"season"`
+	Played            int                `json:"played"`
+	Won               int                `json:"won"`
+	Lost              int                `json:"lost"`
+	Drawn             int                `json:"drawn"`
+	For               int                `json:"for"`
+	Against           int                `json:"against"`
+	Percentage        float64            `json:"percentage"`
+	PremiershipPoints int                `json:"premiershipPoints"`
+	PlayerSeasons     []*AFLPlayerSeason `json:"playerSeasons"`
 }
 
 type AFLLiveRound struct {

--- a/services/afl/internal/interface/graphql/models_gen.go
+++ b/services/afl/internal/interface/graphql/models_gen.go
@@ -218,21 +218,21 @@ type UpdateAFLPlayerMatchInput struct {
 }
 
 // Aggregation method to apply over a set of matches.
-// Only MEAN is implemented; additional methods (MEDIAN, STDDEV, …) can be added
-// without a schema change.
 type AFLStatSummaryMethod string
 
 const (
-	AFLStatSummaryMethodMean AFLStatSummaryMethod = "MEAN"
+	AFLStatSummaryMethodMean   AFLStatSummaryMethod = "MEAN"
+	AFLStatSummaryMethodMedian AFLStatSummaryMethod = "MEDIAN"
 )
 
 var AllAFLStatSummaryMethod = []AFLStatSummaryMethod{
 	AFLStatSummaryMethodMean,
+	AFLStatSummaryMethodMedian,
 }
 
 func (e AFLStatSummaryMethod) IsValid() bool {
 	switch e {
-	case AFLStatSummaryMethodMean:
+	case AFLStatSummaryMethodMean, AFLStatSummaryMethodMedian:
 		return true
 	}
 	return false

--- a/services/afl/internal/interface/graphql/query.resolvers.go
+++ b/services/afl/internal/interface/graphql/query.resolvers.go
@@ -8,6 +8,8 @@ package graphql
 import (
 	"context"
 	"fmt"
+
+	"xffl/services/afl/internal/domain"
 )
 
 // PlayerMatches is the resolver for the playerMatches field.
@@ -225,10 +227,15 @@ func (r *aFLPlayerSeasonResolver) Stats(ctx context.Context, obj *AFLPlayerSeaso
 		lastNVal = *lastN
 	}
 
+	statMethod := domain.StatMethodMean
+	if method != nil && *method == AFLStatSummaryMethodMedian {
+		statMethod = domain.StatMethodMedian
+	}
 	s, err := LoadersFromCtx(ctx).PlayerSeasonStats.Load(ctx, statsKey{
 		PlayerSeasonID: psID,
 		UpToRoundID:    upTo,
 		LastN:          lastNVal,
+		Method:         statMethod,
 	})
 	if err != nil {
 		return nil, err

--- a/services/afl/internal/interface/graphql/query.resolvers.go
+++ b/services/afl/internal/interface/graphql/query.resolvers.go
@@ -8,7 +8,7 @@ package graphql
 import (
 	"context"
 	"fmt"
-
+	"sort"
 	"xffl/services/afl/internal/domain"
 )
 
@@ -62,6 +62,24 @@ func (r *aFLClubSeasonResolver) Season(ctx context.Context, obj *AFLClubSeason) 
 		return nil, err
 	}
 	return convertSeason(s), nil
+}
+
+// PlayerSeasons is the resolver for the playerSeasons field.
+func (r *aFLClubSeasonResolver) PlayerSeasons(ctx context.Context, obj *AFLClubSeason) ([]*AFLPlayerSeason, error) {
+	csID, err := fromID(obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	players, err := r.Queries.GetPlayerSeasonsByClubSeasonID(ctx, csID)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(players, func(i, j int) bool { return players[i].Name < players[j].Name })
+	result := make([]*AFLPlayerSeason, len(players))
+	for i, p := range players {
+		result[i] = &AFLPlayerSeason{ID: toID(p.PlayerSeasonID)}
+	}
+	return result, nil
 }
 
 // Round is the resolver for the round field.
@@ -445,6 +463,23 @@ func (r *queryResolver) AflPlayerSeason(ctx context.Context, id string) (*AFLPla
 		return nil, err
 	}
 	return &AFLPlayerSeason{ID: id}, nil
+}
+
+// AflClubSeason is the resolver for the aflClubSeason field.
+func (r *queryResolver) AflClubSeason(ctx context.Context, id string) (*AFLClubSeason, error) {
+	csID, err := fromID(id)
+	if err != nil {
+		return nil, err
+	}
+	cs, err := r.Queries.GetClubSeasonByID(ctx, csID)
+	if err != nil {
+		return nil, err
+	}
+	club, err := r.Queries.GetClubForClubSeason(ctx, csID)
+	if err != nil {
+		return nil, err
+	}
+	return convertClubSeason(cs, club), nil
 }
 
 // AflLiveRound is the resolver for the aflLiveRound field.

--- a/services/ffl/api/graphql/query.graphqls
+++ b/services/ffl/api/graphql/query.graphqls
@@ -140,6 +140,7 @@ type FFLPlayerMatch {
   playerSeasonId: ID!
   playerSeason: FFLPlayerSeason!
   player: FFLPlayer!
+  matchId: ID
   position: String
   status: FFLPlayerMatchStatus
   aflStatus: FFLAFLPlayerMatchStatus

--- a/services/ffl/api/graphql/query.graphqls
+++ b/services/ffl/api/graphql/query.graphqls
@@ -169,6 +169,7 @@ type AFLPlayer @key(fields: "id") {
 
 type AFLPlayerSeason @key(fields: "id") {
   id: ID!
+  fflPlayerSeasons: [FFLPlayerSeason!]!
 }
 
 type AFLPlayerMatch @key(fields: "id") {

--- a/services/ffl/gqlgen.yml
+++ b/services/ffl/gqlgen.yml
@@ -66,5 +66,9 @@ models:
   FFLPlayerMatch:
     fields:
       playerSeason: { resolver: true }
+      matchId: { resolver: true }
       aflPlayerMatchId: { resolver: true }
       aflPlayerMatch: { resolver: true }
+    extraFields:
+      ClubMatchID:
+        type: int

--- a/services/ffl/gqlgen.yml
+++ b/services/ffl/gqlgen.yml
@@ -63,6 +63,10 @@ models:
       aflPlayerSeason: { resolver: true }
       playerMatches: { resolver: true }
 
+  AFLPlayerSeason:
+    fields:
+      fflPlayerSeasons: { resolver: true }
+
   FFLPlayerMatch:
     fields:
       playerSeason: { resolver: true }

--- a/services/ffl/internal/application/queries.go
+++ b/services/ffl/internal/application/queries.go
@@ -107,6 +107,10 @@ func (q *Queries) GetClubMatch(ctx context.Context, id int) (domain.ClubMatch, e
 	return q.clubMatches.FindByID(ctx, id)
 }
 
+func (q *Queries) GetClubMatchesByIDs(ctx context.Context, ids []int) (map[int]domain.ClubMatch, error) {
+	return q.clubMatches.FindByIDs(ctx, ids)
+}
+
 func (q *Queries) GetClubMatches(ctx context.Context, matchID int) ([]domain.ClubMatch, error) {
 	return q.clubMatches.FindByMatchID(ctx, matchID)
 }

--- a/services/ffl/internal/domain/club_match.go
+++ b/services/ffl/internal/domain/club_match.go
@@ -392,6 +392,7 @@ func (cm ClubMatch) Score() int {
 type ClubMatchRepository interface {
 	FindByMatchID(ctx context.Context, matchID int) ([]ClubMatch, error)
 	FindByID(ctx context.Context, id int) (ClubMatch, error)
+	FindByIDs(ctx context.Context, ids []int) (map[int]ClubMatch, error)
 	UpdateScore(ctx context.Context, id int, score int) error
 	UpdatePremiershipPoints(ctx context.Context, id int, points int) error
 	UpdateNotes(ctx context.Context, id int, notes string) error

--- a/services/ffl/internal/infrastructure/postgres/repository.go
+++ b/services/ffl/internal/infrastructure/postgres/repository.go
@@ -397,6 +397,29 @@ func (r *ClubMatchRepository) FindByID(ctx context.Context, id int) (domain.Club
 	}, nil
 }
 
+func (r *ClubMatchRepository) FindByIDs(ctx context.Context, ids []int) (map[int]domain.ClubMatch, error) {
+	int32IDs := make([]int32, len(ids))
+	for i, id := range ids {
+		int32IDs[i] = int32(id)
+	}
+	rows, err := r.q.FindClubMatchesByIDs(ctx, int32IDs)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int]domain.ClubMatch, len(rows))
+	for _, row := range rows {
+		out[int(row.ID)] = domain.ClubMatch{
+			ID:           int(row.ID),
+			MatchID:      int(row.MatchID),
+			ClubSeasonID: int(row.ClubSeasonID),
+			DataStatus:   domain.ClubMatchDataStatus(row.DataStatus),
+			Notes:        row.Notes,
+			StoredScore:  derefOr(row.DrvScore),
+		}
+	}
+	return out, nil
+}
+
 func (r *ClubMatchRepository) UpdateScore(ctx context.Context, id int, score int) error {
 	s := int32(score)
 	return r.q.UpdateClubMatchScore(ctx, sqlcgen.UpdateClubMatchScoreParams{

--- a/services/ffl/internal/infrastructure/postgres/sqlc/club_match.sql
+++ b/services/ffl/internal/infrastructure/postgres/sqlc/club_match.sql
@@ -9,6 +9,11 @@ SELECT id, match_id, club_season_id, data_status, notes, drv_score
 FROM ffl.club_match
 WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: FindClubMatchesByIDs :many
+SELECT id, match_id, club_season_id, data_status, notes, drv_score
+FROM ffl.club_match
+WHERE id = ANY($1::int[]) AND deleted_at IS NULL;
+
 -- name: UpdateClubMatchScore :exec
 UPDATE ffl.club_match
 SET drv_score = $2,

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/club_match.sql.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/club_match.sql.go
@@ -50,6 +50,48 @@ func (q *Queries) FindClubMatchByID(ctx context.Context, id int32) (FindClubMatc
 	return i, err
 }
 
+const findClubMatchesByIDs = `-- name: FindClubMatchesByIDs :many
+SELECT id, match_id, club_season_id, data_status, notes, drv_score
+FROM ffl.club_match
+WHERE id = ANY($1::int[]) AND deleted_at IS NULL
+`
+
+type FindClubMatchesByIDsRow struct {
+	ID           int32
+	MatchID      int32
+	ClubSeasonID int32
+	DataStatus   string
+	Notes        *string
+	DrvScore     *int32
+}
+
+func (q *Queries) FindClubMatchesByIDs(ctx context.Context, dollar_1 []int32) ([]FindClubMatchesByIDsRow, error) {
+	rows, err := q.db.Query(ctx, findClubMatchesByIDs, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindClubMatchesByIDsRow{}
+	for rows.Next() {
+		var i FindClubMatchesByIDsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.MatchID,
+			&i.ClubSeasonID,
+			&i.DataStatus,
+			&i.Notes,
+			&i.DrvScore,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findClubMatchesByMatchID = `-- name: FindClubMatchesByMatchID :many
 SELECT id, match_id, club_season_id, data_status, notes, drv_score
 FROM ffl.club_match

--- a/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
+++ b/services/ffl/internal/infrastructure/postgres/sqlcgen/querier.go
@@ -22,6 +22,7 @@ type Querier interface {
 	FindAllSeasons(ctx context.Context) ([]FindAllSeasonsRow, error)
 	FindClubByID(ctx context.Context, id int32) (FindClubByIDRow, error)
 	FindClubMatchByID(ctx context.Context, id int32) (FindClubMatchByIDRow, error)
+	FindClubMatchesByIDs(ctx context.Context, dollar_1 []int32) ([]FindClubMatchesByIDsRow, error)
 	FindClubMatchesByMatchID(ctx context.Context, matchID int32) ([]FindClubMatchesByMatchIDRow, error)
 	FindClubSeasonByClubAndSeason(ctx context.Context, arg FindClubSeasonByClubAndSeasonParams) (FindClubSeasonByClubAndSeasonRow, error)
 	FindClubSeasonByID(ctx context.Context, id int32) (FindClubSeasonByIDRow, error)

--- a/services/ffl/internal/interface/graphql/convert.go
+++ b/services/ffl/internal/interface/graphql/convert.go
@@ -131,6 +131,7 @@ func convertPlayerMatch(pm domain.PlayerMatch, player domain.Player) *FFLPlayerM
 		ID:                  toID(pm.ID),
 		PlayerSeasonID:      toID(pm.PlayerSeasonID),
 		Player:              convertPlayer(player),
+		ClubMatchID:         pm.ClubMatchID,
 		BackupPositions:     pm.BackupPositions,
 		InterchangePosition: pm.InterchangePosition,
 		DisplayOrder:        pm.DisplayOrder,

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -130,6 +130,7 @@ type ComplexityRoot struct {
 		DisplayOrder        func(childComplexity int) int
 		ID                  func(childComplexity int) int
 		InterchangePosition func(childComplexity int) int
+		MatchID             func(childComplexity int) int
 		Notes               func(childComplexity int) int
 		Player              func(childComplexity int) int
 		PlayerSeason        func(childComplexity int) int
@@ -267,6 +268,8 @@ type FFLPlayerResolver interface {
 }
 type FFLPlayerMatchResolver interface {
 	PlayerSeason(ctx context.Context, obj *FFLPlayerMatch) (*FFLPlayerSeason, error)
+
+	MatchID(ctx context.Context, obj *FFLPlayerMatch) (*string, error)
 
 	AflPlayerMatchID(ctx context.Context, obj *FFLPlayerMatch) (*string, error)
 	AflPlayerMatch(ctx context.Context, obj *FFLPlayerMatch) (*AFLPlayerMatch, error)
@@ -685,6 +688,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FFLPlayerMatch.InterchangePosition(childComplexity), true
+	case "FFLPlayerMatch.matchId":
+		if e.ComplexityRoot.FFLPlayerMatch.MatchID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FFLPlayerMatch.MatchID(childComplexity), true
 	case "FFLPlayerMatch.notes":
 		if e.ComplexityRoot.FFLPlayerMatch.Notes == nil {
 			break
@@ -1671,6 +1680,8 @@ type FFLPlayerMatch {
   playerSeasonId: ID!
   playerSeason: FFLPlayerSeason!
   player: FFLPlayer!
+  "The FFL match this player match belongs to."
+  matchId: ID
   position: String
   status: FFLPlayerMatchStatus
   aflStatus: FFLAFLPlayerMatchStatus
@@ -2911,6 +2922,8 @@ func (ec *executionContext) fieldContext_FFLClubMatch_playerMatches(_ context.Co
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -3863,6 +3876,35 @@ func (ec *executionContext) fieldContext_FFLPlayerMatch_player(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _FFLPlayerMatch_matchId(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerMatch) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FFLPlayerMatch_matchId,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.FFLPlayerMatch().MatchID(ctx, obj)
+		},
+		nil,
+		ec.marshalOID2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_FFLPlayerMatch_matchId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FFLPlayerMatch",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FFLPlayerMatch_position(ctx context.Context, field graphql.CollectedField, obj *FFLPlayerMatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4497,6 +4539,8 @@ func (ec *executionContext) fieldContext_FFLPlayerSeason_playerMatches(_ context
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -5300,6 +5344,8 @@ func (ec *executionContext) fieldContext_Mutation_calculateFFLFantasyScore(ctx c
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -5371,6 +5417,8 @@ func (ec *executionContext) fieldContext_Mutation_setFFLTeam(ctx context.Context
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -5489,6 +5537,8 @@ func (ec *executionContext) fieldContext_Mutation_confirmFFLTeamSubmission(ctx c
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -5724,6 +5774,8 @@ func (ec *executionContext) fieldContext_Mutation_declareFFLSubstitutions(ctx co
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -5795,6 +5847,8 @@ func (ec *executionContext) fieldContext_Mutation_reorderFFLPlayerMatch(ctx cont
 				return ec.fieldContext_FFLPlayerMatch_playerSeason(ctx, field)
 			case "player":
 				return ec.fieldContext_FFLPlayerMatch_player(ctx, field)
+			case "matchId":
+				return ec.fieldContext_FFLPlayerMatch_matchId(ctx, field)
 			case "position":
 				return ec.fieldContext_FFLPlayerMatch_position(ctx, field)
 			case "status":
@@ -10166,6 +10220,39 @@ func (ec *executionContext) _FFLPlayerMatch(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "matchId":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._FFLPlayerMatch_matchId(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "position":
 			out.Values[i] = ec._FFLPlayerMatch_position(ctx, field, obj)
 		case "status":

--- a/services/ffl/internal/interface/graphql/generated.go
+++ b/services/ffl/internal/interface/graphql/generated.go
@@ -27,6 +27,7 @@ func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 type ResolverRoot interface {
+	AFLPlayerSeason() AFLPlayerSeasonResolver
 	Entity() EntityResolver
 	FFLClubMatch() FFLClubMatchResolver
 	FFLClubSeason() FFLClubSeasonResolver
@@ -53,7 +54,8 @@ type ComplexityRoot struct {
 	}
 
 	AFLPlayerSeason struct {
-		ID func(childComplexity int) int
+		FflPlayerSeasons func(childComplexity int) int
+		ID               func(childComplexity int) int
 	}
 
 	AFLRound struct {
@@ -245,6 +247,9 @@ type ComplexityRoot struct {
 	}
 }
 
+type AFLPlayerSeasonResolver interface {
+	FflPlayerSeasons(ctx context.Context, obj *AFLPlayerSeason) ([]*FFLPlayerSeason, error)
+}
 type EntityResolver interface {
 	FindAFLPlayerByID(ctx context.Context, id string) (*AFLPlayer, error)
 	FindAFLPlayerMatchByID(ctx context.Context, id string) (*AFLPlayerMatch, error)
@@ -349,6 +354,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.AFLPlayerMatch.ID(childComplexity), true
 
+	case "AFLPlayerSeason.fflPlayerSeasons":
+		if e.ComplexityRoot.AFLPlayerSeason.FflPlayerSeasons == nil {
+			break
+		}
+
+		return e.ComplexityRoot.AFLPlayerSeason.FflPlayerSeasons(childComplexity), true
 	case "AFLPlayerSeason.id":
 		if e.ComplexityRoot.AFLPlayerSeason.ID == nil {
 			break
@@ -1680,7 +1691,6 @@ type FFLPlayerMatch {
   playerSeasonId: ID!
   playerSeason: FFLPlayerSeason!
   player: FFLPlayer!
-  "The FFL match this player match belongs to."
   matchId: ID
   position: String
   status: FFLPlayerMatchStatus
@@ -1710,6 +1720,8 @@ type AFLPlayer @key(fields: "id") {
 
 type AFLPlayerSeason @key(fields: "id") {
   id: ID!
+  "All FFL player seasons linked to this AFL player season (across all FFL clubs/stints)."
+  fflPlayerSeasons: [FFLPlayerSeason!]!
 }
 
 type AFLPlayerMatch @key(fields: "id") {
@@ -2282,6 +2294,59 @@ func (ec *executionContext) fieldContext_AFLPlayerSeason_id(_ context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _AFLPlayerSeason_fflPlayerSeasons(ctx context.Context, field graphql.CollectedField, obj *AFLPlayerSeason) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AFLPlayerSeason_fflPlayerSeasons,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.AFLPlayerSeason().FflPlayerSeasons(ctx, obj)
+		},
+		nil,
+		ec.marshalNFFLPlayerSeason2ᚕᚖxfflᚋservicesᚋfflᚋinternalᚋinterfaceᚋgraphqlᚐFFLPlayerSeasonᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AFLPlayerSeason_fflPlayerSeasons(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AFLPlayerSeason",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FFLPlayerSeason_id(ctx, field)
+			case "player":
+				return ec.fieldContext_FFLPlayerSeason_player(ctx, field)
+			case "club":
+				return ec.fieldContext_FFLPlayerSeason_club(ctx, field)
+			case "clubSeasonId":
+				return ec.fieldContext_FFLPlayerSeason_clubSeasonId(ctx, field)
+			case "aflPlayerSeasonId":
+				return ec.fieldContext_FFLPlayerSeason_aflPlayerSeasonId(ctx, field)
+			case "aflPlayerSeason":
+				return ec.fieldContext_FFLPlayerSeason_aflPlayerSeason(ctx, field)
+			case "fromRoundId":
+				return ec.fieldContext_FFLPlayerSeason_fromRoundId(ctx, field)
+			case "toRoundId":
+				return ec.fieldContext_FFLPlayerSeason_toRoundId(ctx, field)
+			case "notes":
+				return ec.fieldContext_FFLPlayerSeason_notes(ctx, field)
+			case "costCents":
+				return ec.fieldContext_FFLPlayerSeason_costCents(ctx, field)
+			case "playerMatches":
+				return ec.fieldContext_FFLPlayerSeason_playerMatches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FFLPlayerSeason", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AFLRound_id(ctx context.Context, field graphql.CollectedField, obj *AFLRound) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2457,6 +2522,8 @@ func (ec *executionContext) fieldContext_Entity_findAFLPlayerSeasonByID(ctx cont
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_AFLPlayerSeason_id(ctx, field)
+			case "fflPlayerSeasons":
+				return ec.fieldContext_AFLPlayerSeason_fflPlayerSeasons(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AFLPlayerSeason", field.Name)
 		},
@@ -4384,6 +4451,8 @@ func (ec *executionContext) fieldContext_FFLPlayerSeason_aflPlayerSeason(_ conte
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_AFLPlayerSeason_id(ctx, field)
+			case "fflPlayerSeasons":
+				return ec.fieldContext_AFLPlayerSeason_fflPlayerSeasons(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AFLPlayerSeason", field.Name)
 		},
@@ -9399,8 +9468,44 @@ func (ec *executionContext) _AFLPlayerSeason(ctx context.Context, sel ast.Select
 		case "id":
 			out.Values[i] = ec._AFLPlayerSeason_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fflPlayerSeasons":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AFLPlayerSeason_fflPlayerSeasons(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/services/ffl/internal/interface/graphql/loaders.go
+++ b/services/ffl/internal/interface/graphql/loaders.go
@@ -16,6 +16,7 @@ type Loaders struct {
 	PlayerByPlayerSeasonID *dataloadgen.Loader[int, *domain.Player]
 	ClubByID               *dataloadgen.Loader[int, *domain.Club]
 	MatchByID              *dataloadgen.Loader[int, *domain.Match]
+	ClubMatchByID          *dataloadgen.Loader[int, *domain.ClubMatch]
 }
 
 func NewLoaders(q *application.Queries) *Loaders {
@@ -30,6 +31,10 @@ func NewLoaders(q *application.Queries) *Loaders {
 		}),
 		MatchByID: dataloadgen.NewLoader(func(ctx context.Context, ids []int) ([]*domain.Match, []error) {
 			m, err := q.GetMatchesByIDs(ctx, ids)
+			return mapToSlice(ids, m, err)
+		}),
+		ClubMatchByID: dataloadgen.NewLoader(func(ctx context.Context, ids []int) ([]*domain.ClubMatch, []error) {
+			m, err := q.GetClubMatchesByIDs(ctx, ids)
 			return mapToSlice(ids, m, err)
 		}),
 	}

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -126,10 +126,12 @@ type FFLPlayer struct {
 }
 
 type FFLPlayerMatch struct {
-	ID                  string                   `json:"id"`
-	PlayerSeasonID      string                   `json:"playerSeasonId"`
-	PlayerSeason        *FFLPlayerSeason         `json:"playerSeason"`
-	Player              *FFLPlayer               `json:"player"`
+	ID             string           `json:"id"`
+	PlayerSeasonID string           `json:"playerSeasonId"`
+	PlayerSeason   *FFLPlayerSeason `json:"playerSeason"`
+	Player         *FFLPlayer       `json:"player"`
+	// The FFL match this player match belongs to.
+	MatchID             *string                  `json:"matchId,omitempty"`
 	Position            *string                  `json:"position,omitempty"`
 	Status              *FFLPlayerMatchStatus    `json:"status,omitempty"`
 	AflStatus           *FFLAFLPlayerMatchStatus `json:"aflStatus,omitempty"`
@@ -140,6 +142,7 @@ type FFLPlayerMatch struct {
 	Score               int                      `json:"score"`
 	AflPlayerMatchID    *string                  `json:"aflPlayerMatchId,omitempty"`
 	AflPlayerMatch      *AFLPlayerMatch          `json:"aflPlayerMatch,omitempty"`
+	ClubMatchID         int                      `json:"-"`
 }
 
 type FFLPlayerSeason struct {

--- a/services/ffl/internal/interface/graphql/models_gen.go
+++ b/services/ffl/internal/interface/graphql/models_gen.go
@@ -23,6 +23,8 @@ func (AFLPlayerMatch) IsEntity() {}
 
 type AFLPlayerSeason struct {
 	ID string `json:"id"`
+	// All FFL player seasons linked to this AFL player season (across all FFL clubs/stints).
+	FflPlayerSeasons []*FFLPlayerSeason `json:"fflPlayerSeasons"`
 }
 
 func (AFLPlayerSeason) IsEntity() {}
@@ -126,11 +128,10 @@ type FFLPlayer struct {
 }
 
 type FFLPlayerMatch struct {
-	ID             string           `json:"id"`
-	PlayerSeasonID string           `json:"playerSeasonId"`
-	PlayerSeason   *FFLPlayerSeason `json:"playerSeason"`
-	Player         *FFLPlayer       `json:"player"`
-	// The FFL match this player match belongs to.
+	ID                  string                   `json:"id"`
+	PlayerSeasonID      string                   `json:"playerSeasonId"`
+	PlayerSeason        *FFLPlayerSeason         `json:"playerSeason"`
+	Player              *FFLPlayer               `json:"player"`
 	MatchID             *string                  `json:"matchId,omitempty"`
 	Position            *string                  `json:"position,omitempty"`
 	Status              *FFLPlayerMatchStatus    `json:"status,omitempty"`

--- a/services/ffl/internal/interface/graphql/query.resolvers.go
+++ b/services/ffl/internal/interface/graphql/query.resolvers.go
@@ -155,6 +155,20 @@ func (r *fFLPlayerMatchResolver) PlayerSeason(ctx context.Context, obj *FFLPlaye
 	return convertPlayerSeason(ps, *player), nil
 }
 
+// MatchID is the resolver for the matchId field.
+// Loads the FFL club match to retrieve the parent match ID.
+func (r *fFLPlayerMatchResolver) MatchID(ctx context.Context, obj *FFLPlayerMatch) (*string, error) {
+	if obj.ClubMatchID == 0 {
+		return nil, nil
+	}
+	cm, err := LoadersFromCtx(ctx).ClubMatchByID.Load(ctx, obj.ClubMatchID)
+	if err != nil {
+		return nil, err
+	}
+	id := toID(cm.MatchID)
+	return &id, nil
+}
+
 // AflPlayerMatchID is the resolver for the aflPlayerMatchId field.
 func (r *fFLPlayerMatchResolver) AflPlayerMatchID(ctx context.Context, obj *FFLPlayerMatch) (*string, error) {
 	return obj.AflPlayerMatchID, nil
@@ -533,30 +547,3 @@ type fFLPlayerSeasonResolver struct{ *Resolver }
 type fFLRoundResolver struct{ *Resolver }
 type fFLSeasonResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-/*
-	func (r *fFLClubMatchResolver) SuggestedInterchange(ctx context.Context, obj *FFLClubMatch) (*FFLSuggestedInterchange, error) {
-	cmID, err := fromID(obj.ID)
-	if err != nil {
-		return nil, err
-	}
-	pms, err := r.Queries.GetPlayerMatches(ctx, cmID)
-	if err != nil {
-		return nil, err
-	}
-	pair := domain.ClubMatch{PlayerMatches: pms}.SuggestedInterchange()
-	if pair == nil {
-		return nil, nil
-	}
-	return &FFLSuggestedInterchange{
-		ReplacedPmID:  toID(pair.ReplacedPMID),
-		ReplacingPmID: toID(pair.ReplacingPMID),
-	}, nil
-}
-*/

--- a/services/ffl/internal/interface/graphql/query.resolvers.go
+++ b/services/ffl/internal/interface/graphql/query.resolvers.go
@@ -11,6 +11,28 @@ import (
 	"xffl/services/ffl/internal/domain"
 )
 
+// FflPlayerSeasons is the resolver for the fflPlayerSeasons field.
+func (r *aFLPlayerSeasonResolver) FflPlayerSeasons(ctx context.Context, obj *AFLPlayerSeason) ([]*FFLPlayerSeason, error) {
+	aflPsID, err := fromID(obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	seasons, err := r.Queries.GetPlayerSeasonsByAFLPlayerSeasonID(ctx, aflPsID)
+	if err != nil {
+		return nil, err
+	}
+	loaders := LoadersFromCtx(ctx)
+	result := make([]*FFLPlayerSeason, len(seasons))
+	for i, ps := range seasons {
+		player, err := loaders.PlayerByPlayerSeasonID.Load(ctx, ps.ID)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = convertPlayerSeason(ps, *player)
+	}
+	return result, nil
+}
+
 // PlayerMatches is the resolver for the playerMatches field.
 func (r *fFLClubMatchResolver) PlayerMatches(ctx context.Context, obj *FFLClubMatch) ([]*FFLPlayerMatch, error) {
 	cmID, err := fromID(obj.ID)
@@ -511,6 +533,9 @@ func (r *queryResolver) FflPlayerSeasonsByAflPlayerSeason(ctx context.Context, a
 	return result, nil
 }
 
+// AFLPlayerSeason returns AFLPlayerSeasonResolver implementation.
+func (r *Resolver) AFLPlayerSeason() AFLPlayerSeasonResolver { return &aFLPlayerSeasonResolver{r} }
+
 // FFLClubMatch returns FFLClubMatchResolver implementation.
 func (r *Resolver) FFLClubMatch() FFLClubMatchResolver { return &fFLClubMatchResolver{r} }
 
@@ -538,6 +563,7 @@ func (r *Resolver) FFLSeason() FFLSeasonResolver { return &fFLSeasonResolver{r} 
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
+type aFLPlayerSeasonResolver struct{ *Resolver }
 type fFLClubMatchResolver struct{ *Resolver }
 type fFLClubSeasonResolver struct{ *Resolver }
 type fFLMatchResolver struct{ *Resolver }


### PR DESCRIPTION
Overhauls the FFL front end around player intelligence: stat summaries, heatmaps, trend indicators, and an optimal-team solver make picking and managing a team far more informed, alongside broad cross-page navigation and UX polish.

## Changes

- **Team builder interactions** — squad, starter, and bench cards support drag-and-drop with overflow-menu popups as the fallback; menus show remaining-slot dots per position.
- **Team builder intelligence** — per-player stat rows with per-column heatmaps, form-vs-season trend arrows, sortable columns, a Last 5/Season stat source toggle, live projected team total, and a Best Team button that fills starters via a Hungarian-algorithm assignment over projected scores.
- **Player hover card** — replaces the averages-only table with Last 5 + season rows plus heat-mapped per-round game lines, and flips above/below the trigger to stay in the viewport.
- **Squad and Free Agents pages** — stats view with season/last-N averages, heatmap colouring, position badges, single-row toolbar, and a new Free Agents page with top-20 ranking per position.
- **AFL pages** — club season page, heatmap colouring on match/club stat tables, player season view with per-round links, median stats, and status pills.
- **Cross-page navigation** — clickable links between FFL and AFL lenses (players, matches, clubs, rounds) with scroll-to-and-highlight when arriving from leaderboards.
- **Scoring fixes** — star position formula excludes hitouts; subs auto-apply corrected so interchanges require explicit user action; misleading squad Total row removed.
- **Backend support** — FFL suggested-substitutions field, AFL median stat method, and stat-summary queries parameterised by lastN/upToRound.
- **Tests and tooling** — e2e suite extended for all new interactions (drag-and-drop, menus, sorting, toggles, Best Team); e2e seed marks past rounds final so form stats resolve; db backup/restore recipes renamed.